### PR TITLE
Polish docs from review feedback

### DIFF
--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -488,7 +488,7 @@ metadata:
   annotations:
     # --- ExternalDNS Annotations ---
     # Specifies the desired DNS hostname. This is the primary trigger.
-    external-dns.alpha.kubernetes.io/hostname: nginx.your-domain.com.
+    external-dns.alpha.kubernetes.io/hostname: nginx.your-domain.com
     
     # Overrides the default proxy setting for this specific record.
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"
@@ -583,9 +583,14 @@ the status of each component in the workflow.
 # Check the status of all Kustomizations, watch for updates
 flux get kustomizations --watch
 
+# Force reconciliation to ensure the latest manifests are applied
+flux reconcile kustomization external-dns --with-source
+
 # Check the status of the ExternalDNS HelmRelease
 flux get helmrelease external-dns -n external-dns
 
+# Inspect the resulting Ingress resource
+kubectl get ingress nginx-ingress -n default -o wide
 ```
 
 A `READY` status of `True` indicates success.19 2. **Inspect ExternalDNS

--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -584,7 +584,7 @@ the status of each component in the workflow.
 flux get kustomizations --watch
 
 # Force reconciliation to ensure the latest manifests are applied
-flux reconcile kustomization external-dns --with-source
+flux reconcile kustomization external-dns -n flux-system --with-source
 
 # Check the status of the ExternalDNS HelmRelease
 flux get helmrelease external-dns -n external-dns

--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -488,7 +488,7 @@ metadata:
   annotations:
     # --- ExternalDNS Annotations ---
     # Specifies the desired DNS hostname. This is the primary trigger.
-    external-dns.alpha.kubernetes.io/hostname: nginx.your-domain.com
+    external-dns.alpha.kubernetes.io/hostname: nginx.example.com
     
     # Overrides the default proxy setting for this specific record.
     external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"

--- a/docs/declarative-tls-guide.md
+++ b/docs/declarative-tls-guide.md
@@ -414,19 +414,23 @@ spec:
 
     # Production-grade settings for high availability
     replicaCount: 3
-    webhook:
-      replicaCount: 3
-    cainjector:
-      replicaCount: 3
-
-    # Resource requests and limits for stability
-    podResources:
+    resources:
       requests:
         cpu: 100m
         memory: 128Mi
       limits:
         cpu: 250m
         memory: 256Mi
+    webhook:
+      replicaCount: 3
+      resources:
+        requests: { cpu: 50m, memory: 64Mi }
+        limits:   { cpu: 200m, memory: 128Mi }
+    cainjector:
+      replicaCount: 3
+      resources:
+        requests: { cpu: 50m, memory: 64Mi }
+        limits:   { cpu: 200m, memory: 128Mi }
 
 ```
 

--- a/docs/declarative-tls-guide.md
+++ b/docs/declarative-tls-guide.md
@@ -436,6 +436,37 @@ spec:
 
 ```
 
+Define PodDisruptionBudgets for the webhook and cainjector when scaling above
+a single replica:
+
+```yaml
+# examples/pdb-cert-manager-webhook.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cert-manager-webhook-pdb
+  namespace: cert-manager
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: webhook
+      app.kubernetes.io/instance: cert-manager
+---
+# examples/pdb-cert-manager-cainjector.yaml
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: cert-manager-cainjector-pdb
+  namespace: cert-manager
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: cainjector
+      app.kubernetes.io/instance: cert-manager
+```
+
 ### 2.3 Deploying the Namecheap DNS-01 Webhook Solver
 
 Cert-manager's core distribution does not include a DNS-01 solver for

--- a/docs/declarative-tls-guide.md
+++ b/docs/declarative-tls-guide.md
@@ -431,6 +431,8 @@ spec:
       resources:
         requests: { cpu: 50m, memory: 64Mi }
         limits:   { cpu: 200m, memory: 128Mi }
+    # When replicaCount > 1, define PodDisruptionBudgets for webhook and cainjector
+    # to maintain availability during voluntary disruptions (drains/evictions).
 
 ```
 

