### PR TITLE
Tidy config and improve user list handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,10 +4,7 @@
 
 # Node
 node_modules/
-/frontend-pwa/node_modules/
-/packages/tokens/node_modules/
-/frontend-pwa/dist/
-/packages/tokens/dist/
+**/dist/
 
 # Misc
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -243,7 +243,8 @@ browser‑only runtime.
   - `test`: `vitest run --coverage`
   - `audit`: `bun x npm@latest audit`
   - `audit:snyk`: `bun x snyk test`
-
+  - Note: `audit` requires a committed `bun.lock`; `audit:snyk` requires
+    installed dependencies—run `bun install` before invoking it.
 ### Compiler Configuration (Make It Sharp)
 
 Use a strict `tsconfig.json` suitable for browser builds:
@@ -334,7 +335,7 @@ Keep docs close to code.
 - **Audit**: Run `bun run audit` locally and in automation. Track exceptions
   with explicit expiry dates.
 - **Culling**: Prefer small, actively maintained packages. Remove unmaintained
-or risky dependencies swiftly.
+  or risky dependencies swiftly.
 
 ### Linting & Formatting
 
@@ -433,8 +434,8 @@ or risky dependencies swiftly.
 
 ### Quick Checklist (Before Commit)
 
-- `bun run fmt`, `bun run lint`, `bun test` all clean; no Biome warnings; no
-  TypeScript errors; coverage thresholds hold.
+ - `bun run fmt`, `bun run lint`, `bun run test` all clean; no Biome warnings;
+  no TypeScript errors; coverage thresholds hold.
 - `bun run audit` passes or has justified, time‑boxed exceptions.
 - No `any`, no `@ts-ignore`; use `@ts-expect-error` only with a reason.
 - All async APIs accept `AbortSignal` where relevant; all fetchers validated

--- a/frontend-pwa/src/api/client.ts
+++ b/frontend-pwa/src/api/client.ts
@@ -1,11 +1,15 @@
 /**
  * @file API client functions generated from OpenAPI.
  */
-import { customFetch } from './fetcher';
+import { z } from 'zod';
+import { customFetchParsed } from './fetcher';
 
-export interface User {
-  id: string;
-  display_name: string;
-}
+const userSchema = z.object({
+  id: z.string(),
+  display_name: z.string(),
+});
 
-export const listUsers = () => customFetch<User[]>('/api/users');
+export type User = z.infer<typeof userSchema>;
+
+export const listUsers = (signal?: AbortSignal) =>
+  customFetchParsed('/api/users', z.array(userSchema), { signal });

--- a/frontend-pwa/src/app/App.tsx
+++ b/frontend-pwa/src/app/App.tsx
@@ -7,23 +7,27 @@ import { listUsers } from '../api/client';
 export function App() {
   const { data, isLoading, isError, error } = useQuery({
     queryKey: ['users'],
-    queryFn: listUsers,
+    queryFn: ({ signal }) => listUsers(signal),
     staleTime: 60_000,
   });
 
   if (isLoading) {
     return (
-      <div className="p-6 min-h-screen bg-base-200 text-base-content" role="status">
+      <output className="p-6 min-h-screen bg-base-200 text-base-content">
         Loading users…
-      </div>
+      </output>
     );
   }
 
   if (isError) {
+    if (import.meta.env.DEV) {
+      // eslint-disable-next-line no-console
+      console.error(error);
+    }
     return (
-      <div className="p-6 min-h-screen bg-base-200 text-base-content" role="alert">
-        Failed to load users: {(error as Error).message}
-      </div>
+      <p className="p-6 min-h-screen bg-base-200 text-base-content" role="alert">
+        Failed to load users.
+      </p>
     );
   }
 
@@ -35,11 +39,17 @@ export function App() {
         </a>
       </div>
       <ul className="menu bg-base-100 rounded-box">
-        {(data ?? []).map(u => (
-          <li key={u.id}>
-            <span>{u.display_name}</span>
+        {data && data.length > 0 ? (
+          data.map(u => (
+            <li key={u.id}>
+              <span>{u.display_name}</span>
+            </li>
+          ))
+        ) : (
+          <li>
+            <span>No users found.</span>
           </li>
-        ))}
+        )}
       </ul>
     </div>
   );


### PR DESCRIPTION
## Summary
- ignore all dist folders and drop duplicate node_modules patterns
- document audit prerequisites and tidy markdown in AGENTS instructions
- validate user API responses and improve App loading/error states

## Testing
- `make check-fmt`
- `make lint`
- `make test`
- `bun install` *(fails: StyleDictionary.extend is not a function)*
- `make markdownlint` *(output exceeded limit)*

------
https://chatgpt.com/codex/tasks/task_e_689e2819d2ac83229c479136e3fb988a