### PR TITLE
Refactor secret validation into Helm helper template

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,13 @@ Ensure documentation and diagrams remain valid:
 make markdownlint-docs
 make mermaid-lint
 ```
+
+## Helm configuration
+
+The included Helm chart surfaces several values for managing secrets:
+
+| Value | Default | Purpose |
+| ----- | ------- | ------- |
+| `existingSecretName` | `""` | Name of a Secret to source environment variables from. |
+| `secretEnvFromKeys` | `{}` | Map environment variables to keys in `existingSecretName`. |
+| `allowMissingSecret` | `true` | Permit rendering when the Secret is absent. Set to `false` to fail. |

--- a/README.md
+++ b/README.md
@@ -66,3 +66,6 @@ The included Helm chart surfaces several values for managing secrets:
 | `existingSecretName` | `""` | Name of a Secret to source environment variables from. |
 | `secretEnvFromKeys` | `{}` | Map environment variables to keys in `existingSecretName`. |
 | `allowMissingSecret` | `true` | Permit rendering when the Secret is absent. Set to `false` to fail. |
+
+Note: Helm client version 3.2.0 or later is required when `secretEnvFromKeys`
+is used, as the chart invokes `lookup` during template rendering.

--- a/deploy/charts/wildside/templates/_helpers.tpl
+++ b/deploy/charts/wildside/templates/_helpers.tpl
@@ -56,16 +56,22 @@ Validate that secretEnvFromKeys references an existing Secret when set.
   {{- fail (printf "Secret %q not found in namespace %q" $name .Release.Namespace) -}}
   {{- end -}}
   {{- if not $missingSecret -}}
-{{- $data := $found.data | default dict -}}
-{{- $stringData := $found.stringData | default dict -}}
+{{- $data := (get $found "data") | default dict -}}
+{{- $stringData := (get $found "stringData") | default dict -}}
 {{- $missing := list -}}
 {{- range $k, $secretKey := $sec -}}
+{{- if not (regexMatch "^[A-Za-z_][A-Za-z0-9_]*$" $k) -}}
+{{- fail (printf "secretEnvFromKeys has invalid env var name %q (must match ^[A-Za-z_][A-Za-z0-9_]*$)" $k) -}}
+{{- end -}}
+{{- if not $secretKey -}}
+{{- fail (printf "secretEnvFromKeys maps %q to an empty secret key" $k) -}}
+{{- end -}}
 {{- if not (or (hasKey $data $secretKey) (hasKey $stringData $secretKey)) -}}
 {{- $missing = append $missing $secretKey -}}
 {{- end -}}
 {{- end -}}
 {{- if gt (len $missing) 0 -}}
-{{- fail (printf "Secret %q missing keys: %s" $name (join $missing ", ")) -}}
+{{- fail (printf "Secret %q missing keys: %s" $name (join ", " $missing)) -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/charts/wildside/templates/_helpers.tpl
+++ b/deploy/charts/wildside/templates/_helpers.tpl
@@ -27,3 +27,24 @@ helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
 app.kubernetes.io/name: {{ include "wildside.name" . }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
+
+{{/*
+Validate that secretEnvFromKeys references an existing Secret when set.
+
+- Requires .Values.existingSecretName when secretEnvFromKeys has entries.
+- Optionally fails if the Secret is missing and allowMissingSecret is false.
+*/}}
+{{- define "wildside.validateSecrets" -}}
+{{- $sec := .Values.secretEnvFromKeys | default dict -}}
+{{- $name := .Values.existingSecretName -}}
+{{- $allowMissing := .Values.allowMissingSecret | default true -}}
+{{- if and (gt (len $sec) 0) (not $name) -}}
+{{- fail "existingSecretName is required when secretEnvFromKeys is set" -}}
+{{- end -}}
+{{- if and (gt (len $sec) 0) $name -}}
+{{- $found := lookup "v1" "Secret" .Release.Namespace $name -}}
+{{- if and (not $found) (not $allowMissing) -}}
+{{- fail (printf "Secret %q not found in namespace %q" $name .Release.Namespace) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/wildside/templates/_helpers.tpl
+++ b/deploy/charts/wildside/templates/_helpers.tpl
@@ -50,11 +50,12 @@ Validate that secretEnvFromKeys references an existing Secret when set.
 {{- if not (semverCompare ">=3.2.0" .Capabilities.HelmVersion.Version) -}}
 {{- fail "wildside.validateSecrets requires Helm >= 3.2.0" -}}
 {{- end -}}
-{{- $found := lookup "v1" "Secret" .Release.Namespace $name -}}
-{{- if and (not $found) (not $allowMissing) -}}
-{{- fail (printf "Secret %q not found in namespace %q" $name .Release.Namespace) -}}
-{{- end -}}
-{{- if $found -}}
+  {{- $found := lookup "v1" "Secret" .Release.Namespace $name -}}
+  {{- $missingSecret := or (not $found) (and (kindIs "slice" $found) (eq (len $found) 0)) -}}
+  {{- if and $missingSecret (not $allowMissing) -}}
+  {{- fail (printf "Secret %q not found in namespace %q" $name .Release.Namespace) -}}
+  {{- end -}}
+  {{- if not $missingSecret -}}
 {{- $data := $found.data | default dict -}}
 {{- $stringData := $found.stringData | default dict -}}
 {{- $missing := list -}}

--- a/deploy/charts/wildside/templates/_helpers.tpl
+++ b/deploy/charts/wildside/templates/_helpers.tpl
@@ -33,18 +33,39 @@ Validate that secretEnvFromKeys references an existing Secret when set.
 
 - Requires .Values.existingSecretName when secretEnvFromKeys has entries.
 - Optionally fails if the Secret is missing and allowMissingSecret is false.
+- Validates that listed keys exist within the referenced Secret.
 */}}
 {{- define "wildside.validateSecrets" -}}
-{{- $sec := .Values.secretEnvFromKeys | default dict -}}
+{{- $raw := .Values.secretEnvFromKeys -}}
+{{- if and $raw (not (kindIs "map" $raw)) -}}
+{{- fail (printf "secretEnvFromKeys must be a map, got %s" (typeOf $raw)) -}}
+{{- end -}}
+{{- $sec := $raw | default dict -}}
 {{- $name := .Values.existingSecretName -}}
 {{- $allowMissing := .Values.allowMissingSecret | default true -}}
 {{- if and (gt (len $sec) 0) (not $name) -}}
 {{- fail "existingSecretName is required when secretEnvFromKeys is set" -}}
 {{- end -}}
 {{- if and (gt (len $sec) 0) $name -}}
+{{- if not (semverCompare ">=3.2.0" .Capabilities.HelmVersion.Version) -}}
+{{- fail "wildside.validateSecrets requires Helm >= 3.2.0" -}}
+{{- end -}}
 {{- $found := lookup "v1" "Secret" .Release.Namespace $name -}}
 {{- if and (not $found) (not $allowMissing) -}}
 {{- fail (printf "Secret %q not found in namespace %q" $name .Release.Namespace) -}}
+{{- end -}}
+{{- if $found -}}
+{{- $data := $found.data | default dict -}}
+{{- $stringData := $found.stringData | default dict -}}
+{{- $missing := list -}}
+{{- range $k, $secretKey := $sec -}}
+{{- if not (or (hasKey $data $secretKey) (hasKey $stringData $secretKey)) -}}
+{{- $missing = append $missing $secretKey -}}
+{{- end -}}
+{{- end -}}
+{{- if gt (len $missing) 0 -}}
+{{- fail (printf "Secret %q missing keys: %s" $name (join $missing ", ")) -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}
 {{- end -}}

--- a/deploy/charts/wildside/templates/deployment.yaml
+++ b/deploy/charts/wildside/templates/deployment.yaml
@@ -75,10 +75,11 @@ spec:
             - name: {{ $k }}
               valueFrom:
                 secretKeyRef:
-                    name: {{ $name | quote }}
-                    key: {{ $secretKey | quote }}
-          {{- end }}
-        {{- end }}
+                  name: {{ $name | quote }}
+                  key: {{ $secretKey | quote }}
+                  optional: {{ .Values.allowMissingSecret | default true }}
+           {{- end }}
+         {{- end }}
 {{- with .Values.securityContext }}
           securityContext:
 {{ toYaml . | replace "drop:\n  -" "drop:\n    -" | nindent 12 }}

--- a/deploy/charts/wildside/templates/deployment.yaml
+++ b/deploy/charts/wildside/templates/deployment.yaml
@@ -77,7 +77,7 @@ spec:
                 secretKeyRef:
                   name: {{ $name | quote }}
                   key: {{ $secretKey | quote }}
-                  optional: {{ .Values.allowMissingSecret | default true }}
+                  optional: {{ $.Values.allowMissingSecret | default true }}
            {{- end }}
          {{- end }}
 {{- with .Values.securityContext }}

--- a/deploy/charts/wildside/templates/deployment.yaml
+++ b/deploy/charts/wildside/templates/deployment.yaml
@@ -61,16 +61,7 @@ spec:
           {{- $cfg := .Values.config | default dict }}
           {{- $sec := .Values.secretEnvFromKeys | default dict }}
           {{- $name := .Values.existingSecretName }}
-          {{- $allowMissing := .Values.allowMissingSecret | default true }}
-          {{- if and (gt (len $sec) 0) (not $name) }}
-          {{- fail "existingSecretName is required when secretEnvFromKeys is set" }}
-          {{- end }}
-          {{- if and (gt (len $sec) 0) $name }}
-          {{- $found := lookup "v1" "Secret" .Release.Namespace $name }}
-          {{- if and (not $found) (not $allowMissing) }}
-          {{- fail (printf "Secret %q not found in namespace %q" $name .Release.Namespace) }}
-          {{- end }}
-          {{- end }}
+          {{- include "wildside.validateSecrets" . -}}
           {{- if or (gt (len $cfg) 0) (gt (len $sec) 0) }}
           env:
             {{- range $k, $_ := $cfg }}

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -139,6 +139,32 @@ cross-field rules (for example, requiring `existingSecretName` when
 > (for example, enabling `seccompProfile` and setting `fsGroup`).
 > Container-specific controls remain under `securityContext`.
 
+#### Deployment secret resolution flow
+
+The deployment template uses the following logic to resolve secrets:
+
+```mermaid
+flowchart TD
+    A[Start Deployment Template Rendering]
+    B{secretEnvFromKeys set?}
+    C{existingSecretName set?}
+    D{Secret exists in namespace?}
+    E[Fail: existingSecretName required]
+    F[Fail: Secret not found]
+    G[Continue rendering]
+    H[allowMissingSecret is true?]
+
+    A --> B
+    B -- No --> G
+    B -- Yes --> C
+    C -- No --> E
+    C -- Yes --> D
+    D -- Yes --> G
+    D -- No --> H
+    H -- Yes --> G
+    H -- No --> F
+```
+
 ---
 
 ## 2) Contracts & Code Generation Hand‑offs


### PR DESCRIPTION
## Summary
- extract secret validation logic into `wildside.validateSecrets` helper
- invoke helper from `deployment.yaml` to reduce inline complexity

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b49060f15c83228e5257ed7147a2f0

## Summary by Sourcery

Refactor the Helm chart to extract secret validation logic into a dedicated helper and simplify the deployment template

Enhancements:
- Move inline secret existence checks into a new wildside.validateSecrets helper in _helpers.tpl
- Replace inline secret validation in deployment.yaml with a call to the new helper