### PR TITLE
Refactor token contrast validation

### DIFF
--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -182,6 +182,10 @@ Tailwind/daisyUI and any future native shells.
   - `dist/tw/preset.cjs` (Tailwind preset mapping spacing/radius/colours),
   - `dist/daisy/theme.cjs` (daisyUI theme object from semantic tokens),
   - optional JS/TS token bundle for RN/NativeWind down the road.
+- `packages/tokens/build/validate-contrast.js`: checks theme colours meet
+  the `contrastThreshold` (override via `CONTRAST_THRESHOLD` env or
+  `packages/tokens/package.json`). Uses the `color` library for WCAG
+  contrast.
 
 **Frontend consumption:**
 

--- a/packages/tokens/build/validate-contrast.js
+++ b/packages/tokens/build/validate-contrast.js
@@ -5,116 +5,97 @@
  * combinations slipping into the design system.
  */
 import fs from 'node:fs';
+import { contrast } from '../src/utils/color.js';
+import { resolveToken } from '../src/utils/tokens.js';
 
-// Load the complete token tree once for reference resolution.
-const tokensJson = JSON.parse(
-  fs.readFileSync(new URL('../src/tokens.json', import.meta.url), 'utf8')
+// Load package settings for defaults.
+const pkgJson = JSON.parse(
+  fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')
 );
 
-/** Resolve `{token.path}` references to concrete hex values, following chains and detecting cycles. */
-function getTokenValue(val) {
-  let current = val;
-  const seen = new Set();
-  while (typeof current === 'string') {
-    const m = /^\{(.+)\}$/.exec(current.trim());
-    if (!m) return current;
-    const key = m[1];
-    if (seen.has(key)) throw new Error(`Circular token reference detected: "${key}"`);
-    seen.add(key);
-    const node = key
-      .split('.')
-      .reduce((obj, k) => {
-        if (obj?.[k] == null) throw new Error(`Token "${key}" not found`);
-        return obj[k];
-      }, tokensJson);
-    current = node?.value;
+/** Resolve the contrast threshold from CLI, env, or package.json. */
+function getThreshold() {
+  const sources = [
+    process.argv[2],
+    process.env.CONTRAST_THRESHOLD,
+    pkgJson.contrastThreshold
+  ];
+  for (const src of sources) {
+    const value = parseFloat(src);
+    if (!Number.isNaN(value)) {
+      if (value <= 1 || value >= 21) {
+        console.error(
+          `Error: contrastThreshold value (${value}) is out of range. It must be > 1 and < 21.`
+        );
+        process.exit(1);
+      }
+      return value;
+    }
   }
-  return current;
+  return 4.5;
 }
 
-/** Calculate relative luminance for a hex colour. */
-function luminance(hex) {
-  if (typeof hex !== 'string') return NaN;
-  let hexStr = hex.trim().replace('#', '');
-  if (hexStr.length === 3) {
-    hexStr = hexStr.split('').map(c => c + c).join('');
-  }
-  if (!/^[0-9a-fA-F]{6}$/.test(hexStr)) return NaN;
-  const [r, g, b] = [0, 2, 4]
-    .map(i => parseInt(hexStr.slice(i, i + 2), 16) / 255)
-    .map(c => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
-  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
-}
+const contrastThreshold = getThreshold();
 
-/** Compute WCAG contrast ratio between two hex colours. */
-function contrast(a, b) {
-  const l1 = luminance(a);
-  const l2 = luminance(b);
-  if (!Number.isFinite(l1) || !Number.isFinite(l2)) {
-    throw new Error(`Invalid colour(s) for contrast: "${a}" vs "${b}"`);
-  }
-  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
-  return (lighter + 0.05) / (darker + 0.05);
-}
-
-function checkTheme(file, options = {}) {
+/**
+ * Validate contrast ratios for brand and accent pairs within a theme file.
+ * Returns an array of error messages rather than throwing to allow full
+ * aggregation of failures.
+ */
+function checkTheme(file, threshold) {
   const json = JSON.parse(fs.readFileSync(file, 'utf8'));
   const brand = json.semantic?.brand;
   const accent = json.semantic?.accent;
+  const errors = [];
+
   if (!brand || !accent) {
-    console.error(`Missing brand/accent in ${file}`);
-    return false;
+    errors.push(`Missing brand/accent in ${file instanceof URL ? file.pathname : file}`);
+    return errors;
   }
+
   const pairs = [
     ['brand default', brand.default?.value, brand.contrast?.value],
     ['brand hover', brand.hover?.value, brand.contrast?.value],
     ['accent default', accent.default?.value, accent.contrast?.value],
     ['accent hover', accent.hover?.value, accent.contrast?.value]
   ];
-  const contrastThreshold =
-    typeof options.contrastThreshold === 'number'
-      ? options.contrastThreshold
-      : 4.5;
-  for (const [label, fg, bg] of pairs) {
+
+  for (const [label, fgRef, bgRef] of pairs) {
     const fileHint = file instanceof URL ? file.pathname : file;
-    if (fg == null || bg == null) {
-      throw new Error(`${label} in ${fileHint} is missing a value or contrast token`);
+    if (fgRef == null || bgRef == null) {
+      errors.push(`${label} in ${fileHint} is missing a value or contrast token`);
+      continue;
     }
-    const fgHex = getTokenValue(fg);
-    const bgHex = getTokenValue(bg);
-    const ratio = contrast(fgHex, bgHex);
-    if (ratio < contrastThreshold) {
-      throw new Error(
-        `${label} in ${fileHint} fails contrast: ${ratio.toFixed(2)} (threshold: ${contrastThreshold})`
-      );
+    try {
+      const ratio = contrast(resolveToken(fgRef), resolveToken(bgRef));
+      if (ratio < threshold) {
+        errors.push(
+          `${label} in ${fileHint} fails contrast: ${ratio.toFixed(2)} (threshold: ${threshold})`
+        );
+      }
+    } catch (err) {
+      errors.push(err instanceof Error ? err.message : String(err));
     }
   }
-  return true;
+
+  return errors;
 }
+
 const themesDir = new URL('../src/themes/', import.meta.url);
 const themeFiles = fs
   .readdirSync(themesDir)
   .filter(f => f.endsWith('.json'))
   .map(f => new URL(f, themesDir));
-const thresholdArg = parseFloat(process.argv[2]);
-const options = Number.isNaN(thresholdArg) ? {} : { contrastThreshold: thresholdArg };
-let hadError = false;
 
+let allErrors = [];
 for (const file of themeFiles) {
-  try {
-    const ok = checkTheme(file, options);
-    if (ok === false) hadError = true;
-  } catch (err) {
-    console.error(err instanceof Error ? err.message : err);
-    hadError = true;
-  }
+  allErrors = allErrors.concat(checkTheme(file, contrastThreshold));
 }
 
-if (hadError) {
+if (allErrors.length) {
+  allErrors.forEach(e => console.error(e));
   process.exit(1);
 }
 
-console.log(
-  `Contrast checks passed for themes (threshold: ${options.contrastThreshold ?? 4.5}).`
-);
+console.log(`Contrast checks passed for themes (threshold: ${contrastThreshold}).`);
 process.exit(0);

--- a/packages/tokens/build/validate-contrast.js
+++ b/packages/tokens/build/validate-contrast.js
@@ -74,7 +74,15 @@ function checkTheme(file, threshold) {
         );
       }
     } catch (err) {
-      errors.push(err instanceof Error ? err.message : String(err));
+      console.error(
+        `Failed to resolve token reference for "${label}" in ${fileHint}.`,
+        { fgRef, bgRef, error: err }
+      );
+      errors.push(
+        `${label} in ${fileHint} failed to resolve token reference: ${
+          err instanceof Error ? err.message : String(err)
+        }`
+      );
     }
   }
 

--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -10,8 +10,10 @@
     "test": "npm run validate:contrast"
   },
   "devDependencies": {
+    "color": "^4.2.3",
     "style-dictionary": "^4"
   },
+  "contrastThreshold": 4.5,
   "engines": {
     "node": ">=18.17"
   }

--- a/packages/tokens/src/utils/color.js
+++ b/packages/tokens/src/utils/color.js
@@ -13,7 +13,17 @@ import Color from 'color';
  * contrast('#000', '#fff'); // => 21
  */
 export function contrast(foreground, background) {
-  const fg = Color(foreground);
-  const bg = Color(background);
+  let fg;
+  let bg;
+  try {
+    fg = Color(foreground);
+  } catch {
+    throw new Error(`Invalid colour: ${foreground}`);
+  }
+  try {
+    bg = Color(background);
+  } catch {
+    throw new Error(`Invalid colour: ${background}`);
+  }
   return fg.contrast(bg);
 }

--- a/packages/tokens/src/utils/color.js
+++ b/packages/tokens/src/utils/color.js
@@ -1,0 +1,19 @@
+/** @file Colour utilities built on the `color` library.
+ * Provides helpers for calculating WCAG contrast ratios.
+ */
+import Color from 'color';
+
+/**
+ * Compute the WCAG contrast ratio between two colours.
+ *
+ * @param {string} foreground - Foreground colour in hex format.
+ * @param {string} background - Background colour in hex format.
+ * @returns {number} Contrast ratio.
+ * @example
+ * contrast('#000', '#fff'); // => 21
+ */
+export function contrast(foreground, background) {
+  const fg = Color(foreground);
+  const bg = Color(background);
+  return fg.contrast(bg);
+}

--- a/packages/tokens/src/utils/tokens.js
+++ b/packages/tokens/src/utils/tokens.js
@@ -26,13 +26,17 @@ export function resolveToken(ref) {
       throw new Error(`Circular token reference detected: "${key}"`);
     }
     seen.add(key);
-    const node = key.split('.').reduce((obj, k) => {
+    const pathSegments = key.split('.');
+    let obj = TOKENS;
+    for (let i = 0; i < pathSegments.length; i++) {
+      const k = pathSegments[i];
       if (obj?.[k] == null) {
-        throw new Error(`Token "${key}" not found`);
+        const missingPath = pathSegments.slice(0, i + 1).join('.');
+        throw new Error(`Token path "${missingPath}" not found (while resolving "${key}")`);
       }
-      return obj[k];
-    }, TOKENS);
-    current = node?.value;
+      obj = obj[k];
+    }
+    current = obj?.value;
   }
   return current;
 }

--- a/packages/tokens/src/utils/tokens.js
+++ b/packages/tokens/src/utils/tokens.js
@@ -1,0 +1,38 @@
+/** @file Token utilities for resolving design token references. */
+import fs from 'node:fs';
+
+// Load token tree once for reference resolution.
+const TOKENS = JSON.parse(
+  fs.readFileSync(new URL('../tokens.json', import.meta.url), 'utf8')
+);
+
+/**
+ * Resolve a `{token.path}` reference to its concrete value.
+ * Follows chained references and detects cycles.
+ *
+ * @param {string} ref - Token reference in `{path.to.token}` form.
+ * @returns {string} Token value.
+ * @example
+ * resolveToken('{color.brand}')
+ */
+export function resolveToken(ref) {
+  let current = ref;
+  const seen = new Set();
+  while (typeof current === 'string') {
+    const match = /^\{(.+)\}$/.exec(current.trim());
+    if (!match) return current;
+    const key = match[1];
+    if (seen.has(key)) {
+      throw new Error(`Circular token reference detected: "${key}"`);
+    }
+    seen.add(key);
+    const node = key.split('.').reduce((obj, k) => {
+      if (obj?.[k] == null) {
+        throw new Error(`Token "${key}" not found`);
+      }
+      return obj[k];
+    }, TOKENS);
+    current = node?.value;
+  }
+  return current;
+}


### PR DESCRIPTION
## Summary
- replace bespoke luminance math with `color` library helper
- validate all theme token pairs and aggregate contrast errors
- make contrast threshold configurable via env or package.json

## Testing
- `npm --prefix packages/tokens test`
- `make fmt`
- `make lint`
- `make test`
- `make check-fmt`


------
https://chatgpt.com/codex/tasks/task_e_68a1e4658a288322850205a63451e724

## Summary by Sourcery

Refactor the theme contrast validation script to use shared utilities and the `color` library, support a configurable contrast threshold, and improve error aggregation across all theme files

New Features:
- Allow contrast threshold to be overridden via CLI argument, CONTRAST_THRESHOLD environment variable, or package.json setting

Enhancements:
- Replace custom luminance and ratio logic with the `color` library for WCAG contrast calculations
- Aggregate and report all contrast validation errors across theme files rather than failing on the first error
- Extract token reference resolution into a dedicated utility to follow and detect chained references

Build:
- Add `color` library as a dev dependency

Documentation:
- Document the `validate-contrast.js` script and its configurable threshold in repository-structure.md