--- a/docs/opentofu-hcl-syntax-guide.md
+++ b/docs/opentofu-hcl-syntax-guide.md
@@ -1,5 +1,5 @@
 
-# A Comprehensive Developer's Guide to HCL for OpenTofu
+# A comprehensive developer’s guide to HCL for OpenTofu
 
 ______________________________________________________________________
 
@@ -172,9 +172,6 @@ OpenTofu supports a range of data types for its values 10:
   - `bool`: A boolean value, either `true` or `false`.
 
 - **Complex (Collection) Types**:
-  - `list(...)`: An ordered sequence of values, identified by zero-based integer
-    indices, e.g., `["us-west-1a", "us-west-1c"]`.
-
   - `list(...)`: An ordered sequence of values, identified by zero-based
     integer indices, e.g., `["us-west-1a", "us-west-1c"]`.
 
@@ -191,11 +188,6 @@ OpenTofu supports a range of data types for its values 10:
     have different types.
 
 - **The Special** `null` **Value**:
-  - `null` is a special value that represents the absence or omission of a
-    value. Setting a resource argument to `null` is equivalent to not setting
-    it at all, causing OpenTofu to fall back to the argument's default value or
-    raise an error if it's a required argument.10
-
   - `null` is a special value that represents the absence or omission of a
     value. Setting a resource argument to `null` is equivalent to not setting
     it at all, causing OpenTofu to fall back to the argument's default value or
@@ -381,7 +373,7 @@ secondary, special-purpose dialect.
    departure from native HCL where these can be more dynamic.
 
 2. **The "Attributes as Blocks" Limitation**: Some resource types have a
-   special behavior where an argument can be specified using either argument
+   special behaviour where an argument can be specified using either argument
    syntax (`example = [...]`) or nested block syntax (`example {... }`). This
    feature, known as "attributes as blocks," is designed for readability in
    native HCL. However, due to the ambiguity it would create in JSON, this
@@ -415,7 +407,7 @@ ______________________________________________________________________
 
 This section provides a deep dive into each of the fundamental top-level blocks
 used in OpenTofu. It moves beyond basic syntax to cover their specific
-arguments, behaviors, advanced features, and best practices in detail.
+arguments, behaviours, advanced features, and best practices in detail.
 
 ### 2.1 resource: The Heart of Infrastructure Definition
 
@@ -444,7 +436,7 @@ resource. These arguments are primarily divided into two categories:
    include `ami` and `instance_type`.7
 
 2. **Meta-Arguments**: These are defined by the OpenTofu language itself and
-   can be used with any resource type to change its behavior. Key
+   can be used with any resource type to change its behaviour. Key
    meta-arguments include `count`, `for_each`, `provider`, `depends_on`, and
    `lifecycle`.7
 
@@ -486,13 +478,13 @@ features, often configured via nested blocks.
 
 - `timeouts` **Block**: For resources that involve long-running operations
   (like creating a large database), some providers expose a `timeouts` block.
-  This allows you to specify custom time limits for `create`, `update`, and
-  `delete` operations, overriding the provider's defaults.7
+  Custom time limits for `create`, `update`, and `delete` operations can be
+  specified, overriding the provider’s defaults.7
 
 - `removed` **Block**: Introduced to simplify refactoring, the `removed` block
