### PR TITLE
Centralise query defaults and stub type package runtime

### DIFF
--- a/frontend-pwa/src/Main.tsx
+++ b/frontend-pwa/src/Main.tsx
@@ -8,7 +8,14 @@ import '@app/tokens/css/variables.css';
 import './index.css';
 import { App } from './app/App';
 
-const qc = new QueryClient();
+const qc = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 60_000,
+      refetchOnWindowFocus: false,
+    },
+  },
+});
 const rootElem = document.getElementById('root');
 if (!rootElem) throw new Error('#root element not found');
 

--- a/frontend-pwa/src/api/client.ts
+++ b/frontend-pwa/src/api/client.ts
@@ -8,6 +8,11 @@ import { type User, UsersSchema } from '@app/types';
 import { customFetchParsed } from './fetcher';
 
 /**
+ * Query key for user listings.
+ */
+export const USERS_QK = ['users'] as const;
+
+/**
  * Fetch all registered users.
  *
  * @example

--- a/frontend-pwa/src/app/App.tsx
+++ b/frontend-pwa/src/app/App.tsx
@@ -2,14 +2,12 @@
  * @file Root application component.
  */
 import { useQuery } from '@tanstack/react-query';
-import { listUsers } from '../api/client';
+import { listUsers, USERS_QK } from '../api/client';
 
 export function App() {
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['users'],
+    queryKey: USERS_QK,
     queryFn: ({ signal }) => listUsers(signal),
-    staleTime: 60_000,
-    refetchOnWindowFocus: false,
   });
 
   if (isLoading) {

--- a/packages/tokens/src/utils/tokens.js
+++ b/packages/tokens/src/utils/tokens.js
@@ -1,21 +1,10 @@
 /** @file Token utilities for resolving design token references. */
 import fs from 'node:fs';
 
-/**
- * Enumerate an array yielding [index, value] pairs.
- *
- * @template T
- * @param {T[]} array - Array to iterate.
- * @returns {IterableIterator<[number, T]>}
- */
-function* enumerate(array) {
-  for (let i = 0; i < array.length; i++) {
-    yield [i, array[i]];
-  }
-}
-
 // Load token tree once for reference resolution.
-const TOKENS = JSON.parse(fs.readFileSync(new URL('../tokens.json', import.meta.url), 'utf8'));
+const TOKENS = JSON.parse(
+  fs.readFileSync(new URL('../tokens.json', import.meta.url), 'utf8'),
+);
 
 /**
  * Resolve a `{token.path}` reference to its concrete value.
@@ -26,7 +15,7 @@ const TOKENS = JSON.parse(fs.readFileSync(new URL('../tokens.json', import.meta.
  * @example
  * resolveToken('{color.brand}')
  */
-export function resolveToken(ref) {
+export function resolveToken(ref, tokens = TOKENS) {
   let current = ref;
   const seen = new Set();
   while (typeof current === 'string') {
@@ -38,11 +27,14 @@ export function resolveToken(ref) {
     }
     seen.add(key);
     const pathSegments = key.split('.');
-    let cursor = TOKENS;
-    for (const [segmentIndex, segment] of enumerate(pathSegments)) {
+    let cursor = tokens;
+    for (let segmentIndex = 0; segmentIndex < pathSegments.length; segmentIndex++) {
+      const segment = pathSegments[segmentIndex];
       if (cursor?.[segment] == null) {
         const missingPath = pathSegments.slice(0, segmentIndex + 1).join('.');
-        throw new Error(`Token path "${missingPath}" not found (while resolving "${key}")`);
+        throw new Error(
+          `Token path "${missingPath}" not found (while resolving "${key}")`,
+        );
       }
       cursor = cursor[segment];
     }

--- a/packages/types/index.js
+++ b/packages/types/index.js
@@ -1,0 +1,4 @@
+/**
+ * @file Runtime stub for @app/types to satisfy Node's module resolution.
+ */
+export {};

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -4,16 +4,19 @@
   "license": "ISC",
   "type": "module",
   "sideEffects": false,
-  "main": "./src/user.ts",
+  "main": "./index.js",
   "types": "./src/user.ts",
   "exports": {
     ".": {
-      "import": "./src/user.ts",
-      "types": "./src/user.ts"
+      "types": "./src/user.ts",
+      "default": "./index.js"
     },
     "./package.json": "./package.json"
   },
-  "dependencies": {
+  "peerDependencies": {
+    "zod": "^3"
+  },
+  "devDependencies": {
     "zod": "^3"
   },
   "engines": {


### PR DESCRIPTION
## Summary
- centralise React Query defaults in PWA entrypoint and reuse a query key constant
- allow token resolver to accept injected token trees
- add JS stub for @app/types and redirect package exports

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make check-fmt`


------
https://chatgpt.com/codex/tasks/task_e_68a678d4a1548322b1b77d6f71d7c369