### PR TITLE
Applies Prettier pass and removes JSON import assertions

### DIFF
--- a/deploy/charts/wildside/values.schema.json
+++ b/deploy/charts/wildside/values.schema.json
@@ -3,14 +3,14 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "replicaCount": {"type": "integer", "minimum": 1},
-    "nameOverride": {"type": "string"},
-    "fullnameOverride": {"type": "string"},
+    "replicaCount": { "type": "integer", "minimum": 1 },
+    "nameOverride": { "type": "string" },
+    "fullnameOverride": { "type": "string" },
     "image": {
       "type": "object",
       "properties": {
-        "repository": {"type": "string"},
-        "tag": {"type": "string"},
+        "repository": { "type": "string" },
+        "tag": { "type": "string" },
         "pullPolicy": {
           "type": "string",
           "enum": ["Always", "IfNotPresent", "Never"]
@@ -25,16 +25,16 @@
         "requests": {
           "type": "object",
           "properties": {
-            "cpu": {"type": "string"},
-            "memory": {"type": "string"}
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
           },
           "additionalProperties": false
         },
         "limits": {
           "type": "object",
           "properties": {
-            "cpu": {"type": "string"},
-            "memory": {"type": "string"}
+            "cpu": { "type": "string" },
+            "memory": { "type": "string" }
           },
           "additionalProperties": false
         }
@@ -44,9 +44,9 @@
     "pdb": {
       "type": "object",
       "properties": {
-        "enabled": {"type": "boolean"},
-        "minAvailable": {"type": "integer"},
-        "maxUnavailable": {"type": "integer"}
+        "enabled": { "type": "boolean" },
+        "minAvailable": { "type": "integer" },
+        "maxUnavailable": { "type": "integer" }
       },
       "allOf": [
         {
@@ -64,20 +64,20 @@
           "type": "string",
           "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
         },
-        "portName": {"type": "string"},
-        "port": {"type": "integer", "minimum": 1, "maximum": 65535},
-        "targetPort": {"type": ["integer", "string"]},
-        "annotations": {"type": "object"}
+        "portName": { "type": "string" },
+        "port": { "type": "integer", "minimum": 1, "maximum": 65535 },
+        "targetPort": { "type": ["integer", "string"] },
+        "annotations": { "type": "object" }
       },
       "additionalProperties": false
     },
     "autoscaling": {
       "type": "object",
       "properties": {
-        "enabled": {"type": "boolean"},
-        "minReplicas": {"type": "integer"},
-        "maxReplicas": {"type": "integer"},
-        "targetCPUUtilizationPercentage": {"type": "integer"},
+        "enabled": { "type": "boolean" },
+        "minReplicas": { "type": "integer" },
+        "maxReplicas": { "type": "integer" },
+        "targetCPUUtilizationPercentage": { "type": "integer" },
         "behavior": {
           "type": "object",
           "additionalProperties": false
@@ -88,25 +88,19 @@
     "ingress": {
       "type": "object",
       "properties": {
-        "enabled": {"type": "boolean"},
-        "className": {"type": "string"},
+        "enabled": { "type": "boolean" },
+        "className": { "type": "string" },
         "hostname": {
           "type": "string",
-          "oneOf": [
-            {"const": ""},
-            {"format": "hostname", "minLength": 1}
-          ]
+          "oneOf": [{ "const": "" }, { "format": "hostname", "minLength": 1 }]
         },
         "tlsSecretName": {
           "type": "string",
-          "oneOf": [
-            {"const": ""},
-            {"minLength": 1}
-          ]
+          "oneOf": [{ "const": "" }, { "minLength": 1 }]
         },
         "annotations": {
           "type": "object",
-          "additionalProperties": {"type": "string"}
+          "additionalProperties": { "type": "string" }
         }
       },
       "allOf": [
@@ -129,27 +123,27 @@
       },
       "additionalProperties": false
     },
-    "existingSecretName": {"type": "string"},
+    "existingSecretName": { "type": "string" },
     "secretEnvFromKeys": {
       "type": "object",
-      "additionalProperties": {"type": "string"}
+      "additionalProperties": { "type": "string" }
     },
-    "affinity": {"type": "object"},
-    "podSecurityContext": {"type": "object"},
-    "securityContext": {"type": "object"},
-    "container": {"type": "object"}
+    "affinity": { "type": "object" },
+    "podSecurityContext": { "type": "object" },
+    "securityContext": { "type": "object" },
+    "container": { "type": "object" }
   },
   "allOf": [
     {
       "if": {
         "properties": {
-          "secretEnvFromKeys": {"minProperties": 1}
+          "secretEnvFromKeys": { "minProperties": 1 }
         }
       },
       "then": {
         "required": ["existingSecretName"],
         "properties": {
-          "existingSecretName": {"type": "string", "minLength": 1}
+          "existingSecretName": { "type": "string", "minLength": 1 }
         }
       }
     }

--- a/docs/local-first-react.md
+++ b/docs/local-first-react.md
@@ -1353,7 +1353,6 @@ an even broader range of applications.
 
 ## Works cited
 
-
 [^1] Local-first software: You own your data, in spite of the cloud, accessed
 on August 20, 2025,
 [https://www.inkandswitch.com/essay/local-first/](https://www.inkandswitch.com/essay/local-first/)
@@ -1444,7 +1443,7 @@ accessed on August 20, 2025,
 [https://stackoverflow.com/questions/68690221/how-to-use-zustand-to-store-the-result-of-a-query](https://stackoverflow.com/questions/68690221/how-to-use-zustand-to-store-the-result-of-a-query)
 
 [^24] Behavior of onSuccess and idea for callbacks · TanStack query · Discussion
-#5034 - GitHub, accessed on August 20, 2025,
+\# 5034 - GitHub, accessed on August 20, 2025,
 [https://github.com/TanStack/query/discussions/5034](https://github.com/TanStack/query/discussions/5034)
 
 [^25] persistQueryClient | TanStack Query React Docs, accessed on August 20,
@@ -1468,7 +1467,8 @@ accessed on August 20, 2025,
 [https://aws.amazon.com/blogs/mobile/offline-caching-with-aws-amplify-tanstack-appsync-and-mongodb-atlas/](https://aws.amazon.com/blogs/mobile/offline-caching-with-aws-amplify-tanstack-appsync-and-mongodb-atlas/)
 
 [^30] Adding Offline Capabilities to React Native Apps with TanStack Query
-| Benoit Paul, accessed on August 20, 2025, [https://www.benoitpaul.com/blog/react-native/offline-first-tanstack-query/](https://www.benoitpaul.com/blog/react-native/offline-first-tanstack-query/) |
+| Benoit Paul, accessed on August 20, 2025,
+[https://www.benoitpaul.com/blog/react-native/offline-first-tanstack-query/](https://www.benoitpaul.com/blog/react-native/offline-first-tanstack-query/)
 
 [^31] WebSocket vs REST: Key differences and which to use - Ably, accessed on
 August 20, 2025,
@@ -1513,6 +1513,7 @@ accessed on August 20, 2025,
 [https://www.reddit.com/r/reactnative/comments/1arlfkd/how_do_you_guys_build_offlinefirst_apps_with/](https://www.reddit.com/r/reactnative/comments/1arlfkd/how_do_you_guys_build_offlinefirst_apps_with/)
 
 [^42] TanStack/db: A reactive client store for building super fast apps on sync
+
 - GitHub, accessed on August 20, 2025,
 [https://github.com/TanStack/db](https://github.com/TanStack/db) [^43]
 Local-first sync with TanStack DB and Electric | ElectricSQL, accessed on
@@ -1534,6 +1535,7 @@ accessed on August 21, 2025,
 
 [^48] Mastering State Management with XState React: Best Practices for
 Developers
+
 - DhiWise, accessed on August 21, 2025,
 [https://www.dhiwise.com/post/mastering-state-management-with-xstate-react-best-practices](https://www.dhiwise.com/post/mastering-state-management-with-xstate-react-best-practices)
 
@@ -1559,6 +1561,7 @@ Medium, accessed on August 21, 2025,
 
 [^54] How do you use XState with React Query (or other data-fetching/caching
 libs)? Should they even be used together? : r/reactjs
+
 - Reddit, accessed on August 21, 2025,
 [https://www.reddit.com/r/reactjs/comments/1m2g5n9/how_do_you_use_xstate_with_react_query_or_other/](https://www.reddit.com/r/reactjs/comments/1m2g5n9/how_do_you_use_xstate_with_react_query_or_other/)
 

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -123,8 +123,8 @@ myapp/
 ### Helm chart values structure
 
 The Helm chart values file (`values.yaml`) is organised in the following
-hierarchy. See [values-class-diagram.mmd](values-class-diagram.mmd) for a visual
-overview. Validation via
+hierarchy. See [values-class-diagram.mmd](values-class-diagram.mmd) for a
+visual overview. Validation via
 [`values.schema.json`](../deploy/charts/wildside/values.schema.json) enforces
 cross-field rules (for example, requiring `existingSecretName` when
 `secretEnvFromKeys` is set).
@@ -200,9 +200,8 @@ Rust types + handlers  →  OpenAPI (utoipa)  →  orval  →  Typed TS client  
 
 ## 3) Design Tokens as a First‑Class Package
 
-**Goals:** single source of truth for
-colours/spacing/typography/radii; drive Tailwind/daisyUI and any
-future native shells.
+**Goals:** single source of truth for colours/spacing/typography/radii; drive
+Tailwind/daisyUI and any future native shells.
 
 - `packages/tokens/src/tokens.json`: global primitives (`color.*`, `space.*`,
   `radius.*`, `font.*`).
@@ -403,13 +402,13 @@ spec:
   ports: [{ port: 80, targetPort: http }]
 ```
 
-**Ingress** points `/api/*` to the Service. The frontend public hostname
-points to the CDN; only `/api` reaches the cluster. The chart renders a
-ConfigMap named `<release-name>-config`, populated from `.Values.config`; the
-Deployment injects keys from it via `configMapKeyRef`. Reference Secret keys
-using `existingSecretName` and `secretEnvFromKeys`; never commit secret
-material to Git—manage it with SOPS or an External Secrets operator. If
-enabled, `tlsSecretName` points to a pre‑provisioned TLS Secret.
+**Ingress** points `/api/*` to the Service. The frontend public hostname points
+to the CDN; only `/api` reaches the cluster. The chart renders a ConfigMap
+named `<release-name>-config`, populated from `.Values.config`; the Deployment
+injects keys from it via `configMapKeyRef`. Reference Secret keys using
+`existingSecretName` and `secretEnvFromKeys`; never commit secret material to
+Git—manage it with SOPS or an External Secrets operator. If enabled,
+`tlsSecretName` points to a pre‑provisioned TLS Secret.
 
 `config` is for non‑secret settings. Place confidential keys in an external
 Secret and reference them by setting `existingSecretName` and providing key

--- a/frontend-pwa/src/api/client.ts
+++ b/frontend-pwa/src/api/client.ts
@@ -24,8 +24,7 @@ Object.freeze(USERS_QK);
  */
 export const usersQK = {
   all: USERS_QK,
-  byId: (id: User['id']): readonly [...typeof USERS_QK, User['id']] =>
-    [...USERS_QK, id] as const,
+  byId: (id: User['id']): readonly [...typeof USERS_QK, User['id']] => [...USERS_QK, id] as const,
 } as const;
 Object.freeze(usersQK);
 

--- a/packages/tokens/build/style-dictionary.js
+++ b/packages/tokens/build/style-dictionary.js
@@ -62,9 +62,7 @@ function unwrap(input) {
   if ('value' in input) {
     return input.value;
   }
-  return Object.fromEntries(
-    Object.entries(input).map(([k, v]) => [k, unwrap(v)]),
-  );
+  return Object.fromEntries(Object.entries(input).map(([k, v]) => [k, unwrap(v)]));
 }
 
 const preset = {
@@ -83,9 +81,7 @@ fs.writeFileSync('dist/tw/preset.js', `export default ${JSON.stringify(preset)};
 
 const themesUrl = new URL('../src/themes/', import.meta.url);
 // Convert the URL to a file-system path via `fileURLToPath` for cross-platform compatibility.
-const themeFiles = fs
-  .readdirSync(fileURLToPath(themesUrl))
-  .filter((f) => f.endsWith('.json'));
+const themeFiles = fs.readdirSync(fileURLToPath(themesUrl)).filter((f) => f.endsWith('.json'));
 const daisyThemes = themeFiles.map((file) => {
   const json = readJson(new URL(file, themesUrl));
   const semantic = unwrap(json.semantic ?? {});

--- a/packages/tokens/build/validate-contrast.js
+++ b/packages/tokens/build/validate-contrast.js
@@ -55,9 +55,7 @@ function hasRequiredPkgFields(json) {
  */
 function validatePkgJson(json) {
   if (!hasRequiredPkgFields(json)) {
-    throw new Error(
-      'package.json must be a valid object with "name" and "version" string fields.',
-    );
+    throw new Error('package.json must be a valid object with "name" and "version" string fields.');
   }
 }
 

--- a/packages/tokens/src/utils/resolve-token.js
+++ b/packages/tokens/src/utils/resolve-token.js
@@ -38,9 +38,7 @@ function* enumerate(iterable) {
  */
 export function resolveToken(ref, tokens) {
   if (typeof ref !== 'string') {
-    throw new TypeError(
-      'ref must be a string like "{path.to.token}" or a literal string',
-    );
+    throw new TypeError('ref must be a string like "{path.to.token}" or a literal string');
   }
   if (tokens == null || typeof tokens !== 'object') {
     throw new TypeError('tokens must be an object token tree');
@@ -60,25 +58,17 @@ export function resolveToken(ref, tokens) {
     for (const [segmentIndex, segment] of enumerate(pathSegments)) {
       if (cursor?.[segment] == null) {
         const missingPath = pathSegments.slice(0, segmentIndex + 1).join('.');
-        const siblings =
-          cursor && typeof cursor === 'object' ? Object.keys(cursor) : [];
+        const siblings = cursor && typeof cursor === 'object' ? Object.keys(cursor) : [];
         const hint =
-          siblings.length > 0
-            ? ` Available keys: ${siblings.slice(0, 10).join(', ')}`
-            : '';
-        throw new Error(
-          `Token path "${missingPath}" not found (while resolving "${key}").${hint}`,
-        );
+          siblings.length > 0 ? ` Available keys: ${siblings.slice(0, 10).join(', ')}` : '';
+        throw new Error(`Token path "${missingPath}" not found (while resolving "${key}").${hint}`);
       }
       cursor = cursor[segment];
     }
     current = cursor?.value;
     if (current == null || typeof current !== 'string') {
-      throw new TypeError(
-        `Token "${key}" must resolve to an object with a string "value"`,
-      );
+      throw new TypeError(`Token "${key}" must resolve to an object with a string "value"`);
     }
   }
   return current;
 }
-

--- a/packages/tokens/src/utils/tokens.browser.js
+++ b/packages/tokens/src/utils/tokens.browser.js
@@ -18,5 +18,3 @@ export const TOKENS = undefined;
 export function resolveToken(ref, tokens = TOKENS) {
   return baseResolveToken(ref, tokens);
 }
-
-

--- a/packages/tokens/src/utils/tokens.js
+++ b/packages/tokens/src/utils/tokens.js
@@ -1,11 +1,19 @@
 /** @file Token utilities with the bundled token tree.
  *
- * Loads the design tokens JSON once and wires it to `resolveToken`. A lean
- * browser entry is available via the conditional export `"browser"` which
- * omits this import to avoid bundling unused data.
+ * Loads the design tokens JSON once and wires it to `resolveToken`.
+ *
+ * Note: We intentionally avoid `import ... assert { type: 'json' }` here
+ * because some tooling (formatters/linters) in this repository does not yet
+ * parse import assertions. Since this file is the Node entry (the browser
+ * entry is provided via the `browser` export), it is safe to read the JSON
+ * using Node's FS API instead.
  */
-import tokensJson from '../tokens.json' assert { type: 'json' };
+import { readFileSync } from 'node:fs';
 import { resolveToken as baseResolveToken } from './resolve-token.js';
+
+// Load and parse the token JSON at module initialisation.
+// Using URL ensures correctness regardless of CWD.
+const tokensJson = JSON.parse(readFileSync(new URL('../tokens.json', import.meta.url), 'utf8'));
 
 // Freeze to guard against accidental mutation at runtime.
 const TOKENS = Object.freeze(tokensJson);
@@ -27,4 +35,3 @@ const TOKENS = Object.freeze(tokensJson);
 export function resolveToken(ref, tokens = TOKENS) {
   return baseResolveToken(ref, tokens);
 }
-

--- a/packages/tokens/src/utils/tokens.test.js
+++ b/packages/tokens/src/utils/tokens.test.js
@@ -22,10 +22,7 @@ test('resolves a chained reference', () => {
 
 test('throws on circular reference', () => {
   const tokens = { a: { value: '{b}' }, b: { value: '{a}' } };
-  assert.throws(
-    () => resolveToken('{a}', tokens),
-    /Circular token reference detected: "a"/,
-  );
+  assert.throws(() => resolveToken('{a}', tokens), /Circular token reference detected: "a"/);
 });
 
 test('throws on missing path with enriched message', () => {
@@ -47,10 +44,7 @@ test('throws on invalid tokens arg', () => {
   // Assert class
   assert.throws(() => resolveToken('{color.brand}', null), TypeError);
   // Assert message
-  assert.throws(
-    () => resolveToken('{color.brand}', null),
-    /tokens must be an object token tree/,
-  );
+  assert.throws(() => resolveToken('{color.brand}', null), /tokens must be an object token tree/);
 });
 
 test('throws on non-string ref', () => {
@@ -58,9 +52,7 @@ test('throws on non-string ref', () => {
     () => resolveToken(123, baseTokens),
     (err) =>
       err instanceof TypeError &&
-      /ref must be a string like "\{path\.to\.token\}" or a literal string/.test(
-        err.message,
-      ),
+      /ref must be a string like "\{path\.to\.token\}" or a literal string/.test(err.message),
   );
 });
 

--- a/packages/types/dist/src/user.d.ts
+++ b/packages/types/dist/src/user.d.ts
@@ -6,32 +6,47 @@
  */
 import { z } from 'zod';
 /** Runtime schema for a branded user identifier. */
-export declare const UserIdSchema: z.ZodBranded<z.ZodString, "UserId">;
+export declare const UserIdSchema: z.ZodBranded<z.ZodString, 'UserId'>;
 /** Unique identifier for a user. */
 export type UserId = z.infer<typeof UserIdSchema>;
 /** Runtime schema for a user record. */
-export declare const UserSchema: z.ZodObject<{
-    id: z.ZodBranded<z.ZodString, "UserId">;
+export declare const UserSchema: z.ZodObject<
+  {
+    id: z.ZodBranded<z.ZodString, 'UserId'>;
     display_name: z.ZodString;
-}, "strict", z.ZodTypeAny, {
-    id?: string & z.BRAND<"UserId">;
+  },
+  'strict',
+  z.ZodTypeAny,
+  {
+    id?: string & z.BRAND<'UserId'>;
     display_name?: string;
-}, {
+  },
+  {
     id?: string;
     display_name?: string;
-}>;
+  }
+>;
 /** User record returned from the API. */
 export type User = z.infer<typeof UserSchema>;
 /** Runtime schema for a list of user records. */
-export declare const UsersSchema: z.ZodArray<z.ZodObject<{
-    id: z.ZodBranded<z.ZodString, "UserId">;
-    display_name: z.ZodString;
-}, "strict", z.ZodTypeAny, {
-    id?: string & z.BRAND<"UserId">;
-    display_name?: string;
-}, {
-    id?: string;
-    display_name?: string;
-}>, "many">;
+export declare const UsersSchema: z.ZodArray<
+  z.ZodObject<
+    {
+      id: z.ZodBranded<z.ZodString, 'UserId'>;
+      display_name: z.ZodString;
+    },
+    'strict',
+    z.ZodTypeAny,
+    {
+      id?: string & z.BRAND<'UserId'>;
+      display_name?: string;
+    },
+    {
+      id?: string;
+      display_name?: string;
+    }
+  >,
+  'many'
+>;
 /** Collection of user records. */
 export type Users = z.infer<typeof UsersSchema>;


### PR DESCRIPTION
### Why  
* Aligns the whole repo with the current Prettier settings for consistent code-style and shorter diffs in the future.  
* Drops the `import … assert { type: 'json' }` pattern in the Node entry of the tokens utilities because some editors/linters in the tool-chain still choke on import-assertion syntax.

### What  
* Re-formats JSON schema, JS/TS, and Markdown files (single-line objects, trimmed blank lines, escaped markdown chars).  
* Re-implements token loading in the Node build with `fs.readFileSync` + `JSON.parse`, keeping behaviour identical while restoring editor support.  
* Updates generated declaration files to match the new formatting.

No runtime logic is affected aside from the transparent switch in token loading.