-  allows you to decouple a resource from the OpenTofu state without destroying
-  the actual remote object. If you delete a resource from your configuration,
-  you can replace it with a `removed` block pointing to its address (e.g.,
+  decouples a resource from the OpenTofu state without destroying the actual
+  remote object. If a resource is deleted from the configuration, it can be
+  replaced with a `removed` block pointing to its address (e.g.,
   `removed { from = aws_instance.web }`). On the next apply, OpenTofu will
   remove the resource from its state file but leave the real infrastructure
   intact.7
@@ -507,7 +499,7 @@ features, often configured via nested blocks.
 
 ### 2.2 variable: Parameterizing Configurations
 
-Input variables are the parameters of an OpenTofu module, allowing its behavior
+Input variables are the parameters of an OpenTofu module, allowing its behaviour
 to be customized without modifying its source code. They are analogous to
 function arguments in traditional programming.11 Each input variable is
 declared using a
@@ -518,7 +510,7 @@ declared using a
 
 The basic syntax is `variable "<NAME>" {... }`, where `<NAME>` is the unique
 name for the variable within the module.11 The block body can contain several
-arguments to define the variable's behavior:
+arguments to define the variable's behaviour:
 
 - `type`: This argument enforces type safety by restricting the type of value
   that can be assigned to the variable. While optional, specifying a type is a
@@ -638,7 +630,7 @@ The syntax is `data "<PROVIDER>_<TYPE>" "<NAME>" {... }`.25
   For example, a data source for an AWS AMI might accept filters for the AMI
   name or tags.25
 
-A key aspect of data source behavior is its evaluation timing. OpenTofu
+A key aspect of data source behaviour is its evaluation timing. OpenTofu
 attempts to read data sources during the `plan` phase. However, if any of a
 data source's arguments depend on a value that is not yet known (i.e., a
 "computed value" from a resource that has not been created yet), the reading of
@@ -687,7 +679,7 @@ themselves clean and readable.13
 
 ### 2.6 provider and terraform Blocks: Configuration Metadata
 
-These two blocks are used to configure OpenTofu's own behavior and its
+These two blocks are used to configure OpenTofu's own behaviour and its
 interaction with providers, rather than defining infrastructure resources
 directly.
 
@@ -701,7 +693,7 @@ This top-level block configures core OpenTofu settings.
 - `required_providers`: This nested block is the modern and mandatory way to
   declare all providers used by the module. For each provider, you must specify
   its `source` (e.g., `"hashicorp/aws"`) and a `version` constraint (e.g.,
-  `"~> 5.0"`). This practice is critical for ensuring predictable behavior by
+  `"~> 5.0"`). This practice is critical for ensuring predictable behaviour by
   preventing providers from being upgraded unexpectedly to a new version with
   breaking changes.13
 
@@ -799,11 +791,11 @@ resource "aws_instance" "server" {
 
 In this scenario, OpenTofu associates each instance with its numeric index:
 
-- `aws_instance.server` is tied to `"subnet-abc"`.
+- `aws_instance.server[0]` is tied to `"subnet-abc"`.
 
-- `aws_instance.server` is tied to `"subnet-def"`.
+- `aws_instance.server[1]` is tied to `"subnet-def"`.
 
-- `aws_instance.server` is tied to `"subnet-ghi"`.
+- `aws_instance.server[2]` is tied to `"subnet-ghi"`.
 
 The problem arises if an element is removed from the middle of the `subnet_ids`
 list. If `"subnet-def"` is removed, the list becomes
@@ -818,8 +810,8 @@ evaluates the `subnet_id` for each instance:
 
 The result is that OpenTofu plans to **change** the subnet for the instance at
 index 1 (from `subnet-def` to `subnet-ghi`) and **destroy** the instance at
-index 2. This is often not the desired behavior; the user likely intended only
-to destroy the instance associated with `subnet-def`. This re-indexing behavior
+index 2. This is often not the desired behaviour; the user likely intended only
+to destroy the instance associated with `subnet-def`. This re-indexing behaviour
 makes `count` fragile for managing dynamic collections.2
 
 #### The `for_each` Meta-Argument
@@ -991,7 +983,7 @@ are particularly essential for developers:
 - **Lifecycle Functions**:
   - `timestamp()`: Returns the current time.
 
-  - uuid(): Generates a random UUID.
+  - `uuid()`: Generates a random UUID.
 
     Caution: These functions are "impure," meaning their result changes on
     every run. Using them directly in resource arguments will cause the
@@ -1094,7 +1086,7 @@ ______________________________________________________________________
 ## Section 4: Troubleshooting: Pitfalls, Gotchas, and Error Resolution
 
 Writing HCL is an iterative process, and encountering errors or unexpected
-behavior is a natural part of development. This section provides a practical
+behaviour is a natural part of development. This section provides a practical
 guide to the common challenges, anti-patterns, and error messages that
 developers face when working with OpenTofu.
 
@@ -1130,7 +1122,7 @@ anti-patterns that lead to brittle, insecure, or unmaintainable configurations.
 
 #### State Management
 
-- **Using Local State**: The default behavior of storing the state file locally
+- **Using Local State**: The default behaviour of storing the state file locally
   (`terraform.tfstate`) is only suitable for experimentation. For any
   collaborative or production work, it is a significant anti-pattern. Local
   state makes collaboration impossible, risks accidental deletion, and can lead
@@ -1228,9 +1220,8 @@ number), and the context (e.g., the specific resource or module that failed).
     caused by a simple typo in a variable or resource reference (e.g.,
     `var.iamge_id` instead of `var.image_id`). It can also occur when trying to
     reference an instance of a resource created with `count` or `for_each`
