### PR TITLE
Update design tokens for dark theme

### DIFF
--- a/packages/tokens/src/themes/dark.json
+++ b/packages/tokens/src/themes/dark.json
@@ -1,21 +1,24 @@
 {
   "semantic": {
     "bg": {
-      "default": { "value": "{color.neutral.900}", "description": "Surface" },
-      "subtle": { "value": "{color.neutral.800}", "description": "Raised surface" },
-      "inverted": { "value": "{color.neutral.0}", "description": "Light surface for inverted areas" }
+      "default": { "value": "{color.neutral.900}", "description": "Default background for dark theme" },
+      "subtle": { "value": "{color.neutral.800}", "description": "Raised surface (e.g., cards) for dark theme" },
+      "inverted": { "value": "{color.neutral.0}", "description": "Inverted surface for dark theme" }
     },
     "fg": {
-      "default": { "value": "{color.neutral.0}", "description": "Primary text" },
-      "muted": { "value": "{color.neutral.50}", "description": "Muted text" },
-      "inverted": { "value": "{color.neutral.900}", "description": "Text on light surfaces" }
+      "default": { "value": "{color.neutral.50}", "description": "Default foreground/text for dark theme" },
+      "muted": { "value": "{color.neutral.400}", "description": "Muted foreground for dark theme" },
+      "inverted": { "value": "{color.neutral.900}", "description": "Text on inverted surfaces for dark theme" }
     },
     "brand": {
-      "default": { "value": "{color.primary.500}", "description": "Brand colour" },
-      "hover": { "value": "{color.primary.600}", "description": "Brand hover" },
-      "contrast": { "value": "{color.neutral.900}", "description": "Text on brand" },
-      "muted": { "value": "{color.primary.400}", "description": "Subtle brand elements" }
+      "default": { "value": "{color.primary.500}", "description": "Primary brand colour (orange)" },
+      "hover": { "value": "{color.primary.400}", "description": "Brand hover state" },
+      "contrast": { "value": "{color.neutral.900}", "description": "Text on brand-coloured elements" }
+    },
+    "accent": {
+      "default": { "value": "{color.secondary.400}", "description": "Accent colour (teal)" },
+      "hover": { "value": "{color.secondary.500}", "description": "Accent hover state" },
+      "contrast": { "value": "{color.neutral.900}", "description": "Text on accent-coloured elements" }
     }
   }
 }
-

--- a/packages/tokens/src/themes/light.json
+++ b/packages/tokens/src/themes/light.json
@@ -1,21 +1,24 @@
 {
   "semantic": {
     "bg": {
-      "default": { "value": "{color.neutral.0}", "description": "Surface" },
-      "subtle": { "value": "{color.neutral.50}", "description": "Raised surface" },
-      "inverted": { "value": "{color.neutral.900}", "description": "Dark surface" }
+      "default": { "value": "{color.neutral.0}", "description": "Default background for light theme" },
+      "subtle": { "value": "{color.neutral.50}", "description": "Raised surface (e.g., cards) for light theme" },
+      "inverted": { "value": "{color.neutral.900}", "description": "Inverted surface for light theme" }
     },
     "fg": {
-      "default": { "value": "{color.neutral.900}", "description": "Primary text" },
-      "muted": { "value": "{color.neutral.600}", "description": "Muted text" },
-      "inverted": { "value": "{color.neutral.0}", "description": "Text on dark surfaces" }
+      "default": { "value": "{color.neutral.900}", "description": "Default foreground/text for light theme" },
+      "muted": { "value": "{color.neutral.600}", "description": "Muted foreground for light theme" },
+      "inverted": { "value": "{color.neutral.0}", "description": "Text on inverted surfaces for light theme" }
     },
     "brand": {
-      "default": { "value": "{color.primary.600}", "description": "Brand colour" },
-      "hover": { "value": "{color.primary.700}", "description": "Brand hover" },
-      "contrast": { "value": "{color.neutral.0}", "description": "Text on brand" },
-      "muted": { "value": "{color.primary.500}", "description": "Subtle brand elements" }
+      "default": { "value": "{color.primary.500}", "description": "Primary brand colour (orange)" },
+      "hover": { "value": "{color.primary.600}", "description": "Brand hover state" },
+      "contrast": { "value": "{color.neutral.900}", "description": "Text on brand-coloured elements" }
+    },
+    "accent": {
+      "default": { "value": "{color.secondary.400}", "description": "Accent colour (teal)" },
+      "hover": { "value": "{color.secondary.500}", "description": "Accent hover state" },
+      "contrast": { "value": "{color.neutral.900}", "description": "Text on accent-coloured elements" }
     }
   }
 }
