### PR TITLE
Pass --no-sandbox to nixie target

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,6 +450,7 @@ Keep docs close to code.
   and load strings by namespace.
 - **Hooks**: Call `useTranslation` within logic hooks and pass all translated
   strings to view components via props.
+
 ### Testing (Vitest & Playwright)
 
 - **Vitest config**: Use the `jsdom` environment, include `tests/setup.ts`, and
@@ -462,6 +463,7 @@ Keep docs close to code.
 - **Playwright**: Run `@axe-core/playwright` scans, exercise keyboard
   navigation, capture accessibility tree snapshots, and emulate locales to test
   translations.
+
 ### Observability (Frontend)
 
 - **Structured logs**: Gate debug logs behind a flag (`?debug=1` or build‑time

--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,5 @@ mermaid-lint:
 	npx --yes @mermaid-js/mermaid-cli -i docs/repository-structure.md -o /tmp/diagram.svg -p mmdc-puppeteer.json
 
 nixie:
-	nixie
+	nixie --no-sandbox
 

--- a/Makefile
+++ b/Makefile
@@ -51,5 +51,7 @@ mermaid-lint:
 	npx --yes @mermaid-js/mermaid-cli -i docs/repository-structure.md -o /tmp/diagram.svg -p mmdc-puppeteer.json
 
 nixie:
+	# CI currently requires --no-sandbox; remove once nixie supports
+	# environment variable control for this option
 	nixie --no-sandbox
 


### PR DESCRIPTION
## Summary
- run nixie with `--no-sandbox` to disable sandboxing

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68a67c84c9c4832281c31b3e751065ba

## Summary by Sourcery

Build:
- Pass --no-sandbox flag to nixie target to disable sandboxing