### PR TITLE
Document React a11y and i18n standards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -418,15 +418,14 @@ Keep docs close to code.
 - **State**: Encapsulate server state with TanStack Query and model complex
   local state with reducers or state machines inside custom hooks.
 
-### Internationalisation
+### Internationalization
 
-- **Setup**: Initialise `react-i18next` with `i18next-http-backend` and
+- **Setup**: Initialize `react-i18next` with `i18next-http-backend` and
   `i18next-browser-languagedetector`; set `fallbackLng: 'en'`.
 - **Translations**: Store locale files under `public/locales/<lang>/<ns>.json`
   and load strings by namespace.
 - **Hooks**: Call `useTranslation` within logic hooks and pass all translated
   strings to view components via props.
-
 ### Testing (Vitest & Playwright)
 
 - **Vitest config**: Use the `jsdom` environment, include `tests/setup.ts`, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -398,6 +398,12 @@ Keep docs close to code.
 - **A11y**: Use semantic HTML first. Prefer daisyUI components only where they
   don’t harm semantics. Audit focus states and colour contrast with automated
   checks.
+- **Radix UI**: Build behaviour with Radix primitives and layer DaisyUI/Tailwind
+  classes for presentation.
+- **Purity**: Export view components as pure functions with props treated as
+  read‑only. Move state, effects, and translations into dedicated `use*` hooks.
+- **Component tests**: Use React Testing Library under Vitest for rendering and
+  user‑centric assertions.
 
 ### TanStack Usage Notes
 
@@ -409,6 +415,29 @@ Keep docs close to code.
   loaders.
 - **Table** (if used): Keep row models pure; virtualise for large sets; memoise
   column defs.
+- **State**: Encapsulate server state with TanStack Query and model complex
+  local state with reducers or state machines inside custom hooks.
+
+### Internationalisation
+
+- **Setup**: Initialise `react-i18next` with `i18next-http-backend` and
+  `i18next-browser-languagedetector`; set `fallbackLng: 'en'`.
+- **Translations**: Store locale files under `public/locales/<lang>/<ns>.json`
+  and load strings by namespace.
+- **Hooks**: Call `useTranslation` within logic hooks and pass all translated
+  strings to view components via props.
+
+### Testing (Vitest & Playwright)
+
+- **Vitest config**: Use the `jsdom` environment, include `tests/setup.ts`, and
+  prioritise `**/*.a11y.test.ts` before other test files.
+- **axe integration**: Import `vitest-axe/extend-expect` in `tests/setup.ts` and
+  list this file in `tsconfig.json` so the matcher types load.
+- **Rule gaps**: Disable `color-contrast` and `scrollable-region-focusable`
+  rules in Vitest; verify them in Playwright.
+- **Playwright**: Run `@axe-core/playwright` scans, exercise keyboard
+  navigation, capture accessibility tree snapshots, and emulate locales to test
+  translations.
 
 ### Observability (Frontend)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -430,15 +430,15 @@ Keep docs close to code.
 ### Testing (Vitest & Playwright)
 
 - **Vitest config**: Use the `jsdom` environment, include `tests/setup.ts`, and
-  prioritise `**/*.a11y.test.ts` before other test files.
+  prioritize running `**/*.a11y.test.ts` in a dedicated Vitest invocation
+  before the rest of the suite.
 - **axe integration**: Import `vitest-axe/extend-expect` in `tests/setup.ts` and
   list this file in `tsconfig.json` so the matcher types load.
 - **Rule gaps**: Disable `color-contrast` and `scrollable-region-focusable`
-  rules in Vitest; verify them in Playwright.
+  rules in Vitest (jsdom limits these checks); verify them in Playwright.
 - **Playwright**: Run `@axe-core/playwright` scans, exercise keyboard
   navigation, capture accessibility tree snapshots, and emulate locales to test
   translations.
-
 ### Observability (Frontend)
 
 - **Structured logs**: Gate debug logs behind a flag (`?debug=1` or build‑time


### PR DESCRIPTION
## Summary
- capture Radix-first, pure component approach in AGENTS
- document react-i18next setup and translation flow
- outline Vitest and Playwright accessibility testing conventions

## Testing
- `make check-fmt`
- `RUSTC_WRAPPER= SCCACHE_NO_DAEMON=1 make lint`
- `RUSTC_WRAPPER= SCCACHE_NO_DAEMON=1 make test`


------
https://chatgpt.com/codex/tasks/task_e_68a3bf3acbe4832297475a6d6cc7f5c1

## Summary by Sourcery

Document React accessibility guidelines, internationalization setup, and testing conventions in the AGENTS.md guide.

Documentation:
- Add Radix-first UI composition, component purity, and state management conventions
- Detail react-i18next initialization, translation file structure, and hook usage
- Outline Vitest and Playwright accessibility testing configuration and practices