-

--- a/packages/tokens/src/tokens.json
+++ b/packages/tokens/src/tokens.json
@@ -1,74 +1,79 @@
 {
   "color": {
-    "accent": {
-      "50": { "value": "#f0fdf4", "description": "Accent 50" },
-      "500": { "value": "#10b981", "description": "Accent 500" },
-      "600": { "value": "#059669", "description": "Accent 600" }
-    },
     "neutral": {
-      "0": { "value": "#ffffff", "description": "Pure white" },
-      "50": { "value": "#f9fafb", "description": "Neutral 50" },
-      "200": { "value": "#e5e7eb", "description": "Neutral 200" },
-      "600": { "value": "#4b5563", "description": "Neutral 600" },
-      "800": { "value": "#1f2937", "description": "Neutral 800" },
-      "900": { "value": "#0b1220", "description": "Near-black" }
+      "0": { "value": "#FFFFFF", "description": "Pure white" },
+      "50": { "value": "#F8FAFC", "description": "Neutral 50" },
+      "100": { "value": "#F1F5F9", "description": "Neutral 100" },
+      "200": { "value": "#E2E8F0", "description": "Neutral 200" },
+      "300": { "value": "#CBD5E1", "description": "Neutral 300" },
+      "400": { "value": "#94A3B8", "description": "Neutral 400" },
+      "500": { "value": "#64748B", "description": "Neutral 500" },
+      "600": { "value": "#475569", "description": "Neutral 600" },
+      "700": { "value": "#374151", "description": "Neutral 700" },
+      "800": { "value": "#1F2937", "description": "Neutral 800" },
+      "900": { "value": "#111827", "description": "Near-black" }
     },
     "primary": {
-      "50": { "value": "#eef2ff", "description": "Primary 50" },
-      "500": { "value": "#6366f1", "description": "Primary 500" },
-      "600": { "value": "#5457e0", "description": "Primary 600" },
-      "700": { "value": "#4338ca", "description": "Primary 700" }
+      "400": { "value": "#FB923C", "description": "Primary 400 (Orange)" },
+      "500": { "value": "#F97316", "description": "Primary 500 (Orange)" },
+      "600": { "value": "#EA580C", "description": "Primary 600 (Orange)" }
     },
     "secondary": {
-      "50": { "value": "#fdf2f8", "description": "Secondary 50" },
-      "500": { "value": "#ec4899", "description": "Secondary 500" },
-      "600": { "value": "#db2777", "description": "Secondary 600" }
+      "300": { "value": "#67E8F9", "description": "Secondary 300 (Teal)" },
+      "400": { "value": "#22D3EE", "description": "Secondary 400 (Teal)" },
+      "500": { "value": "#06B6D4", "description": "Secondary 500 (Teal)" },
+      "600": { "value": "#0891B2", "description": "Secondary 600 (Teal)" }
     }
   },
   "font": {
     "family": {
       "sans": {
         "value": "Inter, ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, \"Apple Color Emoji\", \"Segoe UI Emoji\", \"Segoe UI Symbol\"",
-        "description": "Sans-serif stack"
+        "description": "Sans-serif font stack"
       }
     },
     "size": {
-      "base": { "value": "1rem", "description": "Base text" },
       "sm": { "value": "0.875rem", "description": "Small text" },
-      "xl": { "value": "1.25rem", "description": "Extra-large text" }
+      "base": { "value": "1rem", "description": "Base text size" },
+      "lg": { "value": "1.125rem", "description": "Large text" },
+      "xl": { "value": "1.25rem", "description": "Extra-large text" },
+      "2xl": { "value": "1.5rem", "description": "2x large text" }
     }
   },
   "radius": {
     "sm": { "value": "0.25rem", "description": "Small radius" },
     "md": { "value": "0.5rem", "description": "Medium radius" },
-    "xl": { "value": "1rem", "description": "Extra-large radius" },
-    "2xl": { "value": "1.5rem", "description": "2x large radius" },
-    "round": { "value": "9999px", "description": "Fully rounded" }
-  },
-  "semantic": {
-    "bg": {
-      "default": { "value": "{color.neutral.0}", "description": "Default background" },
-      "subtle": { "value": "{color.neutral.50}", "description": "Raised surface" },
-      "inverted": { "value": "{color.neutral.900}", "description": "Inverted surface" }
-    },
-    "brand": {
-      "default": { "value": "{color.primary.600}", "description": "Brand colour" },
-      "hover": { "value": "{color.primary.500}", "description": "Brand hover state" },
-      "contrast": { "value": "{color.neutral.0}", "description": "Text on brand" },
-      "muted": { "value": "{color.primary.400}", "description": "Subtle brand elements" }
-    },
-    "fg": {
-      "default": { "value": "{color.neutral.900}", "description": "Default foreground" },
-      "muted": { "value": "{color.neutral.600}", "description": "Muted foreground" },
-      "inverted": { "value": "{color.neutral.0}", "description": "Text on brand surfaces" }
-    }
+    "lg": { "value": "1rem", "description": "Large radius" },
+    "full": { "value": "9999px", "description": "Fully rounded" }
   },
   "space": {
-    "0": { "value": "0rem", "description": "Zero spacing" },
     "1": { "value": "0.25rem", "description": "Spacing scale 1" },
     "2": { "value": "0.5rem", "description": "Spacing scale 2" },
     "3": { "value": "0.75rem", "description": "Spacing scale 3" },
-    "4": { "value": "1rem", "description": "Spacing scale 4" }
+    "4": { "value": "1rem", "description": "Spacing scale 4" },
+    "6": { "value": "1.5rem", "description": "Spacing scale 6" },
+    "8": { "value": "2rem", "description": "Spacing scale 8" }
+  },
+  "semantic": {
+    "bg": {
+      "default": { "value": "{color.neutral.900}", "description": "Default background for dark theme" },
+      "subtle": { "value": "{color.neutral.800}", "description": "Raised surface (e.g., cards) for dark theme" },
+      "inverted": { "value": "{color.neutral.0}", "description": "Inverted surface for dark theme" }
+    },
+    "fg": {
+      "default": { "value": "{color.neutral.50}", "description": "Default foreground/text for dark theme" },
+      "muted": { "value": "{color.neutral.400}", "description": "Muted foreground for dark theme" },
+      "inverted": { "value": "{color.neutral.900}", "description": "Text on inverted surfaces for dark theme" }
+    },
+    "brand": {
+      "default": { "value": "{color.primary.500}", "description": "Primary brand colour (orange)" },
+      "hover": { "value": "{color.primary.400}", "description": "Brand hover state" },
+      "contrast": { "value": "{color.neutral.900}", "description": "Text on brand-coloured elements" }
+    },
+    "accent": {
+      "default": { "value": "{color.secondary.400}", "description": "Accent colour (teal)" },
+      "hover": { "value": "{color.secondary.500}", "description": "Accent hover state" },
+      "contrast": { "value": "{color.neutral.900}", "description": "Text on accent-coloured elements" }
+    }
   }
 }
-


### PR DESCRIPTION
## Summary
- update base tokens to orange and teal palette
- align dark and light theme semantics

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_689e4d1999b8832289f3bcb4f33f6d13

## Summary by Sourcery

Refresh design tokens by introducing a new orange and teal palette and harmonizing semantic values across dark and light themes

Enhancements:
- Update base color tokens to orange and teal palette
- Align semantic tokens between dark and light themes for consistency