-    without providing its index or key (e.g., trying to use
-    `aws_instance.server.id` when it should be `aws_instance.server.id` or
-    `aws_instance.server["key"].id`).30
+    without providing its index or key (e.g., `aws_instance.server[0].id` for
+    `count`, or `aws_instance.server["key"].id` for `for_each`).30
 
   - **Recommended Solution**: Carefully check the spelling of the reference.
     Ensure that you are using the correct index `[...]` or key `["..."]` syntax

--- a/docs/opentofu-hcl-syntax-guide.md
+++ b/docs/opentofu-hcl-syntax-guide.md
@@ -960,9 +960,6 @@ are particularly essential for developers:
   - `jsonencode(value)`: Encodes an HCL value into a JSON string. Essential for
     embedding structured data into resource arguments that expect a JSON string.
 
-  - `jsonencode(value)`: Encodes an HCL value into a JSON string. Essential for
-    embedding structured data into resource arguments that expect a JSON string.
-
   - `jsondecode(string)`: Parses a JSON string and returns the corresponding
     HCL value.
 
@@ -981,17 +978,9 @@ are particularly essential for developers:
 - **Type Conversion**:
   - `tostring(value)`, `tonumber(value)`, `tolist(value)`, `toset(value)`:
     Explicitly convert a value to a different type. Useful for resolving
-    conditional type inconsistencies or normalizing module outputs.
-
-  - `tostring(value)`, `tonumber(value)`, `tolist(value)`, `toset(value)`:
-    Explicitly convert a value to a different type. Useful for resolving
-    conditional type inconsistencies or normalizing module outputs.
+    conditional type inconsistencies or normalising module outputs.
 
 - **Error Handling**:
-  - `try(expr1, expr2,...)`: Evaluates expressions in order and returns the
-    result of the first one that succeeds without error. Useful for handling
-    optional attributes in complex objects.
-
   - `try(expr1, expr2,...)`: Evaluates expressions in order and returns the
     result of the first one that succeeds without error. Useful for handling
     optional attributes in complex objects.
@@ -1032,7 +1021,7 @@ of operations for creating, updating, and destroying resources.
   In these "hidden dependency" scenarios, the `depends_on` meta-argument can be
   used to create an explicit dependency.19
 
-  - **Syntax**: `depends_on =`
+  - **Syntax**: `depends_on = [aws_iam_role_policy.example]`
 
   - **Pitfall**: `depends_on` should be used as a last resort. It creates a
     more rigid dependency that can lead to overly conservative plans, as
@@ -1268,12 +1257,6 @@ number), and the context (e.g., the specific resource or module that failed).
     type. For example, one branch returns a `string` and the other returns a
     `list(string)`.34
 
-  - **Likely Cause**: The two result expressions in a ternary conditional
-    (`condition? true_val : false_val`) evaluate to values of incompatible
-    types, and OpenTofu cannot automatically convert them to a single common
-    type. For example, one branch returns a `string` and the other returns a
-    `list(string)`.34
-
   - **Recommended Solution**: Be explicit about the desired type. Use type
     conversion functions like `tostring()`, `tolist()`, or `tomap()` on one or
     both branches of the conditional to ensure they return a consistent type.
