### PR TITLE
Expose health probes and refine backend

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,10 +22,6 @@ gen:
 	cd frontend-pwa && bunx orval --config orval.config.yaml
 
 docker-up:
-	@if [ ! -d "frontend-pwa/dist" ]; then \
-		echo "Error: frontend-pwa/dist not found. Run: cd frontend-pwa && bun run build"; \
-		exit 1; \
-	fi
 	cd deploy && docker compose up --build -d
 
 docker-down:

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -302,7 +302,6 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "actix-web-actors",
- "schemars",
  "serde",
  "serde_json",
  "tracing",
@@ -521,12 +520,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "encoding_rs"
@@ -1242,30 +1235,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
-dependencies = [
- "dyn-clone",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "0.8.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1285,17 +1254,6 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -16,9 +16,6 @@ tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"]
 utoipa = { version = "5", features = ["macros", "uuid", "yaml", "actix_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 
-# JSON Schema (share with AsyncAPI if desired)
-schemars = { version = "0.8", features = ["derive"] }
-
 [dev-dependencies]
 actix-rt = "2"
 

--- a/backend/src/api/users.rs
+++ b/backend/src/api/users.rs
@@ -1,7 +1,7 @@
 //! Users API handlers.
 
 use crate::models::user::User;
-use actix_web::{get, web};
+use actix_web::{get, web, Result};
 
 /// List known users.
 #[utoipa::path(
@@ -16,10 +16,10 @@ use actix_web::{get, web};
     operation_id = "listUsers"
 )]
 #[get("/api/users")]
-pub async fn list_users() -> web::Json<Vec<User>> {
+pub async fn list_users() -> Result<web::Json<Vec<User>>> {
     let data = vec![User {
         id: "u_1".into(),
         display_name: "Ada".into(),
     }];
-    web::Json(data)
+    Ok(web::Json(data))
 }

--- a/backend/src/api/users.rs
+++ b/backend/src/api/users.rs
@@ -1,6 +1,6 @@
 //! Users API handlers.
 
-use crate::models::user::User;
+use crate::models::User;
 use actix_web::{get, web, Result};
 
 /// List known users.

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -1,6 +1,6 @@
 //! OpenAPI documentation setup.
 
-use crate::models::user::User;
+use crate::models::User;
 use utoipa::OpenApi;
 
 /// OpenAPI document for the REST API. Served via Swagger UI and used by tooling.

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -3,7 +3,8 @@
 use crate::models::User;
 use utoipa::OpenApi;
 
-/// OpenAPI document for the REST API. Served via Swagger UI and used by tooling.
+/// OpenAPI document for the REST API.
+/// Swagger UI is enabled in debug builds only and used by tooling.
 #[derive(OpenApi)]
 #[openapi(
     paths(crate::api::users::list_users),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -3,18 +3,23 @@
 use actix_web::{get, App, HttpResponse, HttpServer};
 use tracing::warn;
 use tracing_subscriber::{fmt, EnvFilter};
+#[cfg(debug_assertions)]
 use utoipa::OpenApi;
+#[cfg(debug_assertions)]
 use utoipa_swagger_ui::SwaggerUi;
 
 use backend::api::users::list_users;
+#[cfg(debug_assertions)]
 use backend::doc::ApiDoc;
 use backend::ws;
 
+/// Readiness probe. Return 200 when dependencies are initialised and the server can handle traffic.
 #[get("/health/ready")]
 async fn ready() -> HttpResponse {
     HttpResponse::Ok().finish()
 }
 
+/// Liveness probe. Return 200 when the process is alive.
 #[get("/health/live")]
 async fn live() -> HttpResponse {
     HttpResponse::Ok().finish()

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,7 @@
 //! Backend entry-point: wires REST endpoints, WebSocket entry, and OpenAPI docs.
 
-use actix_web::{App, HttpServer};
+use actix_web::{get, App, HttpResponse, HttpServer};
+use tracing::warn;
 use tracing_subscriber::{fmt, EnvFilter};
 use utoipa::OpenApi;
 use utoipa_swagger_ui::SwaggerUi;
@@ -9,19 +10,39 @@ use backend::api::users::list_users;
 use backend::doc::ApiDoc;
 use backend::ws;
 
+#[get("/health/ready")]
+async fn ready() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+#[get("/health/live")]
+async fn live() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
 /// Application bootstrap.
 #[actix_web::main]
 async fn main() -> std::io::Result<()> {
-    let _ = fmt()
+    if let Err(e) = fmt()
         .with_env_filter(EnvFilter::from_default_env())
         .json()
-        .try_init();
+        .try_init()
+    {
+        warn!(error = %e, "tracing init failed");
+    }
 
     HttpServer::new(|| {
-        App::new()
+        let app = App::new()
             .service(list_users)
             .service(ws::ws_entry)
-            .service(SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi()))
+            .service(ready)
+            .service(live);
+
+        #[cfg(debug_assertions)]
+        let app =
+            app.service(SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi()));
+
+        app
     })
     .bind(("0.0.0.0", 8080))?
     .run()

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -5,7 +5,7 @@
 //! serialisation contracts (serde) in each type's Rustdoc.
 //!
 //! Public surface:
-//! - user::User — domain user identity and display name.
+//! - User (alias to `user::User`) — domain user identity and display name.
 
 pub mod user;
 pub use self::user::User;

--- a/backend/src/models/mod.rs
+++ b/backend/src/models/mod.rs
@@ -1,3 +1,11 @@
 //! Domain data models.
+//!
+//! Purpose: Define strongly typed domain entities used by the API and
+//! persistence layers. Keep types immutable and document invariants and
+//! serialisation contracts (serde) in each type's Rustdoc.
+//!
+//! Public surface:
+//! - user::User — domain user identity and display name.
 
 pub mod user;
+pub use self::user::User;

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -4,11 +4,13 @@ use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
 
 /// Application user.
-#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct User {
     /// Stable user identifier
+    #[schema(example = "u_1")]
     pub id: String,
     /// Display name shown to other users
+    #[schema(example = "Ada")]
     pub display_name: String,
 }

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -15,13 +15,13 @@ services:
       retries: 5
       start_period: 20s
   frontend-build:
-    image: oven/bun:1
+    image: oven/bun:1.1
     working_dir: /frontend
     volumes:
       - ../frontend-pwa:/frontend
     command: ["sh", "-c", "bun install --frozen-lockfile && bun run build"]
     restart: "no"
-    user: "1000:1000"
+    user: "${HOST_UID:-1000}:${HOST_GID:-1000}"
     environment:
       - BUN_INSTALL_CACHE=/frontend/.bun-cache
   web:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -9,16 +9,20 @@ services:
       - RUST_LOG=info
     restart: unless-stopped
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health/ready || exit 1"]
+      test: ["CMD", "curl", "-fsS", "http://localhost:8080/health/ready"]
       interval: 10s
       timeout: 3s
       retries: 5
+      start_period: 20s
   frontend-build:
     image: oven/bun:1
     working_dir: /frontend
     volumes:
       - ../frontend-pwa:/frontend
-    command: ["sh", "-c", "bun install && bun run build"]
+    command: ["sh", "-c", "bun install --frozen-lockfile && bun run build"]
+    restart: "no"
+    environment:
+      - BUN_INSTALL_CACHE=/frontend/.bun-cache
   web:
     image: nginx:1.27-alpine
     volumes:

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -8,6 +8,17 @@ services:
     environment:
       - RUST_LOG=info
     restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8080/health/ready || exit 1"]
+      interval: 10s
+      timeout: 3s
+      retries: 5
+  frontend-build:
+    image: oven/bun:1
+    working_dir: /frontend
+    volumes:
+      - ../frontend-pwa:/frontend
+    command: ["sh", "-c", "bun install && bun run build"]
   web:
     image: nginx:1.27-alpine
     volumes:
@@ -15,5 +26,8 @@ services:
       - ./nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
     ports: ["3000:80"]
     depends_on:
-      - backend
+      backend:
+        condition: service_healthy
+      frontend-build:
+        condition: service_completed_successfully
     restart: unless-stopped

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       - ../frontend-pwa:/frontend
     command: ["sh", "-c", "bun install --frozen-lockfile && bun run build"]
     restart: "no"
+    user: "1000:1000"
     environment:
       - BUN_INSTALL_CACHE=/frontend/.bun-cache
   web:

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -9,9 +9,9 @@ RUN cargo build --release --target x86_64-unknown-linux-musl
 
 FROM alpine:3.18 AS runtime
 RUN apk add --no-cache curl
-WORKDIR /srv
-COPY --from=build /app/backend/target/x86_64-unknown-linux-musl/release/backend /srv/app
 RUN adduser -D -u 1000 app
