### PR TITLE
docs: fix markdownlint errors

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -7,7 +7,8 @@
       "code_block_line_length": 120,
       "tables": false,
       "headings": false
-    }
+    },
+    "MD029": { "style": "ordered" }
   },
   "ignores": [
     "**/.venv/**",

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -5,7 +5,8 @@
     "MD013": {
       "line_length": 80,
       "code_block_line_length": 120,
-      "tables": false
+      "tables": false,
+      "headings": false
     }
   },
   "ignores": [

--- a/docs/high-velocity-accessibility-first-component-testing.md
+++ b/docs/high-velocity-accessibility-first-component-testing.md
@@ -12,7 +12,7 @@ capabilities and limitations of the proposed two-tiered testing model. This
 revised framework leverages Vitest for immediate, component-level feedback and
 Playwright for comprehensive, end-to-end validation, ensuring that the core
 philosophy is upheld through a pragmatic and technically sound approach.
-
+<!-- markdownlint-disable-next-line MD013 -->
 ### 1.1 Deconstructing the Tooling Deadlock: Why the Bun and ,`happy-dom`, Approach is Untenable
 
 An effective testing strategy must be built upon a compatible and stable set of
@@ -110,7 +110,7 @@ the team can immediately implement its accessibility strategy without being
 blocked by the ecosystem immaturity of a newer tool. This pivot ensures that
 the team's accessibility-first ambitions are realized in practice, not just in
 theory.
-
+<!-- markdownlint-disable-next-line MD013 -->
 ### 1.3 Setting Realistic Expectations: Understanding ,`axe-core`, Limitations in ,`jsdom`
 
 While pivoting to Vitest with a `jsdom` environment solves the primary tooling
@@ -986,19 +986,22 @@ capabilities first and incrementally roll out the complete framework.
 - Create and configure the `vitest.config.ts` file to use the `jsdom`
   environment and specify the test setup file.
 - Update the `tsconfig.json` to include the new configuration and setup files.
-2. **Phase 2: Core Tooling (1 Day)**
+
+1. **Phase 2: Core Tooling (1 Day)**
 
 - Create the `./tests/setup.ts` file and add the import for
   `vitest-axe/extend-expect` to globally register the custom matcher.
 - (Optional but Recommended) Implement the custom `toHaveNoAxeViolations`
   matcher logic for enhanced error reporting, as detailed in Section 2.3.
-3. **Phase 3: Initial Rollout (2-3 Days)**
+
+1. **Phase 3: Initial Rollout (2-3 Days)**
 
 - Select a single, well-defined component (e.g., a Button or an Input).
 - Create a `*.a11y.test.ts` file for this component.
 - Write the first accessibility tests using the established pattern to validate
   the entire setup from configuration to assertion.
-4. **Phase 4: E2E Integration (3-5 Days)**
+
+1. **Phase 4: E2E Integration (3-5 Days)**
 
 - Install `@axe-core/playwright`.
 - Identify a critical user flow (e.g., login, add to cart).
@@ -1008,7 +1011,8 @@ capabilities first and incrementally roll out the complete framework.
   navigation menu or a complex form.
 - Implement a Playwright accessibility tree snapshot test for a complex, shared
   component.
-5. **Phase 5: CI/CD Integration (2-3 Days)**
+
+1. **Phase 5: CI/CD Integration (2-3 Days)**
 
 - Implement the sharded GitHub Actions workflow as detailed in Section 4.1.
 - Configure the workflow to upload the final HTML reports from both Vitest and
@@ -1105,7 +1109,7 @@ quality to be built in from the very first line of code.
     [https://vitest.dev/api/expect](https://vitest.dev/api/expect)
 28. Custom Test Matchers - tutorials - Nut.js, accessed on 17 August 2025,
     [https://nutjs.dev/tutorials/custom-test-matchers](https://nutjs.dev/tutorials/custom-test-matchers)
-29. 10. Custom Assertions - Full Stack Testing, accessed on 17 August 2025,
+29. Custom Assertions - Full Stack Testing, accessed on 17 August 2025,
     [https://testing.epicweb.dev/10](https://testing.epicweb.dev/10)
 30. Using the Accessibility Results with Java - Deque Docs, accessed on 17
     August 2025,

--- a/docs/high-velocity-accessibility-first-component-testing.md
+++ b/docs/high-velocity-accessibility-first-component-testing.md
@@ -981,43 +981,43 @@ capabilities first and incrementally roll out the complete framework.
 
 1. **Phase 1: Environment Setup (1-2 Days)**
 
-- Install all required dependencies: `vitest`, `jsdom`, `vitest-axe`,
-  `@testing-library/react`.
-- Create and configure the `vitest.config.ts` file to use the `jsdom`
-  environment and specify the test setup file.
-- Update the `tsconfig.json` to include the new configuration and setup files.
+    - Install all required dependencies: `vitest`, `jsdom`, `vitest-axe`,
+      `@testing-library/react`.
+    - Create and configure the `vitest.config.ts` file to use the `jsdom`
+      environment and specify the test setup file.
+    - Update the `tsconfig.json` to include the new configuration and setup files.
 
-1. **Phase 2: Core Tooling (1 Day)**
+2. **Phase 2: Core Tooling (1 Day)**
 
-- Create the `./tests/setup.ts` file and add the import for
-  `vitest-axe/extend-expect` to globally register the custom matcher.
-- (Optional but Recommended) Implement the custom `toHaveNoAxeViolations`
-  matcher logic for enhanced error reporting, as detailed in Section 2.3.
+    - Create the `./tests/setup.ts` file and add the import for
+      `vitest-axe/extend-expect` to globally register the custom matcher.
+    - (Optional but Recommended) Implement the custom `toHaveNoAxeViolations`
+      matcher logic for enhanced error reporting, as detailed in Section 2.3.
 
-1. **Phase 3: Initial Rollout (2-3 Days)**
+3. **Phase 3: Initial Rollout (2-3 Days)**
 
-- Select a single, well-defined component (e.g., a Button or an Input).
-- Create a `*.a11y.test.ts` file for this component.
-- Write the first accessibility tests using the established pattern to validate
-  the entire setup from configuration to assertion.
+    - Select a single, well-defined component (e.g., a Button or an Input).
+    - Create a `*.a11y.test.ts` file for this component.
+    - Write the first accessibility tests using the established pattern to validate
+      the entire setup from configuration to assertion.
 
-1. **Phase 4: E2E Integration (3-5 Days)**
+4. **Phase 4: E2E Integration (3-5 Days)**
 
-- Install `@axe-core/playwright`.
-- Identify a critical user flow (e.g., login, add to cart).
-- Implement an initial Playwright test that performs a strategic `axe` scan at
-  a key stable state within that flow.
-- Implement a dedicated Playwright test for keyboard navigation on a primary
-  navigation menu or a complex form.
-- Implement a Playwright accessibility tree snapshot test for a complex, shared
-  component.
+    - Install `@axe-core/playwright`.
+    - Identify a critical user flow (e.g., login, add to cart).
+    - Implement an initial Playwright test that performs a strategic `axe` scan at
+      a key stable state within that flow.
+    - Implement a dedicated Playwright test for keyboard navigation on a primary
+      navigation menu or a complex form.
+    - Implement a Playwright accessibility tree snapshot test for a complex, shared
+      component.
 
-1. **Phase 5: CI/CD Integration (2-3 Days)**
+5. **Phase 5: CI/CD Integration (2-3 Days)**
 
-- Implement the sharded GitHub Actions workflow as detailed in Section 4.1.
-- Configure the workflow to upload the final HTML reports from both Vitest and
-  Playwright as artifacts.
-- Establish branch protection rules to require the E2E tests to pass before
+    - Implement the sharded GitHub Actions workflow as detailed in Section 4.1.
+    - Configure the workflow to upload the final HTML reports from both Vitest and
+      Playwright as artifacts.
+    - Establish branch protection rules to require the E2E tests to pass before
   merging.
 
 ### 5.3 Concluding Philosophy: Building an Inclusive Default

--- a/docs/high-velocity-accessibility-first-component-testing.md
+++ b/docs/high-velocity-accessibility-first-component-testing.md
@@ -12,7 +12,7 @@ capabilities and limitations of the proposed two-tiered testing model. This
 revised framework leverages Vitest for immediate, component-level feedback and
 Playwright for comprehensive, end-to-end validation, ensuring that the core
 philosophy is upheld through a pragmatic and technically sound approach.
-<!-- markdownlint-disable-next-line MD013 -->
+
 ### 1.1 Deconstructing the Tooling Deadlock: Why the Bun and ,`happy-dom`, Approach is Untenable
 
 An effective testing strategy must be built upon a compatible and stable set of
@@ -110,7 +110,7 @@ the team can immediately implement its accessibility strategy without being
 blocked by the ecosystem immaturity of a newer tool. This pivot ensures that
 the team's accessibility-first ambitions are realized in practice, not just in
 theory.
-<!-- markdownlint-disable-next-line MD013 -->
+
 ### 1.3 Setting Realistic Expectations: Understanding ,`axe-core`, Limitations in ,`jsdom`
 
 While pivoting to Vitest with a `jsdom` environment solves the primary tooling

--- a/docs/pure-accessible-and-localizable-react-components.md
+++ b/docs/pure-accessible-and-localizable-react-components.md
@@ -1,4 +1,3 @@
-<!-- markdownlint-disable-next-line MD013 -->
 # A Comprehensive Architectural Guide to Pure, Accessible, and Localizable React Components with Radix, Tanstack, and DaisyUI
 
 ## Introduction: The Modern Component Imperative

--- a/docs/pure-accessible-and-localizable-react-components.md
+++ b/docs/pure-accessible-and-localizable-react-components.md
@@ -1,3 +1,4 @@
+<!-- markdownlint-disable-next-line MD013 -->
 # A Comprehensive Architectural Guide to Pure, Accessible, and Localizable React Components with Radix, Tanstack, and DaisyUI
 
 ## Introduction: The Modern Component Imperative
@@ -345,6 +346,7 @@ impossible by design.
 
 Consider a component that fetches data. Instead of managing state with multiple
 booleans
+<!-- markdownlint-disable-next-line MD013 -->
 (`const [isLoading, setIsLoading] = useState(true); const [isError, setIsError] = useState(false);`
  ), an FSM approach would use a single state object:
 
@@ -400,6 +402,7 @@ to prevent invalid state transitions.[^24] A
 `useReducer` centralizes this transition logic, which is an improvement. A full
 state machine library like XState goes further by allowing declarative side
 effects, such as an `after` delay for the animation, directly within the state
+<!-- markdownlint-disable-next-line MD013 -->
 definition.[^24] Therefore, for components with non-trivial lifecycles, adopting a
 reducer-based state machine from the outset is a strategic investment in future
 maintainability, even if it appears more verbose initially.
@@ -666,6 +669,7 @@ view.
 
 To build a truly global application, components must be localizable.
 `react-i18next`, built on top of the powerful `i18next` library, is the de
+<!-- markdownlint-disable-next-line MD013 -->
 facto standard for internationalization in the React ecosystem.[^41] It provides a
 complete solution for managing translations, formatting dates and numbers, and
 handling plurals.[^42]
@@ -798,92 +802,95 @@ user settings.
 **Step-by-Step Implementation:**
 
 1. **Foundation (Behavioral Layer):** The component's structure is defined
-   using Radix UI primitives. `AlertDialog.Root` creates the modal context, and
-   `Form.Root` provides the accessible form structure. This initial step
-   produces an unstyled but fully functional and accessible component.
+    using Radix UI primitives. `AlertDialog.Root` creates the modal context, and
+    `Form.Root` provides the accessible form structure. This initial step
+    produces an unstyled but fully functional and accessible component.
 
-```typescript
-// UserSettingsModal.view.tsx (initial structure)
-import * as AlertDialog from '@radix-ui/react-alert-dialog';
-import * as Form from '@radix-ui/react-form';
+    ```typescript
+    // UserSettingsModal.view.tsx (initial structure)
+    import * as AlertDialog from '@radix-ui/react-alert-dialog';
+    import * as Form from '@radix-ui/react-form';
 
-//... props interface defined here...
+    //... props interface defined here...
 
-export const UserSettingsModalView = ({ /* props */ }) => (
-  <AlertDialog.Portal>
-    <AlertDialog.Overlay />
-    <AlertDialog.Content>
-      <AlertDialog.Title>{/* title text */}</AlertDialog.Title>
-      <Form.Root>
-        {/* Form fields will go here */}
-      </Form.Root>
-    </AlertDialog.Content>
-  </AlertDialog.Portal>
-);
+    export const UserSettingsModalView = ({ /* props */ }) => (
+      <AlertDialog.Portal>
+        <AlertDialog.Overlay />
+        <AlertDialog.Content>
+          <AlertDialog.Title>{/* title text */}</AlertDialog.Title>
+          <Form.Root>
+            {/* Form fields will go here */}
+          </Form.Root>
+        </AlertDialog.Content>
+      </AlertDialog.Portal>
+    );
 
-```
+    ```
+
 2. **Styling (Presentational Layer):** DaisyUI and Tailwind CSS classes are
-   applied to the Radix primitives. `AlertDialog.Content` gets `modal-box`,
-   `Form.Field` gets `form-control`, and so on. Responsive prefixes like `md:`
-   are used to adjust layout for larger screens.
+    applied to the Radix primitives. `AlertDialog.Content` gets `modal-box`,
+    `Form.Field` gets `form-control`, and so on. Responsive prefixes like `md:`
+    are used to adjust layout for larger screens.
+
 3. **State & Logic (Hook Layer):** A `useUserSettingsForm` hook is created to
-   encapsulate all logic.
+    encapsulate all logic.
 
-- **Localization:** The hook begins by calling `useTranslation('userProfile')`
-  to get the `t` function. It prepares all necessary strings to be returned to
-  the view.
-- **Server State:** It uses `useQuery` to fetch the initial user data and
-  `useMutation` to handle the form submission. The `onSuccess` callback of the
-  mutation invalidates the user query.
-- **Local State:** It uses `useReducer` to manage the form's state, including
-  input values, validation status, and submission state (e.g., `'submitting'`,
-  `'success'`). The reducer handles actions like `'UPDATE_FIELD'` and
-  `'SET_VALIDATION_ERROR'`.
+    - **Localization:** The hook begins by calling `useTranslation('userProfile')`
+      to get the `t` function. It prepares all necessary strings to be returned to
+      the view.
+    - **Server State:** It uses `useQuery` to fetch the initial user data and
+      `useMutation` to handle the form submission. The `onSuccess` callback of the
+      mutation invalidates the user query.
+    - **Local State:** It uses `useReducer` to manage the form's state, including
+      input values, validation status, and submission state (e.g., `'submitting'`,
+      `'success'`). The reducer handles actions like `'UPDATE_FIELD'` and
+      `'SET_VALIDATION_ERROR'`.
 
-```typescript
-// useUserSettingsForm.ts
-import { useReducer } from 'react';
-import { useTranslation } from 'react-i18next';
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-//... other imports
+    ```typescript
+    // useUserSettingsForm.ts
+    import { useReducer } from 'react';
+    import { useTranslation } from 'react-i18next';
+    import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+    //... other imports
 
-export const useUserSettingsForm = (userId: string) => {
-  const { t } = useTranslation('userProfile');
-  const queryClient = useQueryClient();
+    export const useUserSettingsForm = (userId: string) => {
+      const { t } = useTranslation('userProfile');
+      const queryClient = useQueryClient();
 
-  //... useQuery to fetch user data...
+      //... useQuery to fetch user data...
 
-  //... useReducer for form state...
+      //... useReducer for form state...
 
-  //... useMutation to update user...
+      //... useMutation to update user...
 
-  const handleSubmit = (event: React.FormEvent) => {
-    event.preventDefault();
-    //... validation logic...
-    //... call mutation...
-  };
+      const handleSubmit = (event: React.FormEvent) => {
+        event.preventDefault();
+        //... validation logic...
+        //... call mutation...
+      };
 
-  return {
-    // State for the view
-    title: t('settingsTitle'),
-    nameLabel: t('nameLabel'),
-    submitButtonText: t('submitButton'),
-    //... other translated strings
-    formState,
-    isLoading,
+      return {
+        // State for the view
+        title: t('settingsTitle'),
+        nameLabel: t('nameLabel'),
+        submitButtonText: t('submitButton'),
+        //... other translated strings
+        formState,
+        isLoading,
 
-    // Handlers for the view
-    dispatch,
-    handleSubmit,
-  };
-};
+        // Handlers for the view
+        dispatch,
+        handleSubmit,
+      };
+    };
 
-```
+    ```
+
 4. **Connecting the View (Synthesis):** The final `UserSettingsModal.view.tsx`
-   is a pure presentational component. It is wrapped in `React.memo` and
-   receives all its data and callbacks from the `useUserSettingsForm` hook via
-   props. It has no internal logic, no direct calls to state management or data
-   fetching libraries, and no direct knowledge of the i18n system.
+    is a pure presentational component. It is wrapped in `React.memo` and
+    receives all its data and callbacks from the `useUserSettingsForm` hook via
+    props. It has no internal logic, no direct calls to state management or data
+    fetching libraries, and no direct knowledge of the i18n system.
 
 This architecture achieves the ultimate separation of concerns. The view
 component is "language-agnostic"; it simply renders the strings it is given.
@@ -1101,4 +1108,3 @@ but also adaptable and maintainable for the future.
 51. Complete Guide — React Internationalization (i18n) with i18next - YouTube,
     accessed on 17 August 2025,
     [https://www.youtube.com/watch?v=LFaFPORPmeo](https://www.youtube.com/watch?v=LFaFPORPmeo)
-


### PR DESCRIPTION
## Summary
- address markdownlint complaints in docs
- silence line-length warnings with inline directives

## Testing
- `make markdownlint`
- `make fmt`
- `make lint`
- `make test`
- `bun run audit` *(fails: Script not found "audit")*

------
https://chatgpt.com/codex/tasks/task_e_68a4456fa8e08322be23ccf4df0acb30

## Summary by Sourcery

Fix markdownlint errors in documentation by adding inline disable directives and adjusting markdown formatting.

Documentation:
- Add inline markdownlint-disable directives to suppress line-length warnings across docs
- Adjust code block indentation and list numbering for compliance with lint rules