@@ -1281,14 +1264,6 @@ number), and the context (e.g., the specific resource or module that failed).
 - **Error:** `Error: Provider instance not present`
   - **Likely Cause**: This error frequently occurs when using `for_each` on both
     a `provider` block (with `alias`) and a `resource` block that uses it,
-    especially if they iterate over the same collection. If an item is removed
-    from the collection, OpenTofu removes both the resource instance *and* its
-    corresponding provider configuration from the plan simultaneously. When it
-    then tries to destroy the resource, it cannot find the provider instance it
-    needs to perform the deletion.44
-
-  - **Likely Cause**: This error frequently occurs when using `for_each` on
-    both a `provider` block (with `alias`) and a `resource` block that uses it,
     especially if they iterate over the same collection. If an item is removed
     from the collection, OpenTofu removes both the resource instance *and* its
     corresponding provider configuration from the plan simultaneously. When it
@@ -1316,7 +1291,7 @@ Table 4.1: Common HCL Parsing and Planning Errors
 
 | Error Message Snippet                 | Likely Cause(s)                                                                                                                           | Recommended Solution(s)                                                                                                         | Relevant Sources |
 | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- | ---------------- |
-| Unresolved reference                  | Typo in a reference; missing index/key for a count/for_each resource.                                                                     | Correct the typo. Add the appropriate index (e.g., ``) or key (e.g., ["web"]) to the reference.                                 | 30               |
+| Unresolved reference                  | Typo in a reference; missing index/key for a count/for_each resource.                                                                     | Correct the typo. Add the appropriate index (e.g., `[0]`) or key (e.g., `["web"]`) to the reference.                                 | 30               |
 | Inconsistent conditional result types | The true and false branches of a ternary operator (? :) return values of incompatible types.                                              | Use explicit type conversion functions (tostring, tolist, etc.) on the results to ensure they are the same type.                | 34               |
 | Provider instance not present         | A resource's provider configuration was removed from the plan at the same time as the resource itself, often when using for_each on both. | Decouple the resource and provider lifecycles. Ensure the provider configuration persists for the destroy operation.            | 44               |
 | checksums… do not match               | The downloaded provider package does not match the trusted checksum in .terraform.lock.hcl.                                               | Verify provider source. If the change is intentional, run tofu init -upgrade. Use tofu providers lock for multi-platform teams. | 42               |

--- a/docs/opentofu-hcl-syntax-guide.md
+++ b/docs/opentofu-hcl-syntax-guide.md
@@ -978,7 +978,7 @@ are particularly essential for developers:
 - **Type Conversion**:
   - `tostring(value)`, `tonumber(value)`, `tolist(value)`, `toset(value)`:
     Explicitly convert a value to a different type. Useful for resolving
-    conditional type inconsistencies or normalising module outputs.
+    conditional type inconsistencies or normalizing module outputs.
 
 - **Error Handling**:
   - `try(expr1, expr2,...)`: Evaluates expressions in order and returns the

--- a/docs/opentofu-hcl-syntax-guide.md
+++ b/docs/opentofu-hcl-syntax-guide.md
@@ -1,4 +1,3 @@
-
 # A comprehensive developer’s guide to HCL for OpenTofu
 
 ______________________________________________________________________

