### PR TITLE
Fix markdown documentation formatting issues

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,6 @@
 # Assistant Instructions
 
 ## Code Style and Structure
-
 - **Code is for humans.** Write your code with clarity and empathy—assume a
   tired teammate will need to debug it at 3 a.m.
 - **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or
@@ -34,7 +33,6 @@
   should be moved to external data files.
 
 ## Documentation Maintenance
-
 - **Reference:** Use the markdown files within the `docs/` directory as a
   knowledge base and source of truth for project requirements, dependency
   choices, and architectural decisions.
@@ -47,73 +45,70 @@
   left unchanged for community consistency.)
 
 ## Change Quality & Committing
-
 - **Atomicity:** Aim for small, focused, atomic changes. Each change (and
   subsequent commit) should represent a single logical unit of work.
 - **Quality Gates:** Before considering a change complete or proposing a commit,
   ensure it meets the following criteria:
-  - New functionality or changes in behaviour are fully validated by relevant
+- New functionality or changes in behaviour are fully validated by relevant
     unittests and behavioural tests.
-  - Where a bug is being fixed, a unittest has been provided demonstrating the
+- Where a bug is being fixed, a unittest has been provided demonstrating the
     behaviour being corrected both to validate the fix and to guard against
     regression.
-  - Passes all relevant unit and behavioural tests according to the guidelines
+- Passes all relevant unit and behavioural tests according to the guidelines
     above. (Use `make test` to verify).
