### PR TITLE
Add contrast validation for theme tokens

### DIFF
--- a/packages/tokens/build/validate-contrast.js
+++ b/packages/tokens/build/validate-contrast.js
@@ -1,0 +1,74 @@
+/** @file Validate theme colour contrast.
+ * Ensures brand and accent colours in theme tokens meet WCAG AA contrast
+ * against their paired text colour. This guards against inaccessible colour
+ * combinations slipping into the design system.
+ */
+import fs from 'node:fs';
+
+/** Flatten nested token objects to dot-notated paths. */
+function flattenTokens(obj, path = [], out = {}) {
+  for (const [key, value] of Object.entries(obj)) {
+    const nextPath = [...path, key];
+    if (value && typeof value === 'object' && 'value' in value) {
+      out[nextPath.join('.')] = value.value;
+    } else if (value && typeof value === 'object') {
+      flattenTokens(value, nextPath, out);
+    }
+  }
+  return out;
+}
+
+/** Resolve `{token.path}` references to concrete hex values. */
+function resolve(val, tokens) {
+  const match = /^\{(.+)\}$/.exec(val);
+  return match ? tokens[match[1]] : val;
+}
+
+/** Calculate relative luminance for a hex colour. */
+function luminance(hex) {
+  const [r, g, b] = hex
+    .replace('#', '')
+    .match(/.{2}/g)
+    .map(c => parseInt(c, 16) / 255)
+    .map(c => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+/** Compute WCAG contrast ratio between two hex colours. */
+function contrast(a, b) {
+  const l1 = luminance(a);
+  const l2 = luminance(b);
+  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+function checkTheme(file, tokens) {
+  const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const brand = json.semantic?.brand;
+  const accent = json.semantic?.accent;
+  if (!brand || !accent) throw new Error(`Missing brand/accent in ${file}`);
+  const pairs = [
+    ['brand default', brand.default?.value, brand.contrast?.value],
+    ['brand hover', brand.hover?.value, brand.contrast?.value],
+    ['accent default', accent.default?.value, accent.contrast?.value],
+    ['accent hover', accent.hover?.value, accent.contrast?.value]
+  ];
+  for (const [label, fg, bg] of pairs) {
+    const fgHex = resolve(fg, tokens);
+    const bgHex = resolve(bg, tokens);
+    const ratio = contrast(fgHex, bgHex);
+    if (ratio < 4.5) {
+      throw new Error(`${label} in ${file} fails contrast: ${ratio.toFixed(2)}`);
+    }
+  }
+}
+
+const tokens = flattenTokens(
+  JSON.parse(fs.readFileSync(new URL('../src/tokens.json', import.meta.url)))
+);
+
+for (const theme of ['dark', 'light']) {
+  checkTheme(new URL(`../src/themes/${theme}.json`, import.meta.url), tokens);
+}
+
+console.log('Contrast checks passed for themes.');

--- a/packages/tokens/build/validate-contrast.js
+++ b/packages/tokens/build/validate-contrast.js
@@ -1,3 +1,4 @@
+#!/usr/bin/env node
 /** @file Validate theme colour contrast.
  * Ensures brand and accent colours in theme tokens meet WCAG AA contrast
  * against their paired text colour. This guards against inaccessible colour
@@ -10,21 +11,31 @@ const tokensJson = JSON.parse(
   fs.readFileSync(new URL('../src/tokens.json', import.meta.url), 'utf8')
 );
 
-/** Resolve `{token.path}` references to concrete hex values. */
+/** Resolve `{token.path}` references to concrete hex values, following chains and detecting cycles. */
 function getTokenValue(val) {
-  const match = /^\{(.+)\}$/.exec(val);
-  if (!match) return val;
-  return match[1]
-    .split('.')
-    .reduce((obj, key) => {
-      if (obj?.[key] == null) throw new Error(`Token "${match[1]}" not found`);
-      return obj[key];
-    }, tokensJson).value;
+  let current = val;
+  const seen = new Set();
+  while (typeof current === 'string') {
+    const m = /^\{(.+)\}$/.exec(current.trim());
+    if (!m) return current;
+    const key = m[1];
+    if (seen.has(key)) throw new Error(`Circular token reference detected: "${key}"`);
+    seen.add(key);
+    const node = key
+      .split('.')
+      .reduce((obj, k) => {
+        if (obj?.[k] == null) throw new Error(`Token "${key}" not found`);
+        return obj[k];
+      }, tokensJson);
+    current = node?.value;
+  }
+  return current;
 }
 
 /** Calculate relative luminance for a hex colour. */
 function luminance(hex) {
-  let hexStr = hex.replace('#', '');
+  if (typeof hex !== 'string') return NaN;
+  let hexStr = hex.trim().replace('#', '');
   if (hexStr.length === 3) {
     hexStr = hexStr.split('').map(c => c + c).join('');
   }
@@ -39,6 +50,9 @@ function luminance(hex) {
 function contrast(a, b) {
   const l1 = luminance(a);
   const l2 = luminance(b);
+  if (!Number.isFinite(l1) || !Number.isFinite(l2)) {
+    throw new Error(`Invalid colour(s) for contrast: "${a}" vs "${b}"`);
+  }
   const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
   return (lighter + 0.05) / (darker + 0.05);
 }
@@ -62,29 +76,33 @@ function checkTheme(file, options = {}) {
       ? options.contrastThreshold
       : 4.5;
   for (const [label, fg, bg] of pairs) {
+    const fileHint = file instanceof URL ? file.pathname : file;
+    if (fg == null || bg == null) {
+      throw new Error(`${label} in ${fileHint} is missing a value or contrast token`);
+    }
     const fgHex = getTokenValue(fg);
     const bgHex = getTokenValue(bg);
     const ratio = contrast(fgHex, bgHex);
     if (ratio < contrastThreshold) {
       throw new Error(
-        `${label} in ${file} fails contrast: ${ratio.toFixed(2)} (threshold: ${contrastThreshold})`
+        `${label} in ${fileHint} fails contrast: ${ratio.toFixed(2)} (threshold: ${contrastThreshold})`
       );
     }
   }
   return true;
 }
-
-const themes = ['dark', 'light'];
+const themesDir = new URL('../src/themes/', import.meta.url);
+const themeFiles = fs
+  .readdirSync(themesDir)
+  .filter(f => f.endsWith('.json'))
+  .map(f => new URL(f, themesDir));
 const thresholdArg = parseFloat(process.argv[2]);
 const options = Number.isNaN(thresholdArg) ? {} : { contrastThreshold: thresholdArg };
 let hadError = false;
 
-for (const theme of themes) {
+for (const file of themeFiles) {
   try {
-    const ok = checkTheme(
-      new URL(`../src/themes/${theme}.json`, import.meta.url),
-      options
-    );
+    const ok = checkTheme(file, options);
     if (ok === false) hadError = true;
   } catch (err) {
     console.error(err instanceof Error ? err.message : err);
@@ -96,5 +114,7 @@ if (hadError) {
   process.exit(1);
 }
 
-console.log('Contrast checks passed for themes.');
+console.log(
+  `Contrast checks passed for themes (threshold: ${options.contrastThreshold ?? 4.5}).`
+);
 process.exit(0);

--- a/packages/tokens/build/validate-contrast.js
+++ b/packages/tokens/build/validate-contrast.js
@@ -5,31 +5,32 @@
  */
 import fs from 'node:fs';
 
-/** Flatten nested token objects to dot-notated paths. */
-function flattenTokens(obj, path = [], out = {}) {
-  for (const [key, value] of Object.entries(obj)) {
-    const nextPath = [...path, key];
-    if (value && typeof value === 'object' && 'value' in value) {
-      out[nextPath.join('.')] = value.value;
-    } else if (value && typeof value === 'object') {
-      flattenTokens(value, nextPath, out);
-    }
-  }
-  return out;
-}
+// Load the complete token tree once for reference resolution.
+const tokensJson = JSON.parse(
+  fs.readFileSync(new URL('../src/tokens.json', import.meta.url), 'utf8')
+);
 
 /** Resolve `{token.path}` references to concrete hex values. */
-function resolve(val, tokens) {
+function getTokenValue(val) {
   const match = /^\{(.+)\}$/.exec(val);
-  return match ? tokens[match[1]] : val;
+  if (!match) return val;
+  return match[1]
+    .split('.')
+    .reduce((obj, key) => {
+      if (obj?.[key] == null) throw new Error(`Token "${match[1]}" not found`);
+      return obj[key];
+    }, tokensJson).value;
 }
 
 /** Calculate relative luminance for a hex colour. */
 function luminance(hex) {
-  const [r, g, b] = hex
-    .replace('#', '')
-    .match(/.{2}/g)
-    .map(c => parseInt(c, 16) / 255)
+  let hexStr = hex.replace('#', '');
+  if (hexStr.length === 3) {
+    hexStr = hexStr.split('').map(c => c + c).join('');
+  }
+  if (!/^[0-9a-fA-F]{6}$/.test(hexStr)) return NaN;
+  const [r, g, b] = [0, 2, 4]
+    .map(i => parseInt(hexStr.slice(i, i + 2), 16) / 255)
     .map(c => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
   return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 }
@@ -42,33 +43,58 @@ function contrast(a, b) {
   return (lighter + 0.05) / (darker + 0.05);
 }
 
-function checkTheme(file, tokens) {
+function checkTheme(file, options = {}) {
   const json = JSON.parse(fs.readFileSync(file, 'utf8'));
   const brand = json.semantic?.brand;
   const accent = json.semantic?.accent;
-  if (!brand || !accent) throw new Error(`Missing brand/accent in ${file}`);
+  if (!brand || !accent) {
+    console.error(`Missing brand/accent in ${file}`);
+    return false;
+  }
   const pairs = [
     ['brand default', brand.default?.value, brand.contrast?.value],
     ['brand hover', brand.hover?.value, brand.contrast?.value],
     ['accent default', accent.default?.value, accent.contrast?.value],
     ['accent hover', accent.hover?.value, accent.contrast?.value]
   ];
+  const contrastThreshold =
+    typeof options.contrastThreshold === 'number'
+      ? options.contrastThreshold
+      : 4.5;
   for (const [label, fg, bg] of pairs) {
-    const fgHex = resolve(fg, tokens);
-    const bgHex = resolve(bg, tokens);
+    const fgHex = getTokenValue(fg);
+    const bgHex = getTokenValue(bg);
     const ratio = contrast(fgHex, bgHex);
-    if (ratio < 4.5) {
-      throw new Error(`${label} in ${file} fails contrast: ${ratio.toFixed(2)}`);
+    if (ratio < contrastThreshold) {
+      throw new Error(
+        `${label} in ${file} fails contrast: ${ratio.toFixed(2)} (threshold: ${contrastThreshold})`
+      );
     }
+  }
+  return true;
+}
+
+const themes = ['dark', 'light'];
+const thresholdArg = parseFloat(process.argv[2]);
+const options = Number.isNaN(thresholdArg) ? {} : { contrastThreshold: thresholdArg };
+let hadError = false;
+
+for (const theme of themes) {
+  try {
+    const ok = checkTheme(
+      new URL(`../src/themes/${theme}.json`, import.meta.url),
+      options
+    );
+    if (ok === false) hadError = true;
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : err);
+    hadError = true;
   }
 }
 
-const tokens = flattenTokens(
-  JSON.parse(fs.readFileSync(new URL('../src/tokens.json', import.meta.url)))
-);
-
-for (const theme of ['dark', 'light']) {
-  checkTheme(new URL(`../src/themes/${theme}.json`, import.meta.url), tokens);
+if (hadError) {
+  process.exit(1);
 }
 
 console.log('Contrast checks passed for themes.');
+process.exit(0);

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "build": "node build/style-dictionary.js",
     "postinstall": "node build/style-dictionary.js",
-    "test": "node build/validate-contrast.js"
+    "validate:contrast": "node build/validate-contrast.js",
+    "test": "npm run validate:contrast"
   },
   "devDependencies": {
     "style-dictionary": "^4"

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -5,8 +5,13 @@
   "type": "module",
   "scripts": {
     "build": "node build/style-dictionary.js",
-    "postinstall": "node build/style-dictionary.js"
+    "postinstall": "node build/style-dictionary.js",
+    "test": "node build/validate-contrast.js"
   },
-  "devDependencies": { "style-dictionary": "^4" },
-  "engines": { "node": ">=18.17" }
+  "devDependencies": {
+    "style-dictionary": "^4"
+  },
+  "engines": {
+    "node": ">=18.17"
+  }
 }


### PR DESCRIPTION
## Summary
- add npm script to verify theme token contrast
- add Node validator ensuring brand and accent colours meet WCAG AA

## Testing
- `node packages/tokens/build/validate-contrast.js`
- `make check-fmt`
- `make lint`
- `make test`
- `npx prettier packages/tokens/build/validate-contrast.js packages/tokens/package.json --write` *(fails: Cannot find package 'prettier-plugin-sort-json')*

------
https://chatgpt.com/codex/tasks/task_e_689f90b3eb6c832288d1352b7f34579f

## Summary by Sourcery

Add automated WCAG AA contrast checks for theme tokens by including a Node-based validator and wiring it into an npm test script

New Features:
- Add a Node script to validate WCAG AA contrast ratios for brand and accent theme tokens
- Introduce an npm "test" script to run the contrast validator

Enhancements:
- Guard against inaccessible colour combinations slipping into the design system