--- a/docs/opentofu-module-unit-testing-guide.md
+++ b/docs/opentofu-module-unit-testing-guide.md
@@ -794,7 +794,7 @@ COMMAND=$(jq -r \
 
 # Assert that the command is what we expect
 EXPECTED_COMMAND="echo hello-world > /tmp/message.txt"
-if; then
+if [ "$COMMAND" != "$EXPECTED_COMMAND" ]; then
   echo "Assertion failed!"
   echo "Expected: $EXPECTED_COMMAND"
   echo "Got:      $COMMAND"

--- a/docs/opentofu-module-unit-testing-guide.md
+++ b/docs/opentofu-module-unit-testing-guide.md
@@ -938,7 +938,7 @@ direct comparison to aid in this decision-making process.
 | Test Scope     | Excels at plan-based unit tests. Can perform integration tests with command=apply.21                      | Excels at integration and E2E tests. Can perform plan-based unit tests, but it's less common and more verbose.26                      |
 | Mocking        | Strong, built-in support for mocking providers and overriding resources, data, and modules.24             | No built-in IaC mocking. Relies on deploying real resources or requires complex, custom Go-based mocking of cloud provider SDKs.      |
 | Setup          | No extra dependencies beyond the OpenTofu binary itself.21                                                | Requires a full Go development environment installation and dependency management via go mod.48                                       |
-| Flexibility    | Limited by HCL's declarative nature. Complex logic or external API interactions require helper modules.21 | Highly flexible. Can perform any action possible in Go: complex logic, custom API calls, file manipulation, database queries, etc..49 |
+| Flexibility    | Limited by HCL's declarative nature. Complex logic or external API interactions require helper modules.21 | Highly flexible. Can perform any action possible in Go: complex logic, custom API calls, file manipulation, database queries, etc.49 |
 | Ecosystem      | Fully integrated into the OpenTofu CLI. Part of the core tool.                                            | Large library of helper functions for AWS, GCP, Azure, Kubernetes, Docker, SSH, and more, simplifying common validation tasks.2       |
 | Learning Curve | Low for existing OpenTofu users; the syntax is the same.23                                                | Steeper, requires proficiency in Go, its testing packages, and the Terratest library itself.49                                        |
 
@@ -979,10 +979,6 @@ A comprehensive module repository should be organized as follows:
     module. For complex modules, it may primarily contain calls to nested
     modules.58
 
-  - `main.tf`: Contains the primary logic and resource definitions of the
-    module. For complex modules, it may primarily contain calls to nested
-    modules.58
-
   - `variables.tf`: Contains all input variable declarations for the module.
 
   - `outputs.tf`: Contains all output value declarations.
@@ -999,10 +995,6 @@ A comprehensive module repository should be organized as follows:
 - `examples/` **Directory**:
   - This directory should contain one or more subdirectories, each demonstrating
     a specific use case of the module.57
-
-  - This directory should contain one or more subdirectories, each
-    demonstrating a specific use case of the module.57
-
   - These examples serve as excellent documentation for consumers of the module
     and can also be used as test fixtures for integration tests.58
 
@@ -1022,11 +1014,6 @@ A comprehensive module repository should be organized as follows:
     components should be structured as nested modules within this directory.57
     This pattern allows for composition, where advanced users can consume the
     smaller components directly.
-
-  - If the module is complex and composed of smaller, reusable components,
-    these components should be structured as nested modules within this
-    directory.57 This pattern allows for composition, where advanced users can
-    consume the smaller components directly.
 
 Adhering to this structure makes modules predictable and easy to work with,
 fostering better collaboration and maintainability.57

--- a/docs/opentofu-module-unit-testing-guide.md
+++ b/docs/opentofu-module-unit-testing-guide.md
@@ -777,7 +777,7 @@ external script.
 
 ```bash
 #!/bin/bash
-set -e
+set -Eeuo pipefail
 
 # Generate the plan as JSON
 tofu plan -var="message=hello-world" -out=tfplan.binary

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -416,10 +416,12 @@ mappings under `secretEnvFromKeys`. Cross-field rules in
 `values.schema.json` enforce this wiring by requiring `existingSecretName`
 whenever `secretEnvFromKeys` is populated. The chart defaults
 `allowMissingSecret` to `true` for `helm template` (maps to `optional: true`
-on `envFrom.secretRef`). Set it to `false` in production to fail rendering when
-the Secret is absent.
+on `envFrom.secretRef`). Set it to `false` in production to fail rendering
+when the Secret is absent. The following snippets show the resulting
+`envFrom.secretRef` for both values:
 
 ```yaml
+# allowMissingSecret: true (default)
 apiVersion: apps/v1
 kind: Deployment
 spec:
@@ -430,11 +432,23 @@ spec:
           envFrom:
             - secretRef:
                 name: app-secrets
-                optional: true   # allowMissingSecret: true (default)
+                optional: true
 ```
 
-In production, render with `allowMissingSecret: false` so the chart fails when
-`app-secrets` is absent and the resulting `optional` flag is omitted or false.
+```yaml
+# allowMissingSecret: false (production)
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          envFrom:
+            - secretRef:
+                name: app-secrets
+                optional: false
+```
 
 > Note: In chart defaults, `ingress.enabled` is `false`. Enable it via the
 > Flux HelmRelease values (e.g., the production overlay) when exposing the API.

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -419,6 +419,23 @@ whenever `secretEnvFromKeys` is populated. The chart defaults
 on `envFrom.secretRef`). Set it to `false` in production to fail rendering when
 the Secret is absent.
 
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          envFrom:
+            - secretRef:
+                name: app-secrets
+                optional: true   # allowMissingSecret: true (default)
+```
+
+In production, render with `allowMissingSecret: false` so the chart fails when
+`app-secrets` is absent and the resulting `optional` flag is omitted or false.
+
 > Note: In chart defaults, `ingress.enabled` is `false`. Enable it via the
 > Flux HelmRelease values (e.g., the production overlay) when exposing the API.
 

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -415,8 +415,9 @@ Secret and reference them by setting `existingSecretName` and providing key
 mappings under `secretEnvFromKeys`. Cross-field rules in
 `values.schema.json` enforce this wiring by requiring `existingSecretName`
 whenever `secretEnvFromKeys` is populated. The chart defaults
-`allowMissingSecret` to `true` for `helm template`. Set it to `false` in
-production to fail rendering when the Secret is absent.
+`allowMissingSecret` to `true` for `helm template` (maps to `optional: true`
+on `envFrom.secretRef`). Set it to `false` in production to fail rendering when
+the Secret is absent.
 
 > Note: In chart defaults, `ingress.enabled` is `false`. Enable it via the
 > Flux HelmRelease values (e.g., the production overlay) when exposing the API.

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -412,11 +412,11 @@ Git—manage it with SOPS or an External Secrets operator. If enabled,
 
 `config` is for non‑secret settings. Place confidential keys in an external
 Secret and reference them by setting `existingSecretName` and providing key
-mappings under `secretEnvFromKeys`. Cross-field rules in `values.schema.json`
-enforce this wiring by requiring `existingSecretName` whenever
-`secretEnvFromKeys` is populated. Set `allowMissingSecret` to `false` to fail
-rendering if the referenced Secret is absent; it defaults to `true` so
-`helm template` can run without a cluster connection.
+mappings under `secretEnvFromKeys`. Cross-field rules in
+`values.schema.json` enforce this wiring by requiring `existingSecretName`
+whenever `secretEnvFromKeys` is populated. The chart defaults
+`allowMissingSecret` to `true` for `helm template`. Set it to `false` in
+production to fail rendering when the Secret is absent.
 
 > Note: In chart defaults, `ingress.enabled` is `false`. Enable it via the
 > Flux HelmRelease values (e.g., the production overlay) when exposing the API.

--- a/docs/srgn.md
+++ b/docs/srgn.md
@@ -631,11 +631,11 @@ invalid one, as `srgn` will helpfully list the valid options.[^9]
 | ----------------------- | ------------------------------------------------------------------------- | --------------------------------------------- |
 | class                   | Selects entire class definitions, from class to the end of the block.     | srgn --py 'class' 'MyClass'                   |
 | function                | Selects entire function definitions, from def to the end of the block.    | srgn --py 'function' 'my_func'                |
-| doc-strings             | Selects the content of docstrings ("""…""" or '''…''').                   | srgn --py 'doc-strings' 'TODO'                |
-| comments                | Selects the content of line comments (#…).                                | srgn --py 'comments' 'FIXME'                  |
+| doc-strings             | Selects the content of docstrings (triple-quoted strings).                | srgn --py 'doc-strings' 'TODO'                |
+| comments                | Selects the content of line comments (#...).                              | srgn --py 'comments' 'FIXME'                  |
 | strings                 | Selects the content of all string literals.                               | srgn --py 'strings' 'hardcoded-secret'        |
 | identifiers             | Selects language identifiers (variable names, function names, etc.).      | srgn --py 'identifiers' '^temp_\w+'           |
-| module-names-in-imports | Selects only the module names in import and from… import statements.      | srgn --py 'module-names-in-imports' 'old_lib' |
+| module-names-in-imports | Selects only module names in `import` and `from ... import` statements.   | srgn --py 'module-names-in-imports' 'old_lib' |
 | call                    | Selects entire function or method call expressions (e.g., foo(bar, baz)). | srgn --py 'call' '^print\('                   |
 
 ### A.[^3] Table: Rust Grammar Scopes (`--rust <SCOPE>` or `--rs <SCOPE>`)
@@ -643,16 +643,16 @@ invalid one, as `srgn` will helpfully list the valid options.[^9]
 | Scope Name                 | Description                                                    | Example Command                                        |
 | -------------------------- | -------------------------------------------------------------- | ------------------------------------------------------ |
 | unsafe                     | Selects unsafe blocks and unsafe function definitions.         | srgn --rs 'unsafe' '.'                                 |
-| comments                   | Selects the content of line (//) and block (/*…*/) comments.   | srgn --rs 'comments' 'HACK'                            |
+| comments                   | Selects line (`//`) and block (`/* ... */`) comments.   | srgn --rs 'comments' 'HACK'                            |
 | strings                    | Selects the content of all string literals.                    | srgn --rs 'strings' 'password'                         |
-| attribute                  | Selects the content of attributes (#[…] and #![…]).            | srgn --rs 'attribute' 'deprecated'                     |
+| attribute                  | Selects attributes (`#[...]` and `#![...]`).            | srgn --rs 'attribute' 'deprecated'                     |
 | names-in-uses-declarations | Selects only the crate/module paths within use statements.     | srgn --rs 'names-in-uses-declarations' 'old_crate'     |
 | pub-enum                   | Selects public enum definitions.                               | srgn --rs 'pub-enum' 'MyEnum'                          |
 | type-identifier            | Selects identifiers that refer to a type.                      | srgn --rs 'pub-enum' --rs 'type-identifier' 'Subgenre' |
 | struct                     | Selects struct definitions.                                    | srgn --rs 'struct' 'RequestPayload'                    |
 | impl                       | Selects impl blocks.                                           | srgn --rs 'impl' 'MyTrait for MyStruct'                |
 | fn                         | Selects function definitions.                                  | srgn --rs 'fn' 'main'                                  |
-| extern-crate               | Selects extern crate…; declarations.                           | srgn --rs 'extern-crate' 'libc'                        |
+| extern-crate               | Selects `extern crate ...;` declarations.                           | srgn --rs 'extern-crate' 'libc'                        |
 
 ## Works Cited
 


### PR DESCRIPTION
## Summary
- tidy DNS guide: drop stray FQDN dot and add Flux reconciliation checks
- align cert-manager HelmRelease with per-component resources
- clarify secret handling and various docs tables and examples

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68b68ba0a7a88322b786b2dbf95a4380

## Summary by Sourcery

Polish various documentation guides by removing duplicate content, correcting syntax and typos, refining examples and tables, and clarifying resource and secret handling configurations.

Documentation:
- Remove duplicate sections and refine example syntax in the OpenTofu HCL syntax guide, including JSON functions, type conversion, and error-handling blocks
- Rename `podResources` to `resources` and add CPU/memory requests and limits for webhook and cainjector in the declarative TLS guide
- Eliminate redundant entries and clean up formatting in the module unit testing guide, including table rows and directory structure descriptions
- Update srgn scope tables for Python and Rust to clarify patterns and normalize punctuation and code formatting
- Clarify `allowMissingSecret` defaults and production settings in the repository-structure guide’s secret handling section
- Fix stray trailing dot in ExternalDNS FQDN annotation and add Flux reconciliation and kubectl inspection commands in the declarative DNS guide