-  - Passes lint checks. (Use `make lint` to verify).
-  - Adheres to formatting standards tested using a formatting validator. (Use
+- Passes lint checks. (Use `make lint` to verify).
+- Adheres to formatting standards tested using a formatting validator. (Use
     `make check-fmt` to verify).
 - **Committing:**
-  - Only changes that meet all the quality gates above should be committed.
-  - Write clear, descriptive commit messages summarizing the change, following
+- Only changes that meet all the quality gates above should be committed.
+- Write clear, descriptive commit messages summarizing the change, following
     these formatting guidelines:
-    - **Imperative Mood:** Use the imperative mood in the subject line (e.g.,
+- **Imperative Mood:** Use the imperative mood in the subject line (e.g.,
       "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
-    - **Subject Line:** The first line should be a concise summary of the change
+- **Subject Line:** The first line should be a concise summary of the change
       (ideally 50 characters or less).
-    - **Body:** Separate the subject from the body with a blank line. Subsequent
+- **Body:** Separate the subject from the body with a blank line. Subsequent
       lines should explain the *what* and *why* of the change in more detail,
       including rationale, goals, and scope. Wrap the body at 72 characters.
-    - **Formatting:** Use Markdown for any formatted text (like bullet points or
+- **Formatting:** Use Markdown for any formatted text (like bullet points or
       code snippets) within the commit message body.
-  - Do not commit changes that fail any of the quality gates.
+- Do not commit changes that fail any of the quality gates.
 
 ## Refactoring Heuristics & Workflow
-
 - **Recognising Refactoring Needs:** Regularly assess the codebase for potential
   refactoring opportunities. Consider refactoring when you observe:
-  - **Long Methods/Functions:** Functions or methods that are excessively long
+- **Long Methods/Functions:** Functions or methods that are excessively long
     or try to do too many things.
-  - **Duplicated Code:** Identical or very similar code blocks appearing in
+- **Duplicated Code:** Identical or very similar code blocks appearing in
     multiple places.
-  - **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or
+- **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or
     `switch` statements (high cyclomatic complexity).
-  - **Large Code Blocks for Single Values:** Significant chunks of logic
+- **Large Code Blocks for Single Values:** Significant chunks of logic
     dedicated solely to calculating or deriving a single value.
-  - **Primitive Obsession / Data Clumps:** Groups of simple variables (strings,
+- **Primitive Obsession / Data Clumps:** Groups of simple variables (strings,
     numbers, booleans) that are frequently passed around together, often
     indicating a missing class or object structure.
-  - **Excessive Parameters:** Functions or methods requiring a very long list of
+- **Excessive Parameters:** Functions or methods requiring a very long list of
     parameters.
-  - **Feature Envy:** Methods that seem more interested in the data of another
+- **Feature Envy:** Methods that seem more interested in the data of another
     class/object than their own.
-  - **Shotgun Surgery:** A single change requiring small modifications in many
+- **Shotgun Surgery:** A single change requiring small modifications in many
     different classes or functions.
 - **Post-Commit Review:** After committing a functional change or bug fix (that
   meets all quality gates), review the changed code and surrounding areas using
   the heuristics above.
 - **Separate Atomic Refactors:** If refactoring is deemed necessary:
-  - Perform the refactoring as a **separate, atomic commit** *after* the
+- Perform the refactoring as a **separate, atomic commit** *after* the
     functional change commit.
-  - Ensure the refactoring adheres to the testing guidelines (behavioural tests
+- Ensure the refactoring adheres to the testing guidelines (behavioural tests
     pass before and after, unit tests added for new units).
-  - Ensure the refactoring commit itself passes all quality gates.
+- Ensure the refactoring commit itself passes all quality gates.
 
 ## Rust Specific Guidance
 
 This repository is written in Rust and uses Cargo for building and dependency
 management. Contributors should follow these best practices when working on the
 project:
-
 - Run `make fmt`, `make lint`, and `make test` before committing. These targets
   wrap `cargo fmt`, `cargo clippy`, and `cargo test` with the appropriate flags.
 - Clippy warnings MUST be disallowed.
@@ -160,7 +155,6 @@ project:
   ```
 
 ### Testing
-
 - Write unit and behavioural tests for new functionality. Run both before and
   after making any change.
 - Use `rstest` fixtures for shared setup.
@@ -171,8 +165,7 @@ project:
   like `Env` and `Clock`) where appropriate. See
   `docs/reliable-testing-in-rust-via-dependency-injection.md` for guidance.
 
-### Dependency Management
-
+### Dependency Management (Rust)
 - **Mandate caret requirements for all dependencies.** All crate versions
   specified in `Cargo.toml` must use SemVer-compatible caret requirements
   (e.g., `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
@@ -185,8 +178,7 @@ project:
   (`~`) should only be used where a dependency must be locked to patch-level
   updates for a specific, documented reason.
 
-### Error Handling
-
+### Error Handling (Rust)
 - **Prefer semantic error enums**. Derive `std::error::Error` (via the
   `thiserror` crate) for any condition the caller might inspect, retry, or map
   to an HTTP status.
@@ -197,7 +189,6 @@ project:
   top-level async task.
 
 ## Markdown Guidance
-
 - Validate Markdown files using `make markdownlint`.
 - Run `make fmt` after any documentation changes to format all Markdown
   files and fix table markup.
@@ -219,7 +210,6 @@ predictable builds—translated into idiomatic, modern TypeScript and a
 browser‑only runtime.
 
 ### Toolchain & Project Shape
-
 - **ESM‑only**: Source and build outputs are ES Modules. No CommonJS. Configure
   Vite accordingly; package publishes only ESM (for libraries) or static assets
   (for apps).
@@ -234,21 +224,21 @@ browser‑only runtime.
   hints, and asset hashing. Esbuild handles TS/JS transforms in dev; production
   uses Rollup via Vite.
 - **Project scripts (Bun)**:
-  - `fmt`: `biome format --write .`
-  - `lint`: `biome lint . && tsc -p tsconfig.json --noEmit`
-  - `typecheck`: `tsc -p tsconfig.json --noEmit`
-  - `dev`: `vite`
-  - `build`: `vite build`
-  - `preview`: `vite preview`
-  - `test`: `vitest run --coverage`
-  - `audit`: `bun x npm@latest audit`
-  - `audit:snyk`: `bun x snyk test`
-  - Note: `audit` requires a committed `bun.lock`; `audit:snyk` requires
-    installed dependencies—run `bun install` before invoking it.
+- `fmt`: `biome format --write .`
+- `lint`: `biome lint . && tsc -p tsconfig.json --noEmit`
+- `typecheck`: `tsc -p tsconfig.json --noEmit`
+- `dev`: `vite`
+- `build`: `vite build`
+- `preview`: `vite preview`
+- `test`: `vitest run --coverage`
+- `audit`: `bun x npm@latest audit`
+- `audit:snyk`: `bun x snyk test`
+- Note: `audit` requires a committed `bun.lock`; `audit:snyk` requires
+      installed dependencies—run `bun install` before invoking it.
+
 ### Compiler Configuration (Make It Sharp)
 
 Use a strict `tsconfig.json` suitable for browser builds:
-
 - `strict: true`
 - `noUncheckedIndexedAccess: true`
 - `exactOptionalPropertyTypes: true`
@@ -265,14 +255,14 @@ Use a strict `tsconfig.json` suitable for browser builds:
 Keep docs close to code.
 
 ### Code Style & Structure
-
 - **Immutability first**: Prefer `const`, `readonly`, and `Readonly<T>`; avoid
   mutating props or inputs.
 - **Functions**: Extract meaningfully named helpers when a function grows long.
-  Keep trivial functions on one line when readability allows:
-  ```ts
-  export const mkId = (n: number): Id => new Id(n);
-  ```
+    Keep trivial functions on one line when readability allows:
+
+    ```ts
+    export const mkId = (n: number): Id => new Id(n);
+    ```
 - **Parameters**: Group related parameters into typed objects or builders;
   avoid long positional lists.
 - **Predicates**: When `if/else` grows beyond two branches, extract a predicate
@@ -284,22 +274,21 @@ Keep docs close to code.
   `exports`/`types`. Avoid wildcard re‑exports that mask breaking changes.
 
 ### Runtime Validation & Types
-
 - **Runtime schemas**: Validate I/O boundaries (network responses, localStorage
   payloads, URL params) with `zod`/`valibot`. Generate TS types from schemas or
   derive schemas from types, but add a CI check to keep them in sync.
 - **Nominal branding**: Use branded types for IDs/tokens to avoid accidental
-  mixing:
-  ```ts
-  type UserId = string & { readonly brand: "UserId" };
-  ```
+    mixing:
+
+    ```ts
+    type UserId = string & { readonly brand: "UserId" };
+    ```
 - **Cancellation**: Accept `AbortSignal` for any async that can hang (fetches,
   long UI work). Wire signals through TanStack Query via `signal` in fetchers.
 - **Time & RNG**: Centralise `now()` and `rng()` adapters; never call
   `Date.now()` or `Math.random()` directly in business logic.
 
-### Error Handling
-
+### Error Handling (Frontend)
 - **Semantic errors**: Use discriminated unions for recoverable conditions
   callers might branch on (e.g.,
   `{ type: "rate_limited"; retryAfterMs: number }`).
@@ -309,7 +298,6 @@ Keep docs close to code.
   only. Never leak raw stack traces to the DOM or logs shipped to analytics.
 
 ### Testing (Unit, Behavioural, and UI)
-
 - **Runner**: Vitest with `jsdom` (or `happy-dom`) for component tests. Keep
   tests parallel‑safe and deterministic.
 - **Fixtures**: Use factories/builders for component props and server
@@ -325,8 +313,7 @@ Keep docs close to code.
 - **E2E (optional)**: Playwright for flows critical to revenue or safety; keep
   the set minimal and fast.
 
-### Dependency Management
-
+### Dependency Management (Frontend)
 - **Version policy**: Use caret requirements (`^x.y.z`) for all direct
   dependencies. Avoid `*`, `>=` or tag aliases like `latest`. Use tilde
   (`~x.y.z`) only with a documented justification.
@@ -338,7 +325,6 @@ Keep docs close to code.
   or risky dependencies swiftly.
 
 ### Linting & Formatting
-
 - **Biome**: One tool for format + lint. Configure with strict rules: disallow
   `any`, no non‑null `!`, forbid `@ts-ignore` in favour of `@ts-expect-error`
   (with a reason).
@@ -348,7 +334,6 @@ Keep docs close to code.
   dependencies.
 
 ### Performance & Correctness
-
 - **Code‑splitting**: Use Vite’s dynamic `import()` to split routes and heavy
   feature bundles.
 - **TanStack Query**: Use stale‑time, cache‑time, and prefetch strategically.
@@ -361,7 +346,6 @@ Keep docs close to code.
   client‑side caches.
 
 ### Security & Privacy (Client‑Side)
-
 - **CSP**: Ship a Content Security Policy where deployment allows it. For SPA
   hosting, prefer hashed scripts and forbid `eval`/`new Function`.
 - **Trusted Types**: If embedding third‑party HTML, gate through a sanitiser
@@ -374,7 +358,6 @@ Keep docs close to code.
   untrusted. Namespaced keys; versioned payloads; schema‑validated reads.
 
 ### React, Tailwind 4, and daisyUI 5
-
 - **Tailwind v4**: Use the new config conventions and JIT‑only pipeline.
   Co‑locate `@apply` in component‑scoped CSS when it improves clarity; prefer
   utilities otherwise. Remove unused utilities via content‑aware purge in
@@ -390,7 +373,6 @@ Keep docs close to code.
   checks.
 
 ### TanStack Usage Notes
-
 - **Query**: Co‑locate query keys and fetchers; prefer stable keys; use
   `select` to project server data for components. Wire `AbortSignal` to
   fetches. Use `retry` policies appropriate to the endpoint.
@@ -401,7 +383,6 @@ Keep docs close to code.
   column defs.
 
 ### Observability (Frontend)
-
 - **Structured logs**: Gate debug logs behind a flag (`?debug=1` or build‑time
   define). Use a small logger that emits structured objects in dev and terse
   strings in prod.
@@ -411,7 +392,6 @@ Keep docs close to code.
   document fallback behaviour.
 
 ### Documentation & Examples
-
 - **Literate examples**: Keep small TS snippets in docs that compile during
   builds (typecheck only). Prefer examples that mirror production patterns
   (schema‑validated fetchers, `AbortSignal`, TanStack Query hooks).
@@ -420,8 +400,7 @@ Keep docs close to code.
 - **Error semantics**: Document user‑visible failure modes next to components
   and hooks that surface them.
 
-### Release Discipline 
-
+### Release Discipline
 - **Conventional Commits + Changesets** for versioning (libraries) and change
   logs.
 - **SemVer**: Honour breaking changes with a major bump; avoid sneaking them in
@@ -433,8 +412,7 @@ Keep docs close to code.
   acceptable variances when adding large features.
 
 ### Quick Checklist (Before Commit)
-
- - `bun run fmt`, `bun run lint`, `bun run test` all clean; no Biome warnings;
+- `bun run fmt`, `bun run lint`, `bun run test` all clean; no Biome warnings;
   no TypeScript errors; coverage thresholds hold.
 - `bun run audit` passes or has justified, time‑boxed exceptions.
 - No `any`, no `@ts-ignore`; use `@ts-expect-error` only with a reason.
@@ -446,7 +424,6 @@ Keep docs close to code.
 ## Additional tooling
 
 The following tooling is available in this environment:
-
 - `mbake` – A Makefile validator. Run using `mbake validate Makefile`.
 - `strace` – Traces system calls and signals made by a process; useful for
   debugging runtime behaviour and syscalls.

--- a/docs/cloud-native-ephemeral-previews.md
+++ b/docs/cloud-native-ephemeral-previews.md
@@ -74,7 +74,7 @@ DigitalOcean, Kubernetes, and Helm.
 
 Terraform
 
-```
+```hcl
 # providers.tf
 
 terraform {
@@ -105,7 +105,7 @@ variable "do_token" {
 provider "digitalocean" {
   token = var.do_token
 }
-```
+    ```yaml
 
 This configuration establishes the required providers and sets up the
 DigitalOcean provider.4 The DigitalOcean API token is defined as a sensitive
@@ -124,7 +124,7 @@ resources, such as internal load balancers and databases.7
 
 Terraform
 
-```
+```hcl
 # network.tf
 
 resource "digitalocean_vpc" "wildside_vpc" {
@@ -132,7 +132,7 @@ resource "digitalocean_vpc" "wildside_vpc" {
   region   = "nyc3"
   ip_range = "10.244.0.0/16"
 }
-```
+    ```yaml
 
 ### DOKS Cluster Resource (`digitalocean_kubernetes_cluster`)
 
@@ -142,7 +142,7 @@ operational best practices.8
 
 Terraform
 
-```
+```hcl
 # cluster.tf
 
 # Data source to get the latest supported patch version for a specific minor release
@@ -199,7 +199,7 @@ improve security, and optimize costs. This is achieved using the
 
 Terraform
 
-```
+```hcl
 # node_pools.tf
 
 # 1. Core Services Node Pool
@@ -272,7 +272,7 @@ dependency chain.10
 
 Terraform
 
-```
+```hcl
 # providers.tf (continued)
 
 # Configure the Kubernetes provider to connect to the new DOKS cluster
@@ -353,7 +353,7 @@ the primary source of truth for the cluster's platform state.
 
 Bash
 
-```
+```bash
 # Set environment variables for GitHub credentials and repository details
 export GITHUB_TOKEN="<your-personal-access-token>"
 export GITHUB_USER="<your-github-username>"
@@ -391,7 +391,7 @@ A well-defined repository structure is essential for managing the complexity of
 the system and ensuring maintainability. The following structures are
 recommended for the two GitOps repositories.
 
-**Table 1: GitOps Repository Structure**
+#### Table 1: GitOps Repository Structure
 
 | Repository | Path | Purpose |
 | --- | --- | --- |
@@ -419,7 +419,7 @@ to tell Flux where to find the Helm charts for the platform components.
 
 YAML
 
-```
+```yaml
 # infrastructure/sources/helm-repositories.yaml
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: HelmRepository
@@ -456,7 +456,7 @@ elsewhere.18
 
 YAML
 
-```
+```yaml
 # infrastructure/sources/git-repositories.yaml
 apiVersion: source.toolkit.fluxcd.io/v1
 kind: GitRepository
@@ -490,7 +490,7 @@ paths. It is deployed using its official Helm chart.
 
 YAML
 
-```
+```yaml
 # infrastructure/core/ingress-nginx.yaml
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -538,7 +538,7 @@ manual step of pointing a subdomain to the load balancer's IP address.19
 
 YAML
 
-```
+```yaml
 # infrastructure/core/external-dns.yaml
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -593,7 +593,7 @@ First, the `HelmRelease` for `cert-manager` itself:
 
 YAML
 
-```
+```yaml
 # infrastructure/core/cert-manager.yaml
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -624,7 +624,7 @@ that defines how `cert-manager` should obtain certificates.
 
 YAML
 
-```
+```yaml
 # infrastructure/core/cluster-issuer.yaml
 apiVersion: cert-manager.io/v1
 kind: ClusterIssuer
@@ -683,7 +683,7 @@ The implementation involves a three-step process:
 
    YAML
 
-   ```
+   ```yaml
    # infrastructure/secrets/cluster-secret-store.yaml
    apiVersion: external-secrets.io/v1beta1
    kind: ClusterSecretStore
@@ -712,7 +712,7 @@ The implementation involves a three-step process:
 
    YAML
 
-   ```
+   ```yaml
    # infrastructure/secrets/cloudflare-token-secret.yaml
    apiVersion: external-secrets.io/v1beta1
    kind: ExternalSecret
@@ -758,7 +758,7 @@ First, the operator is deployed via a `HelmRelease`:
 
 YAML
 
-```
+```yaml
 # infrastructure/databases/cnpg-operator.yaml
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -782,7 +782,7 @@ cluster.
 
 YAML
 
-```
+```yaml
 # infrastructure/databases/wildside-postgres-cluster.yaml
 apiVersion: postgresql.cnpg.io/v1
 kind: Cluster
@@ -827,7 +827,7 @@ disabled to reduce cost and complexity.
 
 YAML
 
-```
+```yaml
 # infrastructure/core/redis.yaml
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -900,7 +900,7 @@ strategy is implemented within the
 The `wildside-apps` repository is structured to facilitate the
 Helm-plus-Kustomize pattern:
 
-```
+```text
 wildside-apps/
 ├── base/
 │   ├── helmrelease.yaml    # The base HelmRelease for Wildside
@@ -928,7 +928,7 @@ non-production environment.
 
 YAML
 
-```
+```yaml
 # wildside-apps/base/helmrelease.yaml
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -989,7 +989,7 @@ The kustomization.yaml file defines the production environment:
 
 YAML
 
-```
+```yaml
 # wildside-apps/overlays/production/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -1007,7 +1007,7 @@ requests/limits, and update the hostname.
 
 YAML
 
-```
+```yaml
 # wildside-apps/overlays/production/patch-replicas-resources.yaml
 apiVersion: helm.toolkit.fluxcd.io/v2
 kind: HelmRelease
@@ -1032,7 +1032,7 @@ dynamically generate these files.
 
 YAML
 
-```
+```yaml
 # wildside-apps/overlays/ephemeral/pr-123/kustomization.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
@@ -1048,7 +1048,7 @@ The patch file will be generated with the unique details for the pull request.
 
 YAML
 
-```
+```yaml
 # wildside-apps/overlays/ephemeral/pr-123/patch-hostname-image.yaml
 # THIS FILE IS GENERATED BY CI
 apiVersion: helm.toolkit.fluxcd.io/v2
@@ -1084,7 +1084,7 @@ The workflow is defined in the application source code repository (e.g.,
 
 YAML
 
-```
+```yaml
 #.github/workflows/preview-environment.yaml
 name: Preview Environment
 
@@ -1103,7 +1103,7 @@ closed) to tear it down.49 It requires permissions to write to a repository (the
 
 `wildside-apps` repo) and to comment on the pull request.
 
-**Table 2: GitHub Actions Workflow Secrets & Variables**
+#### Table 2: GitHub Actions Workflow Secrets & Variables
 
 | Name                 | Scope  | Required | Description                                                                                                |
 | -------------------- | ------ | -------- | ---------------------------------------------------------------------------------------------------------- |
@@ -1121,7 +1121,7 @@ into a container image and pushes it to a registry.
 
 YAML
 
-```
+```yaml
 #.github/workflows/preview-environment.yaml (continued)
 jobs:
   build-and-push:
@@ -1174,7 +1174,7 @@ repository.54
 
 YAML
 
-```
+```yaml
 #.github/workflows/preview-environment.yaml (continued)
   deploy-preview:
     if: github.event.action!= 'closed'
@@ -1204,7 +1204,7 @@ files.56
 
 YAML
 
-```
+```yaml
 #.github/workflows/preview-environment.yaml (continued)
       - name: Generate Ephemeral Environment Manifests
         id: generate
@@ -1259,7 +1259,7 @@ preview URL.
 
 YAML
 
-```
+```yaml
 #.github/workflows/preview-environment.yaml (continued)
       - name: Commit and Push Manifests
         run: |
@@ -1295,7 +1295,7 @@ pruning mechanism handles the rest.
 
 YAML
 
-```
+```yaml
 #.github/workflows/preview-environment.yaml (continued)
   teardown-preview:
     if: github.event.action == 'closed'

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -1,21 +1,22 @@
 # Repository Design Guide
 
 A practical design for a web application with a Rust/Actix backend and a React
+
 + Tailwind/daisyUI PWA frontend. The repo supports:
 
-- Rust→OpenAPI→TypeScript client generation via **utoipa** + **orval**.
-- Actix WebSocket/events→**AsyncAPI** for docs and (optional) client stubs.
-- **Design tokens** as a first‑class package powering Tailwind/daisyUI and
++ Rust→OpenAPI→TypeScript client generation via **utoipa** + **orval**.
++ Actix WebSocket/events→**AsyncAPI** for docs and (optional) client stubs.
++ **Design tokens** as a first‑class package powering Tailwind/daisyUI and
   future native shells.
-- Docker‑friendly builds (musl where sensible) targeting Kubernetes on DOKS,
++ Docker‑friendly builds (musl where sensible) targeting Kubernetes on DOKS,
   with static assets served from object storage/CDN.
-- Bun as the JS runtime/package manager.
++ Bun as the JS runtime/package manager.
 
 ---
 
 ## 1) Monorepo Layout
 
-```
+```text
 myapp/
 ├─ backend/                           # Rust (Actix)
 │  ├─ src/
@@ -79,47 +80,47 @@ myapp/
 
 ### 2.1 Rust/Actix → OpenAPI → TypeScript Client (orval)
 
-- Use **utoipa** and **utoipa-actix-web** to annotate handlers and derive
++ Use **utoipa** and **utoipa-actix-web** to annotate handlers and derive
   schemas from serde models.
-- Expose the OpenAPI document at runtime (e.g., `/api-docs/openapi.json`)
++ Expose the OpenAPI document at runtime (e.g., `/api-docs/openapi.json`)
   and/or emit a static `spec/openapi.json` via `build.rs` or a small bin.
-- Frontend runs **orval** under bun to generate a fetch client and types that
++ Frontend runs **orval** under bun to generate a fetch client and types that
   align with the backend.
 
 **Backend (sketch):**
 
-- `models/` contains structs with
++ `models/` contains structs with
   `#[derive(Serialize, Deserialize, utoipa::ToSchema)]`.
-- `api/` handlers carry `#[utoipa::path(...)]` per route.
-- `main.rs` derives `#[derive(utoipa::OpenApi)]` and mounts Swagger UI for DX.
++ `api/` handlers carry `#[utoipa::path(...)]` per route.
++ `main.rs` derives `#[derive(utoipa::OpenApi)]` and mounts Swagger UI for DX.
 
 **Frontend (sketch):**
 
-- `frontend-pwa/orval.config.yaml` points to `../spec/openapi.json` (or the dev
++ `frontend-pwa/orval.config.yaml` points to `../spec/openapi.json` (or the dev
   URL).
-- `bunx orval` writes `src/api/client.ts` with typed functions.
-- A small `src/api/fetcher.ts` centralises base URL, auth, and error handling.
-- TanStack Query hooks (hand-written or template‑generated) wrap the client for
++ `bunx orval` writes `src/api/client.ts` with typed functions.
++ A small `src/api/fetcher.ts` centralises base URL, auth, and error handling.
++ TanStack Query hooks (hand-written or template‑generated) wrap the client for
   caching and retries.
 
 **Flow:**
 
-```
+```text
 Rust types + handlers  →  OpenAPI (utoipa)  →  orval  →  Typed TS client  →  React + TanStack Query
 ```
 
 ### 2.2 Actix WebSocket/Events → AsyncAPI → Consumers
 
-- For evented channels (WS/SSE/Kafka/etc.), describe contracts in **AsyncAPI**.
-- Author `spec/asyncapi.yaml` by hand **or** construct it programmatically
++ For evented channels (WS/SSE/Kafka/etc.), describe contracts in **AsyncAPI**.
++ Author `spec/asyncapi.yaml` by hand **or** construct it programmatically
   (e.g., using an AsyncAPI crate) and emit YAML/JSON.
-- Use the AsyncAPI Generator in CI to produce:
-  - Human‑readable HTML docs for events.
-  - Optional client/server stubs (WebSocket helpers) as a starting point.
++ Use the AsyncAPI Generator in CI to produce:
+  + Human‑readable HTML docs for events.
+  + Optional client/server stubs (WebSocket helpers) as a starting point.
 
 **Flow:**
 
-```
+```text
 Rust event payloads (serde + schemars)  →  AsyncAPI (YAML)  →  Docs & stubs  →  Frontend WS client + TanStack Query/SWR
 ```
 
@@ -134,21 +135,21 @@ Rust event payloads (serde + schemars)  →  AsyncAPI (YAML)  →  Docs & stubs 
 **Goals:** single source of truth for colours/spacing/typography/radii; drive
 Tailwind/daisyUI and any future native shells.
 
-- `packages/tokens/src/tokens.json`: global primitives (`color.*`, `space.*`,
++ `packages/tokens/src/tokens.json`: global primitives (`color.*`, `space.*`,
   `radius.*`, `font.*`).
-- `packages/tokens/src/themes/{light,dark}.json`: semantic overrides
++ `packages/tokens/src/themes/{light,dark}.json`: semantic overrides
   (`semantic.bg.default`, `semantic.fg.default`, `semantic.brand.*`).
-- `packages/tokens/build/style-dictionary.js`: exports
-  - `dist/css/variables.css` (CSS variables for runtime theming),
-  - `dist/tw/preset.cjs` (Tailwind preset mapping spacing/radius/colours),
-  - `dist/daisy/theme.cjs` (daisyUI theme object from semantic tokens),
-  - optional JS/TS token bundle for RN/NativeWind down the road.
++ `packages/tokens/build/style-dictionary.js`: exports
+  + `dist/css/variables.css` (CSS variables for runtime theming),
+  + `dist/tw/preset.cjs` (Tailwind preset mapping spacing/radius/colours),
+  + `dist/daisy/theme.cjs` (daisyUI theme object from semantic tokens),
+  + optional JS/TS token bundle for RN/NativeWind down the road.
 
 **Frontend consumption:**
 
-- Tailwind `presets: [require('@app/tokens/dist/tw/preset.cjs')]`.
-- daisyUI `daisyui: require('@app/tokens/dist/daisy/theme.cjs')`.
-- Import CSS vars once in `main.tsx`.
++ Tailwind `presets: [require('@app/tokens/dist/tw/preset.cjs')]`.
++ daisyUI `daisyui: require('@app/tokens/dist/daisy/theme.cjs')`.
++ Import CSS vars once in `main.tsx`.
 
 This keeps the visual system consistent across PWA, desktop (Tauri), and mobile
 (Capacitor) shells.
@@ -157,18 +158,18 @@ This keeps the visual system consistent across PWA, desktop (Tauri), and mobile
 
 ## 4) Environment Strategy & Ports/Adapters
 
-- Keep domain logic in `backend/src/domain` (no IO). Define **ports** for
++ Keep domain logic in `backend/src/domain` (no IO). Define **ports** for
   storage, cache, queues, email, etc., with **adapters** in `infra/`.
-- Mirror that concept in the frontend: create thin adapters around fetch (REST)
++ Mirror that concept in the frontend: create thin adapters around fetch (REST)
   and WS (events) so tests can stub them.
-- Use `.env` + `env_file` in Docker Compose for local dev and
++ Use `.env` + `env_file` in Docker Compose for local dev and
   ConfigMaps/Secrets in K8s.
 
 ---
 
 ## 5) Bun‑first Workspace Plumbing
 
-**Root **`` sets bun workspaces and unifies scripts:
+**Root** `package.json` sets bun workspaces and unifies scripts:
 
 ```jsonc
 {
@@ -242,10 +243,10 @@ FROM scratch AS export
 COPY --from=build /web/frontend-pwa/dist/ /dist/
 ```
 
-- In CI, extract `/dist` and upload to **DOKS Spaces** (object storage) behind
++ In CI, extract `/dist` and upload to **DOKS Spaces** (object storage) behind
   a CDN.
-- The backend serves only the API; static assets come from CDN.
-- For local dev, you can also serve via `vite dev` or a simple nginx container.
++ The backend serves only the API; static assets come from CDN.
++ For local dev, you can also serve via `vite dev` or a simple nginx container.
 
 ### 6.3 Docker Compose for Local Dev
 
@@ -266,8 +267,8 @@ services:
   web:
     image: nginx:1.27-alpine
     volumes:
-      - ./frontend-pwa/dist:/usr/share/nginx/html:ro
-      - ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      + ./frontend-pwa/dist:/usr/share/nginx/html:ro
+      + ./deploy/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     ports: ["3000:80"]
     depends_on: [backend]
 ```
@@ -281,11 +282,11 @@ services:
 
 **Principles:**
 
-- Backend pods are stateless; DB/cache live in managed services (e.g.,
++ Backend pods are stateless; DB/cache live in managed services (e.g.,
   PostgreSQL, Redis). Migrations run via Job.
-- Frontend assets are immutable in Spaces + CDN; deploys are object‑store
++ Frontend assets are immutable in Spaces + CDN; deploys are object‑store
   uploads (no pod just to serve files).
-- Ingress terminates TLS; backend exposed via HTTP (or gRPC) behind a single
++ Ingress terminates TLS; backend exposed via HTTP (or gRPC) behind a single
   hostname.
 
 ### 7.1 Static Assets on DOKS Spaces
@@ -315,7 +316,7 @@ rclone copy "$DIST" spaces:my-bucket/$PREFIX --s3-acl public-read \
 **Key objects:** Deployment, Service, ConfigMap (non‑secret settings), Secret
 (tokens/DB urls), HPA, PodDisruptionBudget, NetworkPolicy.
 
-``** (sketch):**
+**Deployment (sketch):**
 
 ```yaml
 apiVersion: apps/v1
@@ -329,12 +330,12 @@ spec:
     metadata: { labels: { app: myapp-backend } }
     spec:
       containers:
-      - name: app
+      + name: app
         image: ghcr.io/acme/myapp-backend:{{ .Values.imageTag }}
         ports: [{ containerPort: 8080 }]
         envFrom:
-          - configMapRef: { name: myapp-config }
-          - secretRef: { name: myapp-secrets }
+          + configMapRef: { name: myapp-config }
+          + secretRef: { name: myapp-secrets }
         readinessProbe:
           httpGet: { path: /health/ready, port: 8080 }
         livenessProbe:
@@ -361,88 +362,84 @@ to the CDN; only `/api` goes to cluster.
 
 1. **Lint & test**: cargo fmt/clippy/test; bun lint/type‑check/unit tests.
 2. **Build artifacts**:
-   - Build backend image → push to registry.
-   - Build frontend dist → upload to Spaces.
-   - Emit `spec/openapi.json` and publish as build artifact; run `orval` in a
+   + Build backend image → push to registry.
+   + Build frontend dist → upload to Spaces.
+   + Emit `spec/openapi.json` and publish as build artifact; run `orval` in a
      “types up‑to‑date” check.
-   - (Optional) Generate AsyncAPI HTML docs and publish to an internal docs
+   + (Optional) Generate AsyncAPI HTML docs and publish to an internal docs
      bucket.
 3. **Deploy**:
-   - Update Helm values with new image tag; commit to a GitOps repo watched by
+   + Update Helm values with new image tag; commit to a GitOps repo watched by
      FluxCD.
-   - Invalidate CDN (only for `index.html`), or rely on cache busting for
+   + Invalidate CDN (only for `index.html`), or rely on cache busting for
      hashed assets.
 
 ---
 
 ## 8) Local DX (Makefile targets)
 
-``
-
 ```makefile
 .PHONY: dev be fe gen openapi asyncapi docker-up docker-down
 
 be:
-	cargo run --manifest-path backend/Cargo.toml
+    cargo run --manifest-path backend/Cargo.toml
 
 fe:
-	cd frontend-pwa && bun dev
+    cd frontend-pwa && bun dev
 
 dev:
-	# run both (use tmux or just two terminals)
+    # run both (use tmux or just two terminals)
 
 openapi:
-	# write openapi.json to spec/
-	cargo run --manifest-path backend/Cargo.toml --bin openapi-dump > spec/openapi.json
+    # write openapi.json to spec/
+    cargo run --manifest-path backend/Cargo.toml --bin openapi-dump > spec/openapi.json
 
 gen:
-	bunx orval --config frontend-pwa/orval.config.yaml
+    bunx orval --config frontend-pwa/orval.config.yaml
 
 asyncapi:
-	bunx @asyncapi/generator spec/asyncapi.yaml @asyncapi/html-template -o docs/asyncapi
+    bunx @asyncapi/generator spec/asyncapi.yaml @asyncapi/html-template -o docs/asyncapi
 
 docker-up:
-	cd deploy && docker compose up --build -d
+    cd deploy && docker compose up --build -d
 
 docker-down:
-	cd deploy && docker compose down
+    cd deploy && docker compose down
 ```
 
 ---
 
 ## 9) Observability & Operations Hooks
 
-- **Health endpoints**: `/health/live` and `/health/ready` in backend for
-  probes.
-- **Structured logs** (JSON) with request IDs; propagate over WS too.
-- **Prometheus** metrics (expose `/metrics`) and scrape via ServiceMonitor.
-- **Feature flags**: sealed behind env/config; surfaced in OpenAPI as headers
-  where relevant.
++ **Health endpoints**: `/health/live` and `/health/ready` in backend for
+   probes.
++ **Structured logs** (JSON) with request IDs; propagate over WS too.
++ **Prometheus** metrics (expose `/metrics`) and scrape via ServiceMonitor.
++ **Feature flags**: sealed behind env/config; surfaced in OpenAPI as headers
+   where relevant.
 
 ---
 
 ## 10) Security & Hardening Notes
 
-- Minimal base images (distroless). Non‑root user.
-- SBOMs for backend images (e.g., `syft`); sign images (cosign) and verify in
-  cluster (policy‑controller/Kyverno).
-- CORS: restrict to CDN/public hostnames. Set HSTS and sensible CSP on static.
-- Secrets: mount via K8s Secrets (consider external secret operator for DO
-  Secrets Manager).
++ Minimal base images (distroless). Non‑root user.
++ SBOMs for backend images (e.g., `syft`); sign images (cosign) and verify in
+   cluster (policy‑controller/Kyverno).
++ CORS: restrict to CDN/public hostnames. Set HSTS and sensible CSP on static.
++ Secrets: mount via K8s Secrets (consider external secret operator for DO
+   Secrets Manager).
 
 ---
 
 ## 11) Summary of Hand‑offs
 
-- **HTTP:** Actix + utoipa → `spec/openapi.json` → orval → typed TS client →
-  React + TanStack.
-- **Events:** Actix WS (or Kafka, etc.) → `spec/asyncapi.yaml` → generator → WS
-  clients/docs.
-- **Design:** Tokens JSON → Style Dictionary → CSS vars + Tailwind preset +
-  daisyUI theme.
-- **Build/Deploy:** Docker multi‑stage (musl where possible) → K8s Deployment →
++ **HTTP:** Actix + utoipa → `spec/openapi.json` → orval → typed TS client →
+   React + TanStack.
++ **Events:** Actix WS (or Kafka, etc.) → `spec/asyncapi.yaml` → generator → WS
+   clients/docs.
++ **Design:** Tokens JSON → Style Dictionary → CSS vars + Tailwind preset +
+   daisyUI theme.
++ **Build/Deploy:** Docker multi‑stage (musl where possible) → K8s Deployment →
   CDN‑hosted static from DOKS Spaces; Ingress routes `/api` into cluster.
-
 This structure keeps contracts central, isolates platform concerns, and allows
 painless evolution from PWA to native shells without a rewrite.
-

--- a/docs/wildside-high-level-design.md
+++ b/docs/wildside-high-level-design.md
@@ -266,7 +266,7 @@ best, most delightful route for a given user at a given moment.
 
 ---
 
-**Table 1: Competitive Feature Matrix**
+### Table 1: Competitive Feature Matrix
 
 | Feature             | Wildside (Proposed)             | AllTrails                             | Komoot                          | Strava                         | GPSmyCity                   |
 | ------------------- | ------------------------------- | ------------------------------------- | ------------------------------- | ------------------------------ | --------------------------- |
@@ -867,7 +867,7 @@ is proposed to balance these requirements.
 
 ---
 
-**Table 2: Technology Stack Recommendation**
+### Table 2: Technology Stack Recommendation
 
 | Layer              | Technology                          | Rationale                                                                                            | Pros                                                                                             | Cons/Risks                                                                                         |
 | ------------------ | ----------------------------------- | ---------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
@@ -1155,7 +1155,7 @@ usage scenarios for the first year of operation.
 
 ---
 
-**Table 3: Detailed MVP Monthly Cost Estimation**
+### Table 3: Detailed MVP Monthly Cost Estimation
 
 | Service/Component            | Provider/Technology         | Plan/Tier                          | Estimated Monthly Cost (Low Usage: ~1k MAU) | Estimated Monthly Cost (Medium Usage: ~10k MAU) | Estimated Monthly Cost (High Usage: ~50k MAU) |
 | ---------------------------- | --------------------------- | ---------------------------------- | ------------------------------------------- | ----------------------------------------------- | --------------------------------------------- |
@@ -1165,8 +1165,7 @@ usage scenarios for the first year of operation.
 | Map Tile Hosting             | AWS S3 + CloudFront         | Pay-as-you-go                      | ~$25                                        | ~$50                                            | ~$150                                         |
 | Cache                        | Redis Cloud                 | Essentials (250 MB)                | $7                                          | $7                                              | $15 (500 MB)                                  |
 | LLM API Usage                | Anthropic Claude 3.5 Sonnet | Pay-as-you-go                      | ~$200                                       | ~$2,000                                         | ~$10,000                                      |
-| Total Estimated Monthly Cost |
-| ~$283                        | ~$2,150                     | ~$10,391                           |
+| Total Estimated Monthly Cost | - | - | ~$283 | ~$2,150 | ~$10,391 |
 
 Note: Cost estimates are based on pricing data from sources , and.83 LLM costs
 are highly variable and represent the largest financial risk; the estimate
@@ -1353,7 +1352,7 @@ Wildside and proposes concrete strategies for their mitigation.
 
 ---
 
-**Table 4: Risk Assessment Matrix**
+### Table 4: Risk Assessment Matrix
 
 | Risk Category | Specific Risk Description                                                                                                  | Likelihood | Impact | Mitigation Strategy                                                                                                                                              |
 | ------------- | -------------------------------------------------------------------------------------------------------------------------- | ---------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -1431,198 +1430,199 @@ how people experience and connect with the cities around them.
 
 ## Works cited
 
-1. API Pricing - OpenAI, https://openai.com/api/pricing/
+1. API Pricing - OpenAI, <https://openai.com/api/pricing/>
 2. ZeLonewolf's Diary | Host an OpenMapTiles Vector Tile Server on AWS for
    $19.75/month | OpenStreetMap,
-   https://www.openstreetmap.org/user/ZeLonewolf/diary/401697
+   <https://www.openstreetmap.org/user/ZeLonewolf/diary/401697>
 3. Comparing React Native vs Capacitor - Capgo,
-   https://capgo.app/blog/comparing-react-native-vs-capacitor/
+   <https://capgo.app/blog/comparing-react-native-vs-capacitor/>
 4. Capacitor vs React Native - Reveation Labs,
-   https://www.reveation.io/blog/capacitor-vs-react-native
-5. Using Capacitor with React, https://capacitorjs.com/solution/react
+   <https://www.reveation.io/blog/capacitor-vs-react-native>
+5. Using Capacitor with React, <https://capacitorjs.com/solution/react>
 6. Team Orienteering Problem with Time Windows and Variable Profit - Annals of
    Computer Science and Information Systems,
-   https://annals-csis.org/Volume_30/drp/pdf/158.pdf
+   <https://annals-csis.org/Volume_30/drp/pdf/158.pdf>
 7. [2506.08837] Design Patterns for Securing LLM Agents against Prompt
-   Injections - arXiv, https://arxiv.org/abs/2506.08837
+   Injections - arXiv, <https://arxiv.org/abs/2506.08837>
 8. Geometa Lab at IFS / OpenStreetMap Wikidata Quality Checker - GitLab,
-   https://gitlab.com/geometalab/osm-wikidata-quality-checker
+   <https://gitlab.com/geometalab/osm-wikidata-quality-checker>
 9. LLM Chronicles #6.9: Design Patterns for Securing LLM Agents Against Prompt
    Injection (Paper Review) - YouTube,
-   https://www.youtube.com/watch?v=2Er7bmyhPfM
+   <https://www.youtube.com/watch?v=2Er7bmyhPfM>
 10. Wikidata for Digital Preservationists,
-    https://www.dpconline.org/docs/technology-watch-reports/2551-thorntonwikidatadpc-revsionthornton/file
+    <https://www.dpconline.org/docs/technology-watch-reports/2551-thorntonwikidatadpc-revsionthornton/file>
 11. Intent Classification using LLMs (Hybrid) - Voiceflow's docs,
-    https://docs.voiceflow.com/docs/llm-intent-classification-method
+    <https://docs.voiceflow.com/docs/llm-intent-classification-method>
 12. Comparing React Native vs. Vue and Capacitor - LogRocket Blog,
-    https://blog.logrocket.com/comparing-react-native-vs-vue-capacitor/
+    <https://blog.logrocket.com/comparing-react-native-vs-vue-capacitor/>
 13. Tauri vs. Electron: performance, bundle size, and the real trade-offs -
-    Hopp, https://www.gethopp.app/blog/tauri-vs-electron
-14. Tauri vs. Electron: A New Dawn in Desktop App Development | by DhruvK_Sethi
-    | Medium, https://medium.com/@DhruvK_Sethi/tauri-vs-electron-a-new-dawn-in-desktop-app-development-16f13372b8fc |
+    Hopp, <https://www.gethopp.app/blog/tauri-vs-electron>
+14. Tauri vs. Electron: A New Dawn in Desktop App Development –
+    DhruvK_Sethi
+    Medium, <https://medium.com/p/16f13372b8fc>
 15. Tauri VS. Electron - Real world application - Levminer,
-    https://www.levminer.com/blog/tauri-vs-electron
+    <https://www.levminer.com/blog/tauri-vs-electron>
 16. Tauri vs Electron: The best Electron alternative created yet -
-    Astrolytics.io analytics, https://www.astrolytics.io/blog/electron-vs-tauri
+    Astrolytics.io analytics, <https://www.astrolytics.io/blog/electron-vs-tauri>
 17. Comparing Diesel and rust-postgres | by Sean Griffin | HackerNoon.com -
     Medium,
-    https://medium.com/hackernoon/comparing-diesel-and-rust-postgres-97fd8c656fdd
+    <https://medium.com/hackernoon/comparing-diesel-and-rust-postgres-97fd8c656fdd>
 18. TypeScript vs. JavaScript: Which One to Choose in 2025? - Carmatec,
-    https://www.carmatec.com/blog/typescript-vs-javascript-which-one-to-choose/
+    <https://www.carmatec.com/blog/typescript-vs-javascript-which-one-to-choose/>
 19. Rust Web Frameworks Compared: Actix vs Axum vs Rocket - DEV Community,
-    https://dev.to/leapcell/rust-web-frameworks-compared-actix-vs-axum-vs-rocket-4bad
+    <https://dev.to/leapcell/rust-web-frameworks-compared-actix-vs-axum-vs-rocket-4bad>
 20. OR-Tools' Vehicle Routing Solver: a Generic Constraint-Programming Solver
     with Heuristic Search for Routing Problems - Google Research,
-    https://research.google/pubs/or-tools-vehicle-routing-solver-a-generic-constraint-programming-solver-with-heuristic-search-for-routing-problems/
-21. PostGIS, https://postgis.net/
+    <https://research.google/pubs/or-tools-vehicle-routing-solver-a-generic-constraint-programming-solver-with-heuristic-search-for-routing-problems/>
+21. PostGIS, <https://postgis.net/>
 22. The best React UI component libraries of 2025 | Croct Blog,
-    https://blog.croct.com/post/best-react-ui-component-libraries
+    <https://blog.croct.com/post/best-react-ui-component-libraries>
 23. Solving Orienteering Problem with Advanced Techniques - Number Analytics,
-    https://www.numberanalytics.com/blog/advanced-orienteering-problem-solutions
+    <https://www.numberanalytics.com/blog/advanced-orienteering-problem-solutions>
 24. Leaflet migration guide - MapLibre GL JS,
-    https://maplibre.org/maplibre-gl-js/docs/guides/leaflet-migration-guide/
+    <https://maplibre.org/maplibre-gl-js/docs/guides/leaflet-migration-guide/>
 25. Pricing - Anthropic API,
-    https://docs.anthropic.com/en/docs/about-claude/pricing
+    <https://docs.anthropic.com/en/docs/about-claude/pricing>
 26. Don't trust the LLM: Rethinking LLM Architectures for Better Security -
-    Mindgard AI, https://mindgard.ai/blog/llm-architecture-positioning
+    Mindgard AI, <https://mindgard.ai/blog/llm-architecture-positioning>
 27. Worry-Free Managed PostgreSQL Hosting - DigitalOcean,
-    https://www.digitalocean.com/products/managed-databases-postgresql
-28. Redis Cloud Pricing, https://redis.io/pricing/
+    <https://www.digitalocean.com/products/managed-databases-postgresql>
+28. Redis Cloud Pricing, <https://redis.io/pricing/>
 29. The Data Model of OpenStreetMap - Overpass API,
-    https://dev.overpass-api.de/overpass-doc/en/preface/osm_data_model.html
-30. Wikidata - OpenStreetMap Wiki, https://wiki.openstreetmap.org/wiki/Wikidata
+    <https://dev.overpass-api.de/overpass-doc/en/preface/osm_data_model.html>
+30. Wikidata - OpenStreetMap Wiki, <https://wiki.openstreetmap.org/wiki/Wikidata>
 31. The cooperative orienteering problem with time windows - Optimization
-    Online, https://optimization-online.org/wp-content/uploads/2014/04/4316.pdf
+    Online, <https://optimization-online.org/wp-content/uploads/2014/04/4316.pdf>
 32. I'm a bit uncertain about what Google OR-Tools is…it *seems* to be some
-    sort of - Hacker News, https://news.ycombinator.com/item?id=22582688
+    sort of - Hacker News, <https://news.ycombinator.com/item?id=22582688>
 33. JSONB PostgreSQL: How To Store & Index JSON Data - ScaleGrid,
-    https://scalegrid.io/blog/using-jsonb-in-postgresql-how-to-effectively-store-index-json-data-in-postgresql/
+    <https://scalegrid.io/blog/using-jsonb-in-postgresql-how-to-effectively-store-index-json-data-in-postgresql/>
 34. Best Walking Apps (2025) - Garage Gym Reviews,
-    https://www.garagegymreviews.com/best-walking-apps
+    <https://www.garagegymreviews.com/best-walking-apps>
 35. 14 Best Walking Trip Planner Apps in 2025 - Upper,
-    https://www.upperinc.com/blog/best-walking-route-planner-apps/
+    <https://www.upperinc.com/blog/best-walking-route-planner-apps/>
 36. User:Krauss/Wikidata-question1 - OpenStreetMap Wiki,
-    https://wiki.openstreetmap.org/wiki/User:Krauss/Wikidata-question1
+    <https://wiki.openstreetmap.org/wiki/User:Krauss/Wikidata-question1>
 37. Software MVP: Monolith vs Other Form : r/startups - Reddit,
-    https://www.reddit.com/r/startups/comments/125u276/software_mvp_monolith_vs_other_form/
+    <https://www.reddit.com/r/startups/comments/125u276/software_mvp_monolith_vs_other_form/>
 38. Rust Web Frameworks Compared: Actix vs Axum vs Rocket | by Leapcell | Jul,
     2025,
-    https://leapcell.medium.com/rust-web-frameworks-compared-actix-vs-axum-vs-rocket-20f0cc8a6cda
+    <https://leapcell.medium.com/rust-web-frameworks-compared-actix-vs-axum-vs-rocket-20f0cc8a6cda>
 39. Unleashing the Power of Rust in GIS Development - GEO Jobe,
-    https://geo-jobe.com/mapthis/unleashing-the-power-of-rust-in-gis-development/
+    <https://geo-jobe.com/mapthis/unleashing-the-power-of-rust-in-gis-development/>
 40. TanStack Query: A Powerful Tool for Data Management in React - Medium,
-    https://medium.com/@ignatovich.dm/tanstack-query-a-powerful-tool-for-data-management-in-react-0c5ae6ef037c
+    <https://medium.com/@ignatovich.dm/tanstack-query-a-powerful-tool-for-data-management-in-react-0c5ae6ef037c>
 41. Self Host LLM vs Api LLM : r/AI_Agents - Reddit,
-    https://www.reddit.com/r/AI_Agents/comments/1kpt89v/self_host_llm_vs_api_llm/
+    <https://www.reddit.com/r/AI_Agents/comments/1kpt89v/self_host_llm_vs_api_llm/>
 42. How to Monitor Your LLM API Costs and Cut Spending by 90% - Helicone,
-    https://www.helicone.ai/blog/monitor-and-optimize-llm-costs
+    <https://www.helicone.ai/blog/monitor-and-optimize-llm-costs>
 43. Load OpenStreetMap data to PostGIS - Blog @ RustProof Labs,
-    https://blog.rustprooflabs.com/2019/01/postgis-osm-load
+    <https://blog.rustprooflabs.com/2019/01/postgis-osm-load>
 44. Using OpenStreetMap data - Algorithms,
-    https://algo.win.tue.nl/tutorials/openstreetmap/
+    <https://algo.win.tue.nl/tutorials/openstreetmap/>
 45. A Practical Review: Solving Vehicle Routing Problems with OR-Tools and
     SCIP,
-    https://dev.to/thana_b/a-practical-review-solving-vehicle-routing-problems-with-or-tools-and-scip-52me
+    <https://dev.to/thana_b/a-practical-review-solving-vehicle-routing-problems-with-or-tools-and-scip-52me>
 46. GPSmyCity: Walks in 1K+ Cities - App Store,
-    https://apps.apple.com/us/app/gpsmycity-walks-in-1k-cities/id417207307
+    <https://apps.apple.com/us/app/gpsmycity-walks-in-1k-cities/id417207307>
 47. Top 11 Multi-Stop Route Planner Apps in 2025,
-    https://www.upperinc.com/blog/best-multi-stop-route-planner-app/
-48. Home - osm2pgsql, https://osm2pgsql.org/
-49. Claude Sonnet 4 - Anthropic, https://www.anthropic.com/claude/sonnet
+    <https://www.upperinc.com/blog/best-multi-stop-route-planner-app/>
+48. Home - osm2pgsql, <https://osm2pgsql.org/>
+49. Claude Sonnet 4 - Anthropic, <https://www.anthropic.com/claude/sonnet>
 50. Tour Guide Apps Development 101 - Krasamo,
-    https://www.krasamo.com/tour-guide-apps/
+    <https://www.krasamo.com/tour-guide-apps/>
 51. Vite vs. Next.js: Features, Comparisons, Pros & Cons, & More - Prismic,
-    https://prismic.io/blog/vite-vs-nextjs
+    <https://prismic.io/blog/vite-vs-nextjs>
 52. What is DaisyUI? Advantages, Disadvantages, and FAQ's - By SW Habitation,
-    https://www.swhabitation.com/blogs/what-is-daisyui-advantages-disadvantages-and-faqs
+    <https://www.swhabitation.com/blogs/what-is-daisyui-advantages-disadvantages-and-faqs>
 53. daisyUI adoption guide: Overview, examples, and alternatives - LogRocket
-    Blog, https://blog.logrocket.com/daisyui-adoption-guide/
+    Blog, <https://blog.logrocket.com/daisyui-adoption-guide/>
 54. DaisyUI vs Mantine: Which One is Better in 2025? - Subframe,
-    https://www.subframe.com/tips/daisyui-vs-mantine
+    <https://www.subframe.com/tips/daisyui-vs-mantine>
 55. My Favorite Tailwind Library | Daisy UI - DEV Community,
-    https://dev.to/thatanjan/my-favorite-tailwind-library-daisy-ui-2n3j
+    <https://dev.to/thatanjan/my-favorite-tailwind-library-daisy-ui-2n3j>
 56. DaisyUI Reviews (2025) - Product Hunt,
-    https://www.producthunt.com/products/daisyui/reviews
+    <https://www.producthunt.com/products/daisyui/reviews>
 57. Comparison of UI libraries for React : r/reactjs - Reddit,
-    https://www.reddit.com/r/reactjs/comments/vtgbai/comparison_of_ui_libraries_for_react/
+    <https://www.reddit.com/r/reactjs/comments/vtgbai/comparison_of_ui_libraries_for_react/>
 58. Daisy UI is a godsend : r/Frontend - Reddit,
-    https://www.reddit.com/r/Frontend/comments/1ag8qx3/daisy_ui_is_a_godsend/
+    <https://www.reddit.com/r/Frontend/comments/1ag8qx3/daisy_ui_is_a_godsend/>
 59. AllTrails Review - Exploration Solo,
-    https://explorationsolo.com/alltrails-review/
+    <https://explorationsolo.com/alltrails-review/>
 60. Is AllTrails+ worth it? (Spoiler: It isn't for everyone but it is for this
-    type of hiker.), https://uprootedtraveler.com/is-alltrails-pro-worth-it/
+    type of hiker.), <https://uprootedtraveler.com/is-alltrails-pro-worth-it/>
 61. Visit A City - Apps on Google Play,
-    https://play.google.com/store/apps/details?id=com.visitacity.visitacityapp
+    <https://play.google.com/store/apps/details?id=com.visitacity.visitacityapp>
 62. Top 12 Features to Look for in a Modern Tour Guide App - Vox Tours,
-    https://voxtours.com/12-features-to-look-for-in-a-modern-tour-guide-app/
+    <https://voxtours.com/12-features-to-look-for-in-a-modern-tour-guide-app/>
 63. React Component Libraries - Mismo,
-    https://mismo.team/react-component-libraries-comparison-mui-vs-mantine/
+    <https://mismo.team/react-component-libraries-comparison-mui-vs-mantine/>
 64. Diesel is a Safe, Extensible ORM and Query Builder for Rust,
-    https://diesel.rs/
+    <https://diesel.rs/>
 65. Self-Hosting vs Managed Hosting - Which Suits Your Business? - MGT
-    Commerce, https://www.mgt-commerce.com/blog/self-hosting-vs-managed-hosting/
+    Commerce, <https://www.mgt-commerce.com/blog/self-hosting-vs-managed-hosting/>
 66. 11 Best Free Route Planners with Unlimited Stops - Maptive,
-    https://www.maptive.com/free-route-planners-with-unlimited-stops/
+    <https://www.maptive.com/free-route-planners-with-unlimited-stops/>
 67. Point-of-interest lists and their potential in recommendation systems -
-    PMC, https://pmc.ncbi.nlm.nih.gov/articles/PMC7848883/
+    PMC, <https://pmc.ncbi.nlm.nih.gov/articles/PMC7848883/>
 68. TypeScript vs JavaScript: Which is Better for Your Next Project? - Medium,
-    https://medium.com/@killoldesai/typescript-vs-javascript-which-is-better-for-your-next-project-23475355e499
+    <https://medium.com/@killoldesai/typescript-vs-javascript-which-is-better-for-your-next-project-23475355e499>
 69. Intent Recognition using a LLM with Predefined Intentions | by Ai
     insightful - Medium,
-    https://medium.com/@aiinisghtful/intent-recognition-using-a-llm-with-predefined-intentions-4620284b72f7
+    <https://medium.com/@aiinisghtful/intent-recognition-using-a-llm-with-predefined-intentions-4620284b72f7>
 70. PostgreSQL Pricing | DigitalOcean Documentation,
-    https://docs.digitalocean.com/products/databases/postgresql/details/pricing/
+    <https://docs.digitalocean.com/products/databases/postgresql/details/pricing/>
 71. Heroku PostgreSQL vs. Amazon RDS for PostgreSQL - CloudBees,
-    https://www.cloudbees.com/blog/heroku-postgresql-versus-amazon-rds-postgresql
+    <https://www.cloudbees.com/blog/heroku-postgresql-versus-amazon-rds-postgresql>
 72. Heroku Postgres - Add-ons,
-    https://elements.heroku.com/addons/heroku-postgresql
+    <https://elements.heroku.com/addons/heroku-postgresql>
 73. A Straightforward Comparison Of Mantine Vs Chakra | Magic UI,
-    https://magicui.design/blog/mantine-vs-chakra
+    <https://magicui.design/blog/mantine-vs-chakra>
 74. Flexible pricing for online mapping - MapTiler,
-    https://www.maptiler.com/cloud/pricing/
+    <https://www.maptiler.com/cloud/pricing/>
 75. Choosing the best graph database for your organization: A practical guide -
-    Linkurious, https://linkurious.com/blog/choosing-the-best-graph-database/
+    Linkurious, <https://linkurious.com/blog/choosing-the-best-graph-database/>
 76. Diesel: A Safe, Extensible ORM and Query Builder for Rust | Hacker News,
-    https://news.ycombinator.com/item?id=11045412
+    <https://news.ycombinator.com/item?id=11045412>
 77. A Primer on Tailwind CSS: Pros, Cons & Real-World Use Cases - Telerik.com,
-    https://www.telerik.com/blogs/primer-tailwind-css-pros-cons-real-world-use-cases
+    <https://www.telerik.com/blogs/primer-tailwind-css-pros-cons-real-world-use-cases>
 78. OpenStreetMap Data Model - Itinero - Documentation,
-    https://docs.itinero.tech/docs/osmsharp/osm.html
+    <https://docs.itinero.tech/docs/osmsharp/osm.html>
 79. LLM Prompt Injection Prevention - OWASP Cheat Sheet Series,
-    https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html
+    <https://cheatsheetseries.owasp.org/cheatsheets/LLM_Prompt_Injection_Prevention_Cheat_Sheet.html>
 80. Amazon RDS for PostgreSQL Pricing,
-    https://aws.amazon.com/rds/postgresql/pricing/
+    <https://aws.amazon.com/rds/postgresql/pricing/>
 81. Mistral 7B System Requirements: What You Need to Run It Locally,
-    https://www.oneclickitsolution.com/centerofexcellence/aiml/run-mistral-7b-locally-hardware-software-specs
+    <https://www.oneclickitsolution.com/centerofexcellence/aiml/run-mistral-7b-locally-hardware-software-specs>
 82. TypeScript vs JavaScript Which is Best for Web Development - Moon
-    Technolabs, https://www.moontechnolabs.com/blog/typescript-vs-javascript/
+    Technolabs, <https://www.moontechnolabs.com/blog/typescript-vs-javascript/>
 83. Vehicle Routing Problem | OR-Tools - Google for Developers,
-    https://developers.google.com/optimization/routing/vrp
+    <https://developers.google.com/optimization/routing/vrp>
 84. Prompt Injection Attacks in LLMs: Mitigating Risks with Microsegmentation -
     ColorTokens,
-    https://colortokens.com/blogs/prompt-injection-attack-llm-microsegmentation/
+    <https://colortokens.com/blogs/prompt-injection-attack-llm-microsegmentation/>
 85. Orienteering Problem: A survey of recent variants, solution approaches and
     applications,
-    https://smusg.elsevierpure.com/en/publications/orienteering-problem-a-survey-of-recent-variants-solution-approac
+    <https://smusg.elsevierpure.com/en/publications/orienteering-problem-a-survey-of-recent-variants-solution-approac>
 86. Personalized Tour Recommendation Based on User Interests and Points of
     Interest Visit Durations - IJCAI,
-    https://www.ijcai.org/Proceedings/15/Papers/253.pdf
+    <https://www.ijcai.org/Proceedings/15/Papers/253.pdf>
 87. The Orienteering Problem: A Review of Variants and Solution Approaches -
     ResearchGate,
-    https://www.researchgate.net/publication/367666894_The_Orienteering_Problem_A_Review_of_Variants_and_Solution_Approaches
+    <https://www.researchgate.net/publication/367666894_The_Orienteering_Problem_A_Review_of_Variants_and_Solution_Approaches>
 88. An iterated local search algorithm for solving the Orienteering Problem
-    with Time Windows - InK@SMU.edu.sg,
-    https://ink.library.smu.edu.sg/cgi/viewcontent.cgi?article=3794&context=sis_research
+    with Time Windows - <InK@SMU.edu>.sg,
+    <https://ink.library.smu.edu.sg/cgi/viewcontent.cgi?article=3794&context=sis_research>
 89. Asynchronous State Management with TanStack Query - Atlantbh Sarajevo,
-    https://www.atlantbh.com/asynchronous-state-management-with-tanstack-query/
+    <https://www.atlantbh.com/asynchronous-state-management-with-tanstack-query/>
 90. Preparing Geospatial Data in PostGIS - Benny's Mind Hack,
-    https://bennycheung.github.io/preparing-geospatial-data-in-postgis
+    <https://bennycheung.github.io/preparing-geospatial-data-in-postgis>
 91. Osm2pgsql - OpenStreetMap Wiki,
-    https://wiki.openstreetmap.org/wiki/Osm2pgsql
-92. Pricing | Render, https://render.com/pricing
+    <https://wiki.openstreetmap.org/wiki/Osm2pgsql>
+92. Pricing | Render, <https://render.com/pricing>
 93. Monolith vs. Microservices Architecture - DevZero,
-    https://www.devzero.io/blog/monolith-vs-microservices
+    <https://www.devzero.io/blog/monolith-vs-microservices>
 94. How to Balance The Pros and Cons of Tailwind CSS - Blogs - Purecode.AI,
-    https://blogs.purecode.ai/blogs/pros-cons-tailwind
+    <https://blogs.purecode.ai/blogs/pros-cons-tailwind>
 95. Render PostgreSQL | FindDevTools,
-    https://finddev.tools/about/render-postgresql
+    <https://finddev.tools/about/render-postgresql>


### PR DESCRIPTION
## Summary
- Rename duplicated guidance sections in `AGENTS.md`
- Add explicit languages to fenced code blocks and tables in docs
- Correct table markup and long lines across documentation

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`
- `make markdownlint` *(fails: AGENTS.md requires additional cleanup)*

------
https://chatgpt.com/codex/tasks/task_e_689e50e7461483228a7ce1f06995cddd