### PR TITLE
Refactor JSON loading for tokens build scripts

### DIFF
--- a/packages/tokens/build/read-json.js
+++ b/packages/tokens/build/read-json.js
@@ -1,0 +1,24 @@
+/** @file Utility helpers for working with JSON files in build scripts.
+ * Provides a single function to synchronously read and parse a JSON file with
+ * consistent error reporting. This avoids repeating boilerplate and ensures any
+ * failures surface with clear context.
+ */
+import fs from 'node:fs';
+
+/**
+ * Read and parse a JSON file from disk.
+ *
+ * @param {string | URL} file - Path or URL pointing to the JSON file.
+ * @returns {unknown} Parsed JSON content.
+ * @throws {Error} When the file cannot be read or parsed.
+ */
+export function readJson(file) {
+  try {
+    const data = fs.readFileSync(file, 'utf8');
+    return JSON.parse(data);
+  } catch (err) {
+    const fileHint = file instanceof URL ? file.pathname : file;
+    console.error(`Failed to load JSON from ${fileHint}.`, err);
+    throw err;
+  }
+}

--- a/packages/tokens/build/style-dictionary.js
+++ b/packages/tokens/build/style-dictionary.js
@@ -1,5 +1,11 @@
+/** @file Build Style Dictionary outputs and derive framework presets.
+ * Converts design token sources into CSS variables, Tailwind presets, and
+ * daisyUI themes. Utility functions live alongside build scripts to keep them
+ * small and focused.
+ */
 import fs from 'node:fs';
 import StyleDictionary from 'style-dictionary';
+import { readJson } from './read-json.js';
 
 const sd = new StyleDictionary({
   source: ['src/tokens.json', 'src/themes/*.json'],
@@ -25,7 +31,7 @@ const sd = new StyleDictionary({
 sd.buildAllPlatforms();
 
 // Map tokens into Tailwind and DaisyUI presets
-const tokens = JSON.parse(fs.readFileSync('src/tokens.json', 'utf-8'));
+const tokens = readJson('src/tokens.json');
 const unwrap = (input) =>
   Object.fromEntries(
     Object.entries(input).map(([k, v]) => [
@@ -51,7 +57,7 @@ fs.writeFileSync('dist/tw/preset.js', `export default ${JSON.stringify(preset)};
 const themesDir = 'src/themes';
 const themeFiles = fs.readdirSync(themesDir).filter((f) => f.endsWith('.json'));
 const daisyThemes = themeFiles.map((file) => {
-  const json = JSON.parse(fs.readFileSync(`${themesDir}/${file}`, 'utf-8'));
+  const json = readJson(`${themesDir}/${file}`);
   const semantic = unwrap(json.semantic ?? {});
   return {
     ...(json.name ? { name: json.name } : {}),

--- a/packages/tokens/build/validate-contrast.js
+++ b/packages/tokens/build/validate-contrast.js
@@ -7,9 +7,10 @@
 import fs from 'node:fs';
 import { contrast } from '../src/utils/color.js';
 import { resolveToken } from '../src/utils/tokens.js';
+import { readJson } from './read-json.js';
 
 // Load package settings for defaults.
-const pkgJson = JSON.parse(fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8'));
+const pkgJson = readJson(new URL('../package.json', import.meta.url));
 
 /** Resolve the contrast threshold from CLI, env, or package.json. */
 function getThreshold() {
@@ -37,7 +38,7 @@ const contrastThreshold = getThreshold();
  * aggregation of failures.
  */
 function checkTheme(file, threshold) {
-  const json = JSON.parse(fs.readFileSync(file, 'utf8'));
+  const json = readJson(file);
   const brand = json.semantic?.brand;
   const accent = json.semantic?.accent;
   const errors = [];


### PR DESCRIPTION
## Summary
- extract `readJson` helper to handle JSON file parsing with consistent errors
- reuse utility across Style Dictionary and contrast validator

## Testing
- `make check-fmt`
- `make lint`
- `make test`

closes #32

------
https://chatgpt.com/codex/tasks/task_e_68ae4c97a0448322b6585ba9e5f3787d