### PR TITLE
Refine docs and tooling per review

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,12 @@ check-fmt:
 	bun x biome format
 
 markdownlint:
-	find . -type f -name '*.md' -not \( -path './backend/target/*' -o -path '*/node_modules/*' \) -print0 | xargs -0 -- markdownlint
+	find . \
+	  -path './backend/target' -prune -o \
+	  -path './target' -prune -o \
+	  -path './.node_modules' -prune -o \
+	  -path '*/node_modules' -prune -o \
+	  -type f -name '*.md' -print0 | xargs -0 -- markdownlint
 
 markdownlint-docs:
 	markdownlint docs/repository-structure.md

--- a/docs/using-cloudflare-dns-with-opentofu.md
+++ b/docs/using-cloudflare-dns-with-opentofu.md
@@ -127,11 +127,11 @@ infra/
 
 - **`provider.tf`** – Sets Cloudflare provider and auth via variables.
 - **`variables.tf`** – Defines `dns_records`, `cloudflare_zone_id`, etc.
-- **`main.tf`** – Contains `cloudflare_zone` and `cloudflare_record` blocks
-  (static or dynamic).
+- **`main.tf`** – Contains `cloudflare_zone` and `cloudflare_record`
+  blocks (static or dynamic).
 - **`outputs.tf`** – Outputs useful values like `name_servers`.
-- **`terraform.tfvars`** – Specifies your actual values: zone name, token,
-  record definitions.
+- **`terraform.tfvars`** – Specifies concrete values: zone name, token,
+  and record definitions.
 
 ## 7. Workflow Quick Hit List
 
@@ -144,11 +144,13 @@ infra/
 
 ## Additional Levers & Advanced Practices
 
-- Refer to the Filador blog for integrating DNS, WAF, mTLS, Pages—all with
-  OpenTofu and Cloudflare. It offers rich sample code for elevated use cases.
+- Refer to the [Filador blog](https://filador.com/blog) for integrating DNS,
+  WAF, and Pages with OpenTofu and Cloudflare. Provide sample code references.
 
-- Cloudflare’s Terraform provider supports advanced modularisation. Use the
-  module registry and example repos for better modular design.
+- Cloudflare’s Terraform provider supports advanced modularization. Use the
+  [module registry](https://registry.terraform.io/providers/cloudflare/cloudflare/latest)
+  and [example repositories](https://github.com/cloudflare/terraform-examples)
+  for stronger modular design.
 
 ### Summary Table
 


### PR DESCRIPTION
## Summary
- document single‑core performance, update memory units, and switch Depot links to HTTPS
- clarify builder selection and deployment steps in CI/CD pipeline guide
- tighten Cloudflare DNS guide wording and linting script

## Testing
- `make fmt`
- `make lint`
- `make markdownlint`
- `make test` *(fails: The `npm ci` command can only install with an existing package-lock.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b625af9ae083229a7bcd96b46ad92b