+WORKDIR /srv
+COPY --from=build --chown=1000:1000 /app/backend/target/x86_64-unknown-linux-musl/release/backend /srv/app
 USER app
 EXPOSE 8080
 ENV RUST_LOG=info

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -7,10 +7,12 @@ RUN cargo fetch --locked
 COPY backend/ ./
 RUN cargo build --release --target x86_64-unknown-linux-musl
 
-FROM gcr.io/distroless/static:nonroot
+FROM alpine:3.18 AS runtime
+RUN apk add --no-cache curl
 WORKDIR /srv
 COPY --from=build /app/backend/target/x86_64-unknown-linux-musl/release/backend /srv/app
-USER nonroot:nonroot
+RUN adduser -D -u 1000 app
+USER app
 EXPOSE 8080
 ENV RUST_LOG=info
 ENTRYPOINT ["/srv/app"]

--- a/deploy/docker/backend.Dockerfile
+++ b/deploy/docker/backend.Dockerfile
@@ -8,8 +8,8 @@ COPY backend/ ./
 RUN cargo build --release --target x86_64-unknown-linux-musl
 
 FROM alpine:3.18 AS runtime
-RUN apk add --no-cache curl
-RUN adduser -D -u 1000 app
+RUN apk add --no-cache curl=8.12.1-r0 ca-certificates=20241121-r1 && \
+    adduser -D -u 1000 app
 WORKDIR /srv
 COPY --from=build --chown=1000:1000 /app/backend/target/x86_64-unknown-linux-musl/release/backend /srv/app
 USER app

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -419,6 +419,24 @@ docker-down:
 - **Feature flags**: sealed behind env/config; surfaced in OpenAPI as headers
   where relevant.
 
+### WebSocket heartbeat sequence
+
+```mermaid
+sequenceDiagram
+    participant Client
+    participant UserSocket
+    participant Server
+    Note over UserSocket: Heartbeat interval triggers
+    UserSocket->UserSocket: Check last_heartbeat
+    alt Heartbeat timeout exceeded
+        UserSocket->Server: Log info (heartbeat timeout)
+        UserSocket->Client: Close connection (CloseCode::Normal, "heartbeat timeout")
+        UserSocket->UserSocket: Stop actor
+    else Heartbeat received
+        UserSocket->UserSocket: Update last_heartbeat
+    end
+```
+
 ---
 
 ## 10) Security & Hardening Notes

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -405,7 +405,26 @@ docker-up:
 	cd deploy && docker compose up --build -d
 
 docker-down:
-	cd deploy && docker compose down
+        cd deploy && docker compose down
+```
+
+### Docker Compose startup sequence
+
+```mermaid
+sequenceDiagram
+  participant DC as Docker Compose
+  participant FB as frontend-build
+  participant BE as backend
+  participant WEB as web
+
+  DC->>FB: Start frontend build (bun install && bun run build)
+  DC->>BE: Start backend
+  BE-->>BE: Serve /health/ready and /health/live
+  loop until healthy
+    DC->>BE: GET /health/ready
+    BE-->>DC: 200 OK when ready
+  end
+  DC->>WEB: Start web after FB completed and BE healthy
 ```
 
 ---


### PR DESCRIPTION
## Summary
- remove unused `schemars` dependency
- return `Result` from users API and gate Swagger UI to debug builds
- add health probe handlers and WebSocket heartbeat close
- document models module and re-export `User`
- add backend healthcheck and frontend build step to compose

## Testing
- `cargo build --manifest-path backend/Cargo.toml`
- `make fmt lint test`


------
https://chatgpt.com/codex/tasks/task_e_689e86c431a88322b2a6cf5d6dc5d293

## Summary by Sourcery

Expose health probe endpoints and integrate them into Docker Compose, refine WebSocket heartbeat handling, gate Swagger UI to debug builds, update users API error handling, remove unused dependencies, and enhance model documentation.

New Features:
- Expose /health/ready and /health/live endpoints for readiness and liveness checks
- Introduce WebSocket heartbeat timeout closure with a normal close code

Enhancements:
- Gate Swagger UI to debug builds only
- Change users API to return Result for error handling
- Log warnings on tracing initialization failures
- Add example attributes to the User schema

Build:
- Remove unused schemars dependency

Deployment:
- Add backend healthcheck and frontend-build services with dependency conditions in Docker Compose

Documentation:
- Document the models module and re-export User