### PR TITLE
feat: introduce branded user identifiers

### DIFF
--- a/frontend-pwa/src/api/client.ts
+++ b/frontend-pwa/src/api/client.ts
@@ -4,12 +4,17 @@
 import { z } from 'zod';
 import { customFetchParsed } from './fetcher';
 
-const userSchema = z.object({
-  id: z.string(),
-  display_name: z.string(),
-});
+export type UserId = string & { readonly brand: 'UserId' };
 
-export type User = z.infer<typeof userSchema>;
+export interface User {
+  id: UserId;
+  display_name: string;
+}
+
+const userSchema = z.object({
+  id: z.string().transform(id => id as UserId),
+  display_name: z.string(),
+}) satisfies z.ZodType<User>;
 
 export const listUsers = (signal?: AbortSignal) =>
   customFetchParsed('/api/users', z.array(userSchema), { signal });


### PR DESCRIPTION
## Summary
- type user IDs with a brand to avoid mixing with arbitrary strings

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e400c106c83228dcf64663b87b624

## Summary by Sourcery

Introduce a branded UserId type and update the user API schema to enforce it

New Features:
- Add UserId branded string type for stronger ID safety

Enhancements:
- Define explicit User interface and refine Zod schema to transform id into UserId