### PR TITLE
Guard ingress rules on hostname

### DIFF
--- a/deploy/charts/wildside/templates/ingress.yaml
+++ b/deploy/charts/wildside/templates/ingress.yaml
@@ -19,10 +19,9 @@ spec:
         - {{ .Values.ingress.hostname | quote }}
       secretName: {{ .Values.ingress.tlsSecretName | quote }}
   {{- end }}
+  {{- if .Values.ingress.hostname }}
   rules:
-    - {{- if .Values.ingress.hostname }}
-      host: {{ .Values.ingress.hostname | quote }}
-      {{- end }}
+    - host: {{ .Values.ingress.hostname | quote }}
       http:
         paths:
           - path: /
@@ -32,4 +31,5 @@ spec:
                 name: {{ include "wildside.fullname" . }}
                 port:
                   name: {{ .Values.service.portName | default "http" | quote }}
+  {{- end }}
 {{- end }}

--- a/deploy/charts/wildside/templates/ingress.yaml
+++ b/deploy/charts/wildside/templates/ingress.yaml
@@ -20,20 +20,13 @@ spec:
         - {{ $.Values.ingress.hostname | quote }}
       secretName: {{ . | quote }}
   {{- end }}
+  {{- end }}
+  # Leave host unset to apply the rule to all hosts
   rules:
-    - host: {{ . | quote }}
+    - {{- with .Values.ingress.hostname }}
+      host: {{ . | quote }}
+      {{- end }}
       http:
-        paths:
-          - path: /
-            pathType: Prefix
-            backend:
-              service:
-                name: {{ include "wildside.fullname" $ }}
-                port:
-                  name: {{ $.Values.service.portName | default "http" | quote }}
-  {{- else }}
-  rules:
-    - http:
         paths:
           - path: /
             pathType: Prefix
@@ -42,5 +35,4 @@ spec:
                 name: {{ include "wildside.fullname" . }}
                 port:
                   name: {{ .Values.service.portName | default "http" | quote }}
-  {{- end }}
 {{- end }}

--- a/deploy/charts/wildside/templates/ingress.yaml
+++ b/deploy/charts/wildside/templates/ingress.yaml
@@ -13,16 +13,27 @@ spec:
   {{- with .Values.ingress.className }}
   ingressClassName: {{ . | quote }}
   {{- end }}
-  {{- if and .Values.ingress.tlsSecretName .Values.ingress.hostname }}
+  {{- with .Values.ingress.hostname }}
+  {{- with $.Values.ingress.tlsSecretName }}
   tls:
     - hosts:
-        - {{ .Values.ingress.hostname | quote }}
-      secretName: {{ .Values.ingress.tlsSecretName | quote }}
+        - {{ $.Values.ingress.hostname | quote }}
+      secretName: {{ . | quote }}
   {{- end }}
-  {{- if .Values.ingress.hostname }}
   rules:
-    - host: {{ .Values.ingress.hostname | quote }}
+    - host: {{ . | quote }}
       http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "wildside.fullname" $ }}
+                port:
+                  name: {{ $.Values.service.portName | default "http" | quote }}
+  {{- else }}
+  rules:
+    - http:
         paths:
           - path: /
             pathType: Prefix

--- a/deploy/charts/wildside/templates/ingress.yaml
+++ b/deploy/charts/wildside/templates/ingress.yaml
@@ -14,19 +14,27 @@ spec:
   ingressClassName: {{ . | quote }}
   {{- end }}
   {{- with .Values.ingress.hostname }}
-  {{- with $.Values.ingress.tlsSecretName }}
+  {{- if $.Values.ingress.tlsSecretName }}
   tls:
     - hosts:
-        - {{ $.Values.ingress.hostname | quote }}
-      secretName: {{ . | quote }}
+        - {{ . | quote }}
+      secretName: {{ $.Values.ingress.tlsSecretName | quote }}
   {{- end }}
-  {{- end }}
+  rules:
+    - host: {{ . | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "wildside.fullname" $ }}
+                port:
+                  name: {{ $.Values.service.portName | default "http" | quote }}
+  {{- else }}
   # Leave host unset to apply the rule to all hosts
   rules:
-    - {{- with .Values.ingress.hostname }}
-      host: {{ . | quote }}
-      {{- end }}
-      http:
+    - http:
         paths:
           - path: /
             pathType: Prefix
@@ -35,4 +43,5 @@ spec:
                 name: {{ include "wildside.fullname" . }}
                 port:
                   name: {{ .Values.service.portName | default "http" | quote }}
+  {{- end }}
 {{- end }}


### PR DESCRIPTION
## Summary
- conditionally render ingress rules only when hostname is provided

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make yamllint`


------
https://chatgpt.com/codex/tasks/task_e_68b4906a74d883229d08ae0051647f35

## Summary by Sourcery

Guard the Helm chart ingress configuration to only render TLS and HTTP rules when a hostname is provided in values

Enhancements:
- Conditionally wrap the ingress 'rules' block behind an .Values.ingress.hostname check
- Remove redundant nested hostname guard around the host field