### PR TITLE
Fix schema-based type inference in API fetcher

### DIFF
--- a/frontend-pwa/src/api/fetcher.ts
+++ b/frontend-pwa/src/api/fetcher.ts
@@ -158,14 +158,17 @@ export const customFetch = async <T>(input: string, init?: RequestInit): Promise
  * Fetch JSON and validate it against a provided Zod schema.
  *
  * @example
+ * import { z } from 'zod';
+ * const UserSchema = z.object({ id: z.string() });
+ * // Inferred: z.output<typeof UserSchema>
  * const user = await customFetchParsed('/api/user', UserSchema);
- * user.id;
+ * user.id; // string
  */
 export const customFetchParsed = async <Schema extends z.ZodTypeAny>(
   input: string,
   schema: Schema,
   init?: RequestInit,
-): Promise<z.infer<Schema>> => {
+): Promise<z.output<Schema>> => {
   const data = await customFetch<unknown>(input, init);
   return schema.parse(data);
 };
@@ -174,7 +177,7 @@ export const customFetchParsedSafe = async <Schema extends z.ZodTypeAny>(
   input: string,
   schema: Schema,
   init?: RequestInit,
-): Promise<z.SafeParseReturnType<unknown, z.infer<Schema>>> => {
+): Promise<z.SafeParseReturnType<unknown, z.output<Schema>>> => {
   const data = await customFetch<unknown>(input, init);
   return schema.safeParse(data);
 };

--- a/frontend-pwa/src/api/fetcher.ts
+++ b/frontend-pwa/src/api/fetcher.ts
@@ -156,12 +156,16 @@ export const customFetch = async <T>(input: string, init?: RequestInit): Promise
 
 /**
  * Fetch JSON and validate it against a provided Zod schema.
+ *
+ * @example
+ * const user = await customFetchParsed('/api/user', UserSchema);
+ * user.id;
  */
-export const customFetchParsed = async <T>(
+export const customFetchParsed = async <Schema extends z.ZodTypeAny>(
   input: string,
-  schema: z.ZodType<T>,
+  schema: Schema,
   init?: RequestInit,
-): Promise<T> => {
+): Promise<z.infer<Schema>> => {
   const data = await customFetch<unknown>(input, init);
   return schema.parse(data);
 };


### PR DESCRIPTION
## Summary
- ensure `customFetchParsed` returns the schema's inferred type
- document `customFetchParsed` usage example

## Testing
- `make check-fmt`
- `make lint`
- `make test`
- `make typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68b5ebf66cc48322a1d9c763b9acf32b

## Summary by Sourcery

Improve type inference and documentation for customFetchParsed

Enhancements:
- Change customFetchParsed generic signature to accept any Zod schema and return its inferred type

Documentation:
- Add usage example to customFetchParsed JSDoc comment