### PR TITLE
Tidy documentation references and sample configs

### DIFF
--- a/docs/ci-cd-container-pipeline-design.md
+++ b/docs/ci-cd-container-pipeline-design.md
@@ -156,7 +156,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-            context: .
+          context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -246,7 +246,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-            context: .
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -426,7 +426,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-            context: .
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -764,7 +764,6 @@ following matrix provides guidance on selecting a strategy.
 By adopting these principles, teams can build CI/CD pipelines that are not only
 powerful and efficient today but also flexible and resilient enough to adapt to
 the technological and business needs of tomorrow.
-
 
 [^1]: Publishing and installing a package with GitHub Actions - GitHub Docs,
 [https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions](https://docs.github.com/en/packages/managing-github-packages-using-github-actions-workflows/publishing-and-installing-a-package-with-github-actions)

--- a/docs/ci-cd-container-pipeline-design.md
+++ b/docs/ci-cd-container-pipeline-design.md
@@ -156,7 +156,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context:.
+            context: .
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
@@ -246,7 +246,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context:.
+            context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
@@ -426,7 +426,7 @@ jobs:
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
         with:
-          context:.
+            context: .
           platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/docs/cloud-native-ephemeral-previews.md
+++ b/docs/cloud-native-ephemeral-previews.md
@@ -1217,16 +1217,16 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Docker image
-        id: build-and-push
-        uses: docker/build-push-action@v5
-        with:
-          context:.
-          file:./Dockerfile # Path to the application's Dockerfile
-          push: true
-          tags: your-registry/wildside-app:${{ github.sha }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+        - name: Build and push Docker image
+          id: build-and-push
+          uses: docker/build-push-action@v5
+          with:
+            context: .
+            file:./Dockerfile # Path to the application's Dockerfile
+            push: true
+            tags: your-registry/wildside-app:${{ github.sha }}
+            cache-from: type=gha
+            cache-to: type=gha,mode=max
 ```
 
 This job uses official Docker actions to handle login, build, and push

--- a/docs/cloud-native-ephemeral-previews.md
+++ b/docs/cloud-native-ephemeral-previews.md
@@ -1222,7 +1222,7 @@ jobs:
           uses: docker/build-push-action@v5
           with:
             context: .
-            file:./Dockerfile # Path to the application's Dockerfile
+            file: ./Dockerfile # Path to the application's Dockerfile
             push: true
             tags: your-registry/wildside-app:${{ github.sha }}
             cache-from: type=gha

--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -619,8 +619,8 @@ the status of each component in the workflow.
    ownership record.
 
 4. **Confirm public DNS resolution:** Use a command-line tool like `dig` to
-   query a public DNS resolver and confirm the record resolves to the expected
-   IP address.
+   query a public DNS resolver and confirm that the record resolves to the
+   expected IP address.
 
 ```bash
 # Query for the A record

--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -460,7 +460,7 @@ spec:
     spec:
       containers:
       - name: nginx
-        image: nginx:latest
+        image: nginx:1.25.5
         ports:
         - containerPort: 80
 ---
@@ -618,9 +618,9 @@ the status of each component in the workflow.
    `CNAME` record has been created, along with its corresponding `TXT`
    ownership record.
 
-4. **Confirm public DNS resolution:** Use a command-line tool like `dig` to
-   query a public DNS resolver and confirm that the record resolves to the
-   expected IP address.
+4. **Confirm public DNS resolution:** A command-line tool such as `dig` can be
+   used to query a public DNS resolver and confirm that the record resolves to
+   the expected IP address.
 
 ```bash
 # Query for the A record

--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -32,7 +32,7 @@ establishes a Git repository as the single source of truth for the desired
 state of the entire system. An automated agent, or operator, running within the
 cluster ensures that the live state continuously converges to the state
 declared in Git, making infrastructure management version-controlled,
-auditable, and collaborative.[^3]
+auditable, and collaborative.[^2]
 
 ### 1.2 Synergistic Components of the Ecosystem
 
@@ -46,13 +46,13 @@ specific, well-defined role.
   state. It manages the lifecycle of containerized workloads and provides the
   resource primitives—primarily `Services` and `Ingresses`—that define how
   applications are networked and exposed. In this architecture, Kubernetes
-  resources become the declarative intent for public DNS records.[^6]
+  resources become the declarative intent for public DNS records.[^3]
 - **Cloudflare:** As the authoritative DNS provider and network edge,
   Cloudflare is the system’s “actuality” layer. It is responsible for resolving
   public DNS queries and, optionally, for providing security and performance
   services like DDoS mitigation and a Content Delivery Network (CDN) through
   its proxy feature. Its comprehensive REST API is the critical programmatic
-  interface that enables external automation.[^8]
+  interface that enables external automation.[^4]
 - **ExternalDNS:** This component is the crucial bridge between the Kubernetes
   cluster’s internal state and the external DNS provider. ExternalDNS runs as a
   controller within the cluster, continuously watching the Kubernetes API for
@@ -60,7 +60,7 @@ specific, well-defined role.
   for DNS management. Upon detecting a change, it translates the resource’s
   specifications into the appropriate API calls to configure records in
   Cloudflare, effectively making Kubernetes resources discoverable via public
-  DNS servers.[^6]
+  DNS servers.[^3]
 - **FluxCD:** FluxCD is the GitOps operator that automates the entire cluster
   management lifecycle. Its role extends beyond simple application deployment;
   it manages the desired state of all Kubernetes resources declaratively from a
@@ -74,7 +74,7 @@ specific, well-defined role.
   manage the Cloudflare DNS zone itself (e.g., `example.com`). This task is
   typically performed once or infrequently, establishing a clear separation
   between the stable, underlying infrastructure and the dynamic,
-  application-driven records managed by ExternalDNS.[^13]
+  application-driven records managed by ExternalDNS.[^5]
 
 This layered architecture establishes a powerful separation of concerns. The
 management of static, foundational infrastructure (the DNS zone) is handled by
@@ -105,21 +105,21 @@ orchestrated by the integrated components:
    specifies routing rules. Critically, they add specific annotations to this
    manifest, such as
    `external-dns.alpha.kubernetes.io/hostname: my-app.example.com`, to declare
-   the desired public DNS name.[^17]
+   the desired public DNS name.[^6]
 2. **Commit to Source of Truth:** The developer commits this `Ingress` manifest
    to a designated application configuration path within the GitOps repository
    and pushes the change.
 3. **Git Repository Reconciliation:** FluxCD’s `source-controller`, which is
    configured to monitor the Git repository, detects the new commit within its
-   configured interval.[^12] It fetches the latest revision and stores it as an
+   configured interval.[^7] It fetches the latest revision and stores it as an
    artifact within the cluster.
 4. **Cluster State Synchronization:** FluxCD’s `kustomize-controller`, which is
    subscribed to changes from the `source-controller`, detects the new
    artifact. It applies the `Ingress` manifest to the Kubernetes cluster,
-   creating the Ingress resource via the Kubernetes API server.[^12]
+   creating the Ingress resource via the Kubernetes API server.[^7]
 5. **DNS Controller Detection:** The ExternalDNS controller, which is
    continuously watching the Kubernetes API for changes to `Ingress` resources,
-   detects the creation of the new `Ingress`.[^7]
+   detects the creation of the new `Ingress`.[^8]
 6. **API-driven DNS Configuration:** ExternalDNS parses the annotations on the
    `Ingress` resource. It extracts the desired hostname (`my-app.example.com`)
    and identifies the target IP address from the `Ingress` object’s status
@@ -147,24 +147,24 @@ following checklist outlines the necessary components:
 
 - **Kubernetes Cluster:** A running Kubernetes cluster is required. For local
   development and testing, tools like `kind` are suitable. For production, a
-  managed Kubernetes service such as GKE, EKS, or AKS is recommended.[^2]
+  managed Kubernetes service such as GKE, EKS, or AKS is recommended.[^9]
 - **Cloudflare Account:** An active Cloudflare account is necessary, with a
-  domain already registered and onboarded.[^2]
+  domain already registered and onboarded.[^9]
 - **Git Provider Account:** A Git repository hosted on a provider like GitHub,
   GitLab, or Gitea is required to serve as the single source of truth for the
-  GitOps workflow.[^11]
+  GitOps workflow.[^10]
 - **Command-Line Tools:** The following CLI tools must be installed on the
   local administrative machine:
 - **kubectl:** The Kubernetes command-line tool for interacting with the
   cluster API.
-- **flux:** The CLI for bootstrapping and interacting with FluxCD.[^11]
-- **tofu:** The OpenTofu CLI for managing infrastructure as code.[^13]
+- **flux:** The CLI for bootstrapping and interacting with FluxCD.[^10]
+- **tofu:** The OpenTofu CLI for managing infrastructure as code.[^5]
 - **helm:** The Helm package manager CLI, useful for inspecting charts and
-  templating values.[^2]
+  templating values.[^9]
 
 Installation instructions for these tools are widely available in their
 official documentation. For example, the Flux CLI can be installed on Linux and
-macOS using a simple shell script.[^11]
+macOS using a simple shell script.[^10]
 
 ### 2.2 Configuring the Cloudflare Environment
 
@@ -182,13 +182,13 @@ Cloudflare. This is achieved by:
    point to the nameservers provided by Cloudflare.
 
 This change delegates DNS authority for the domain to Cloudflare, allowing its
-API to manage DNS records effectively.[^9]
+API to manage DNS records effectively.[^11]
 
 #### 2.2.2 Generating a Scoped API Token
 
 For security, it is imperative to use a narrowly-scoped API Token rather than
 the legacy Global API Key. API tokens adhere to the principle of least
-privilege, granting only the permissions necessary for a specific task.[^8]
+privilege, granting only the permissions necessary for a specific task.[^4]
 
 To create a token for ExternalDNS:
 
@@ -238,7 +238,7 @@ failures.[^1]
 
 With the prerequisites in place, the next step is to install FluxCD on the
 cluster and link it to the GitOps repository. The `flux bootstrap` command
-automates this entire process.[^11]
+automates this entire process.[^10]
 
 The bootstrap command installs the FluxCD controllers into the `flux-system`
 namespace and commits their manifests to the specified Git repository. It also
@@ -261,7 +261,7 @@ flux bootstrap github \
 
 This command will create a private repository named `my-gitops-repo` under the
 specified user’s account and configure Flux to monitor the
-`clusters/production` directory within that repository.[^12]
+`clusters/production` directory within that repository.[^7]
 
 The choice of authentication method between Flux and the Git provider—either a
 Personal Access Token (PAT) via HTTPS or an SSH deploy key—has important
@@ -273,13 +273,13 @@ commit changes back to the repository, a read-write key is necessary. This can
 be enabled during bootstrap by adding the `--read-write-key=true` flag. Making
 this decision upfront prevents the need to re-bootstrap or manually reconfigure
 credentials later, ensuring the system is architected for full-cycle automation
-from the start.[^20]
+from the start.[^12]
 
 Upon successful bootstrap, the Git repository will contain a directory
 structure similar to `clusters/production/flux-system/`, which holds the
 declarative state of the FluxCD installation itself. All subsequent cluster
 configurations, including the deployment of ExternalDNS, will be managed by
-adding YAML manifests to this repository.[^27]
+adding YAML manifests to this repository.[^13]
 
 ## Part 3: Phase II - Deploying and Configuring ExternalDNS via GitOps
 
@@ -295,7 +295,7 @@ The first step is to inform FluxCD where to find the ExternalDNS Helm chart.
 This is accomplished by creating a `HelmRepository` resource. This manifest
 tells Flux’s `source-controller` to periodically fetch the index from a
 specified Helm repository URL and make its charts available as artifacts within
-the cluster.[^6]
+the cluster.[^3]
 
 Create a file in the GitOps repository (e.g.,
 `infrastructure/sources/helm-repositories.yaml`) with the following content:
@@ -314,13 +314,13 @@ spec:
 
 Once this file is committed and pushed, FluxCD will apply it, making the charts
 from the `kubernetes-sigs` repository available for `HelmRelease` resources.
-The `bitnami` repository is another common source for the ExternalDNS chart.[^6]
+The `bitnami` repository is another common source for the ExternalDNS chart.[^3]
 
 ### 3.2 Crafting the ExternalDNS HelmRelease
 
 The `HelmRelease` is the core declarative manifest for a Helm deployment
 managed by FluxCD. It specifies the source chart, version, release name, and
-configuration values.[^6] This single YAML file encapsulates the entire desired
+configuration values.[^3] This single YAML file encapsulates the entire desired
 state of the ExternalDNS deployment.
 
 Create a file in the GitOps repository (e.g.,
@@ -390,22 +390,22 @@ This `HelmRelease` manifest contains several critical configuration points:
 - **Chart Specification:** It references the `external-dns` `HelmRepository`
   and specifies a semantic version range (`1.14.x`), allowing FluxCD to
   automatically apply patch updates while preventing breaking changes from
-  major version upgrades.[^6]
+  major version upgrades.[^3]
 - **Values Configuration:**
-- `provider: cloudflare`: Explicitly sets Cloudflare as the DNS provider.[^25]
+- `provider: cloudflare`: Explicitly sets Cloudflare as the DNS provider.[^14]
 - `cloudflare.secretName`: Points to the Kubernetes `Secret` created in Phase
-  I, decoupling the sensitive token from the declarative configuration.[^6]
+  I, decoupling the sensitive token from the declarative configuration.[^3]
 - `domainFilters`: This is a crucial security and safety feature. It constrains
   the controller to only manage records within the specified domains,
-  preventing it from accidentally modifying records in other zones.[^7]
+  preventing it from accidentally modifying records in other zones.[^8]
   - `policy: sync`: This setting authorises ExternalDNS to perform create,
     update, and delete operations. The alternative, `upsert-only`, would not
     remove DNS records when the corresponding Kubernetes resource is deleted,
-    leading to stale and potentially insecure records.[^31]
+    leading to stale and potentially insecure records.[^15]
 - `extraArgs`: This array allows for passing command-line arguments directly to
   the ExternalDNS container. Here, it is used to enable the Cloudflare proxy by
   default and to configure a high records-per-page value to avoid hitting
-  Cloudflare’s API rate limits.[^8]
+  Cloudflare’s API rate limits.[^4]
 - `txtOwnerId`: This is arguably the most important setting for operating
   ExternalDNS safely in any environment that is not trivially simple. When set,
   ExternalDNS creates an accompanying `TXT` record for every `A` or `CNAME`
@@ -438,7 +438,7 @@ The most common method for exposing web services in Kubernetes is through an
 trigger DNS automation.
 
 First, a sample application is deployed. The following manifests define a
-simple Nginx deployment and a `ClusterIP` service to expose it internally.[^2]
+simple Nginx deployment and a `ClusterIP` service to expose it internally.[^9]
 
 **Sample Application Manifest (**`nginx-app.yaml`**):**
 
@@ -521,16 +521,16 @@ spec:
 - `external-dns.alpha.kubernetes.io/hostname`: This is the essential annotation
   that signals to ExternalDNS that this `Ingress` should have a corresponding
   DNS record created. The value specifies the fully qualified domain name
-  (FQDN).[^17]
+  (FQDN).[^6]
 - `external-dns.alpha.kubernetes.io/cloudflare-proxied`: This annotation
   provides granular, per-resource control over Cloudflare’s proxy feature (the
   “orange cloud”). By setting it to `"true"` (as a string), this specific
   record will be proxied, regardless of the default setting in the
   `HelmRelease`. This empowers application developers to control network
   features like CDN and WAF directly from their application manifests, a
-  powerful example of “shifting left” infrastructure control.[^18]
+  powerful example of “shifting left” infrastructure control.[^16]
 - `external-dns.alpha.kubernetes.io/ttl`: This allows for setting a custom TTL
-  for the DNS record, overriding any provider defaults.[^32]
+  for the DNS record, overriding any provider defaults.[^17]
 
 When these manifests are committed to the GitOps repository, FluxCD applies
 them. ExternalDNS detects the new `Ingress` with the `hostname` annotation and
@@ -543,10 +543,10 @@ While `Ingress` resources are ideal for HTTP/S services, there are scenarios
 where DNS records are needed for other purposes, such as pointing a domain to a
 specific IP address not managed by an `Ingress`, or for non-HTTP services. For
 these cases, ExternalDNS provides a `DNSEndpoint` Custom Resource Definition
-(CRD).[^6]
+(CRD).[^3]
 
 To use this feature, the CRD must first be enabled in the ExternalDNS
-`HelmRelease` by setting `crd.create: true` in the `values` section.[^6]
+`HelmRelease` by setting `crd.create: true` in the `values` section.[^3]
 
 Once enabled, a `DNSEndpoint` resource can be created to define a DNS record
 declaratively:
@@ -572,7 +572,7 @@ spec:
 This manifest instructs ExternalDNS to create an `A` record for
 `static.example.com` pointing to the IP address `192.0.2.100`. This provides a
 flexible, Kubernetes-native way to manage any DNS record declaratively through
-the same GitOps workflow.[^6]
+the same GitOps workflow.[^3]
 
 ### 4.3 Verification and Validation Workflow
 
@@ -598,7 +598,7 @@ the status of each component in the workflow.
    kubectl get ingress nginx-ingress -n default -o wide
    ```
 
-   A `READY` status of `True` indicates success.[^19]
+   A `READY` status of `True` indicates success.[^18]
 
 2. **Inspect ExternalDNS Logs:** The logs of the ExternalDNS pod are the
    primary source for debugging its behaviour. They will show whether it has
@@ -611,16 +611,16 @@ the status of each component in the workflow.
    ```
 
    Look for log entries mentioning the creation or update of the desired DNS
-   record.[^23]
+   record.[^19]
 
 3. **Check Cloudflare dashboard:** Log in to the Cloudflare dashboard and
    navigate to the DNS records page for the domain. Verify that the new `A` or
    `CNAME` record has been created, along with its corresponding `TXT`
    ownership record.
 
-4. **Confirm public DNS resolution:** Use a command-line tool such as `dig` to
-   query a public DNS resolver and confirm that the record resolves correctly
-   to the expected IP address.
+4. **Confirm public DNS resolution:** Use a command-line tool like `dig` to
+   query a public DNS resolver and confirm the record resolves to the expected
+   IP address.
 
 ```bash
 # Query for the A record
@@ -628,8 +628,8 @@ dig A nginx.example.com +short
 
 ```
 
-The command should return the external IP address of your Kubernetes cluster’s
-Ingress Controller.[^33]
+The command should return the external IP address of the Kubernetes cluster's
+Ingress Controller.[^20]
 
 ## Part 5: Managing Foundational DNS with OpenTofu
 
@@ -669,7 +669,7 @@ provider "cloudflare" {
 This configuration specifies the Cloudflare provider and its version.
 Authentication is handled automatically if the `CLOUDFLARE_API_TOKEN`
 environment variable is set, which is the most secure method as it avoids
-hardcoding secrets in version-controlled files.[^13]
+hardcoding secrets in version-controlled files.[^5]
 
 ### 5.2 Managing the Cloudflare Zone as Code
 
@@ -716,7 +716,7 @@ resource "cloudflare_record" "spf" {
 
 This OpenTofu code declaratively manages the existence of the `example.com`
 zone and ensures that essential static records, such as those for email (MX,
-SPF), are always present and correctly configured.[^9]
+SPF), are always present and correctly configured.[^11]
 
 ### 5.3 Defining Responsibilities: OpenTofu vs. ExternalDNS
 
@@ -730,7 +730,7 @@ responsibilities within a modern engineering organisation.
 - The lifecycle of the Cloudflare DNS zone (`cloudflare_zone`).
 - Static, global DNS records that are not tied to specific Kubernetes
   workloads. This includes apex records (`@`), `www` redirects, and
-  email-related records (`MX`, `SPF`, `DKIM`, `DMARC`).[^9]
+  email-related records (`MX`, `SPF`, `DKIM`, `DMARC`).[^11]
 - Changes at this layer are typically infrequent, critical, and subject to a
   rigorous review process, for which OpenTofu’s `plan` and `apply` workflow is
   perfectly suited.
@@ -740,7 +740,7 @@ responsibilities within a modern engineering organisation.
 - `A` and `CNAME` records for services and applications deployed within the
   Kubernetes cluster.
 - The lifecycle of these records is directly tied to the lifecycle of the
-  corresponding Kubernetes `Ingress` or `Service` resource.[^7]
+  corresponding Kubernetes `Ingress` or `Service` resource.[^8]
 - Changes at this layer are frequent, automated, and self-service, enabling
   high development velocity.
 
@@ -773,7 +773,7 @@ practices.
   changes and mandate at least one review from a designated code owner. This
   enforces a four-eyes principle, ensuring that no single individual can push
   un-reviewed changes to the cluster, and creates a clear audit trail for every
-  modification.[^3]
+  modification.[^2]
 - **Encrypted Secret Management:** While Kubernetes Secrets are an improvement
   over plain text, their values are only Base64 encoded, not encrypted at rest
   within `etcd` by default. For a more robust security posture, secrets stored
@@ -784,7 +784,7 @@ practices.
   encrypted secret, and Flux’s `kustomize-controller` will decrypt it
   on-the-fly just before applying it to the cluster. This ensures that
   sensitive data like the Cloudflare API token remains encrypted end-to-end,
-  from the Git repository to the cluster.[^28]
+  from the Git repository to the cluster.[^21]
 - **API Rate Limiting:** Cloudflare imposes a global API rate limit of 1,200
   requests per five minutes for most accounts. In a large or highly dynamic
   cluster, a naive ExternalDNS configuration could easily exceed this limit,
@@ -793,7 +793,7 @@ practices.
   high value (e.g., 1000 or 5000) in the `HelmRelease`. This instructs
   ExternalDNS to fetch records from the Cloudflare API in larger batches,
   significantly reducing the total number of API calls required for
-  reconciliation.[^8]
+  reconciliation.[^4]
 
 ### 6.2 Troubleshooting Common Integration Pitfalls
 
@@ -813,7 +813,7 @@ troubleshooting is key to rapid resolution.
     - Authentication error. Look for `Invalid request headers (6003)`.
       Ensure the API token has `Zone:Read` and `DNS:Edit` permissions.
       Re-create the Kubernetes secret, avoiding invisible characters and
-      matching the expected secret key name (for example, `apiToken`).[^26]
+      matching the expected secret key name (for example, `apiToken`).[^22]
     - RBAC error. Inspect logs for permission denied when reading `Ingress` or
       `Service` resources. Ensure the `HelmRelease` sets `rbac.create=true` and
       that the `ClusterRole` grants the required permissions.
@@ -823,7 +823,7 @@ troubleshooting is key to rapid resolution.
   - Verify: `kubectl get helmrelease external-dns -n external-dns -o yaml`
   - Causes/Resolution:
     - Incorrect policy. The `policy` in the `HelmRelease` must be `sync`. If it
-      is `upsert-only`, ExternalDNS will not delete records.[^31]
+      is `upsert-only`, ExternalDNS will not delete records.[^15]
     - Ownership mismatch. If `txtOwnerId` changed since records were created,
       ExternalDNS will no longer recognize them as its own and will not delete
       them.
@@ -836,7 +836,7 @@ troubleshooting is key to rapid resolution.
       `--cloudflare-proxied=true` in `extraArgs` in the `HelmRelease`, or add
       the annotation
       `external-dns.alpha.kubernetes.io/cloudflare-proxied: "true"` (string) to
-      the relevant `Ingress` manifest.[^18]
+      the relevant `Ingress` manifest.[^16]
 
 - Symptom: Flux Kustomization is not ready
 
@@ -857,7 +857,7 @@ troubleshooting is key to rapid resolution.
   - Causes/Resolution:
     - Conflicting record. Cloudflare DNS does not apply a wildcard (`*`) to a
       hostname that already has another record (for example, `TXT`, `MX`).
-      Remove the conflicting record to allow the wildcard to take effect.[^39]
+      Remove the conflicting record to allow the wildcard to take effect.[^23]
 
 ### 6.3 Comparative Analysis: The GitOps Advantage
 
@@ -895,7 +895,7 @@ advantages over traditional DNS management paradigms.
   application manifests remain portable across different DNS backends. The
   security posture is improved by using narrowly-scoped, machine-to-machine API
   tokens and by removing the need for developers to have direct access to DNS
-  provider credentials.[^3] While the initial setup complexity is higher, the
+  provider credentials.[^2] While the initial setup complexity is higher, the
   long-term gains in efficiency, reliability, and security are substantial.
 
 ## Part 7: Conclusion and Future Outlook
@@ -940,7 +940,7 @@ open-source Kubernetes controller.
 `Ingress` resources, and when it finds one configured for TLS, it automatically
 communicates with a certificate authority like Let’s Encrypt to obtain a valid
 TLS certificate. It then stores this certificate in a Kubernetes `Secret` and
-configures the `Ingress` to use it, enabling HTTPS.[^3]
+configures the `Ingress` to use it, enabling HTTPS.[^2]
 
 By deploying `cert-manager` alongside ExternalDNS (also managed via a FluxCD
 `HelmRelease`), the entire application exposure pipeline becomes automated: a
@@ -955,77 +955,77 @@ declarative solution for modern application delivery on Kubernetes.
 [^1]: Automating DNS Management in Kubernetes with External-DNS …,
 [https://containerinfra.nl/blog/2024/10/09/automating-dns-management-in-kubernetes-with-external-dns-and-cloudflare/](https://containerinfra.nl/blog/2024/10/09/automating-dns-management-in-kubernetes-with-external-dns-and-cloudflare/)
 
-[^2]: Simplifying DNS Management with ExternalDNS in Kubernetes - Develeap,
-[https://www.develeap.com/Simplifying-DNS-Management-with-ExternalDNS-in-Kubernetes/](https://www.develeap.com/Simplifying-DNS-Management-with-ExternalDNS-in-Kubernetes/)
-
-[^3]: GitOps for Azure Kubernetes Service - Azure Architecture Center |
+[^2]: GitOps for Azure Kubernetes Service - Azure Architecture Center |
 Microsoft Learn,
 [https://learn.microsoft.com/en-us/azure/architecture/example-scenario/gitops-aks/gitops-blueprint-aks](https://learn.microsoft.com/en-us/azure/architecture/example-scenario/gitops-aks/gitops-blueprint-aks)
 
-[^6]: External DNS - Funky Penguin’s Geek Cookbook,
+[^3]: External DNS - Funky Penguin’s Geek Cookbook,
 <https://geek-cookbook.funkypenguin.co.nz/kubernetes/external-dns/>
 
-[^7]: Configure external DNS servers dynamically from Kubernetes resources -
-GitHub,
-[https://github.com/kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns)
-
-[^8]: external-dns/docs/tutorials/cloudflare.md (GitHub),
+[^4]: external-dns/docs/tutorials/cloudflare.md (GitHub),
 [https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md](https://github.com/kubernetes-sigs/external-dns/blob/master/docs/tutorials/cloudflare.md)
 
-[^9]: Onboard a domain · Cloudflare Fundamentals docs,
-[https://developers.cloudflare.com/fundamentals/manage-domains/add-site/](https://developers.cloudflare.com/fundamentals/manage-domains/add-site/)
-
-[^11]: What is Flux CD & How Does It Work? [Tutorial] - Spacelift,
-[https://spacelift.io/blog/fluxcd](https://spacelift.io/blog/fluxcd)
-
-[^12]: Get Started with Flux - Flux CD,
-[https://fluxcd.io/flux/get-started/](https://fluxcd.io/flux/get-started/)
-
-[^13]: Cloudflare Provider - OpenTofu Registry,
+[^5]: Cloudflare Provider - OpenTofu Registry,
 [https://search.opentofu.org/provider/opentofu/cloudflare/latest](https://search.opentofu.org/provider/opentofu/cloudflare/latest)
 
-[^17]: Automate DNS for Your Ingress: Kubernetes + Cloudflare + ExternalDNS | by
+[^6]: Automate DNS for Your Ingress: Kubernetes + Cloudflare + ExternalDNS | by
 Ritik Kesharwani | Jul, 2025 | AWS in Plain English,
 [https://aws.plainenglish.io/automate-dns-for-your-ingress-kubernetes-cloudflare-externaldns-133772cc46df](https://aws.plainenglish.io/automate-dns-for-your-ingress-kubernetes-cloudflare-externaldns-133772cc46df)
 
-[^18]: cloudflare and ingress-nginx : r/kubernetes - Reddit,
-[https://www.reddit.com/r/kubernetes/comments/z2vogg/cloudflare_and_ingressnginx/](https://www.reddit.com/r/kubernetes/comments/z2vogg/cloudflare_and_ingressnginx/)
+[^7]: Get Started with Flux - Flux CD,
+[https://fluxcd.io/flux/get-started/](https://fluxcd.io/flux/get-started/)
 
-[^19]: Kustomization - Flux CD,
-[https://fluxcd.io/flux/components/kustomize/kustomizations/](https://fluxcd.io/flux/components/kustomize/kustomizations/)
+[^8]: Configure external DNS servers dynamically from Kubernetes resources -
+GitHub,
+[https://github.com/kubernetes-sigs/external-dns](https://github.com/kubernetes-sigs/external-dns)
 
-[^20]: Flux bootstrap for Gitea - Flux CD,
+[^9]: Simplifying DNS Management with ExternalDNS in Kubernetes - Develeap,
+[https://www.develeap.com/Simplifying-DNS-Management-with-ExternalDNS-in-Kubernetes/](https://www.develeap.com/Simplifying-DNS-Management-with-ExternalDNS-in-Kubernetes/)
+
+[^10]: What is Flux CD & How Does It Work? [Tutorial] - Spacelift,
+[https://spacelift.io/blog/fluxcd](https://spacelift.io/blog/fluxcd)
+
+[^11]: Onboard a domain · Cloudflare Fundamentals docs,
+[https://developers.cloudflare.com/fundamentals/manage-domains/add-site/](https://developers.cloudflare.com/fundamentals/manage-domains/add-site/)
+
+[^12]: Flux bootstrap for Gitea - Flux CD,
 [https://fluxcd.io/flux/installation/bootstrap/gitea/](https://fluxcd.io/flux/installation/bootstrap/gitea/)
 
-[^23]: Manage your Cloudflare domains automatically with an Nginx Ingress
+[^13]: Managing Flux | Welcome to Nishanth’s Blog,
+[https://blog.nishanthkp.com/docs/devsecops/gitops/flux/managing-flux/](https://blog.nishanthkp.com/docs/devsecops/gitops/flux/managing-flux/)
+
+[^14]: Automatically set home-lab DNS records to Cloudflare using External DNS |
+by 楠 - Medium,
+[https://medium.com/@fawenyo/automatically-set-home-lab-dns-records-to-cloudflare-using-external-dns-d85eaff326be](https://medium.com/@fawenyo/automatically-set-home-lab-dns-records-to-cloudflare-using-external-dns-d85eaff326be)
+
+[^15]: Exposing Kubernetes Apps to the Internet with Cloudflare Tunnel …,
+[https://itnext.io/exposing-kubernetes-apps-to-the-internet-with-cloudflare-tunnel-ingress-controller-and-e30307c0fcb0](https://itnext.io/exposing-kubernetes-apps-to-the-internet-with-cloudflare-tunnel-ingress-controller-and-e30307c0fcb0)
+
+[^16]: cloudflare and ingress-nginx : r/kubernetes - Reddit,
+[https://www.reddit.com/r/kubernetes/comments/z2vogg/cloudflare_and_ingressnginx/](https://www.reddit.com/r/kubernetes/comments/z2vogg/cloudflare_and_ingressnginx/)
+
+[^17]: Add cloudflare-proxied annotation to service · Issue #3956 ·
+kubernetes-sigs/external-dns,
+[https://github.com/kubernetes-sigs/external-dns/issues/3956](https://github.com/kubernetes-sigs/external-dns/issues/3956)
+
+[^18]: Kustomization - Flux CD,
+[https://fluxcd.io/flux/components/kustomize/kustomizations/](https://fluxcd.io/flux/components/kustomize/kustomizations/)
+
+[^19]: Manage your Cloudflare domains automatically with an Nginx Ingress
 controller and External DNS, together with SSL Certificates through Cert
 Manager - Xavier Geerinck,
 <https://xaviergeerinck.com/2025/01/28/manage-your-cloudflare-domains-automatically-with-an-nginx-ingress-controller-and-external-dns-together-with-ssl-certificates-through-cert-manager/>
 
-[^25]: Automatically set home-lab DNS records to Cloudflare using External DNS |
-by 楠 - Medium,
-[https://medium.com/@fawenyo/automatically-set-home-lab-dns-records-to-cloudflare-using-external-dns-d85eaff326be](https://medium.com/@fawenyo/automatically-set-home-lab-dns-records-to-cloudflare-using-external-dns-d85eaff326be)
-
-[^26]: Cloudflare CF_API_TOKEN doesn’t work · Issue #4263 · kubernetes …,
-[https://github.com/kubernetes-sigs/external-dns/issues/4263](https://github.com/kubernetes-sigs/external-dns/issues/4263)
-
-[^27]: Managing Flux | Welcome to Nishanth’s Blog,
-[https://blog.nishanthkp.com/docs/devsecops/gitops/flux/managing-flux/](https://blog.nishanthkp.com/docs/devsecops/gitops/flux/managing-flux/)
-
-[^28]: External-DNS - Automated DNS Management for k3s Homelab - Kamil Błaż,
-[https://www.devkblaz.com/blog/external-dns/](https://www.devkblaz.com/blog/external-dns/)
-
-[^31]: Exposing Kubernetes Apps to the Internet with Cloudflare Tunnel …,
-[https://itnext.io/exposing-kubernetes-apps-to-the-internet-with-cloudflare-tunnel-ingress-controller-and-e30307c0fcb0](https://itnext.io/exposing-kubernetes-apps-to-the-internet-with-cloudflare-tunnel-ingress-controller-and-e30307c0fcb0)
-
-[^32]: Add cloudflare-proxied annotation to service · Issue #3956 ·
-kubernetes-sigs/external-dns,
-[https://github.com/kubernetes-sigs/external-dns/issues/3956](https://github.com/kubernetes-sigs/external-dns/issues/3956)
-
-[^33]: Automated DNS Record Management for Kubernetes Resources using
+[^20]: Automated DNS Record Management for Kubernetes Resources using
 external-dns and AWS Route53 - DEV Community,
 [https://dev.to/suin/automated-dns-record-management-for-kubernetes-resources-using-external-dns-and-aws-route53-cnm](https://dev.to/suin/automated-dns-record-management-for-kubernetes-resources-using-external-dns-and-aws-route53-cnm)
 
-[^39]: Comparative Analysis of GitOps vs. Traditional Infrastructure Management
+[^21]: External-DNS - Automated DNS Management for k3s Homelab - Kamil Błaż,
+[https://www.devkblaz.com/blog/external-dns/](https://www.devkblaz.com/blog/external-dns/)
+
+[^22]: Cloudflare CF_API_TOKEN doesn’t work · Issue #4263 · kubernetes …,
+[https://github.com/kubernetes-sigs/external-dns/issues/4263](https://github.com/kubernetes-sigs/external-dns/issues/4263)
+
+[^23]: Comparative Analysis of GitOps vs. Traditional Infrastructure Management
 Approaches,
 [https://www.researchgate.net/publication/388068285_Comparative_Analysis_of_GitOps_vs_Traditional_Infrastructure_Management_Approaches](https://www.researchgate.net/publication/388068285_Comparative_Analysis_of_GitOps_vs_Traditional_Infrastructure_Management_Approaches)

--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -618,13 +618,13 @@ the status of each component in the workflow.
    `CNAME` record has been created, along with its corresponding `TXT`
    ownership record.
 
-4. **Confirm public DNS resolution:** A command-line tool such as `dig` can be
-   used to query a public DNS resolver and confirm that the record resolves to
+4. **Confirm public DNS resolution:** A command-line tool such as `dig` can
+   query a well-known public DNS resolver to confirm that the record resolves to
    the expected IP address.
 
 ```bash
 # Query for the A record
-dig A nginx.example.com +short
+dig A nginx.example.com @1.1.1.1 +short
 
 ```
 

--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -398,7 +398,7 @@ This `HelmRelease` manifest contains several critical configuration points:
 - `domainFilters`: This is a crucial security and safety feature. It constrains
   the controller to only manage records within the specified domains,
   preventing it from accidentally modifying records in other zones.[^8]
-  - `policy: sync`: This setting authorises ExternalDNS to perform create,
+  - `policy: sync`: This setting authorizes ExternalDNS to perform create,
     update, and delete operations. The alternative, `upsert-only`, would not
     remove DNS records when the corresponding Kubernetes resource is deleted,
     leading to stale and potentially insecure records.[^15]

--- a/docs/declarative-dns-guide.md
+++ b/docs/declarative-dns-guide.md
@@ -353,7 +353,9 @@ spec:
   releaseName: external-dns
   targetNamespace: external-dns
   values:
-      # -- Role-Based Access Control (RBAC) configuration --
+    crd:
+      create: true
+    # -- Role-Based Access Control (RBAC) configuration --
     rbac:
       create: true
 
@@ -616,7 +618,7 @@ the status of each component in the workflow.
    `CNAME` record has been created, along with its corresponding `TXT`
    ownership record.
 
-4. **Confirm public DNS resolution:** Use a command-line tool like `dig` to
+4. **Confirm public DNS resolution:** Use a command-line tool such as `dig` to
    query a public DNS resolver and confirm that the record resolves correctly
    to the expected IP address.
 
@@ -627,7 +629,7 @@ dig A nginx.example.com +short
 ```
 
 The command should return the external IP address of your Kubernetes cluster’s
-ingress controller.[^33]
+Ingress Controller.[^33]
 
 ## Part 5: Managing Foundational DNS with OpenTofu
 

--- a/docs/declarative-tls-guide.md
+++ b/docs/declarative-tls-guide.md
@@ -89,7 +89,7 @@ which is the recommended approach.[^4]
 terraform {
   required_providers {
     digitalocean = {
-      source  = "digitalocean/digitalocean"
+      source  = "opentofu/digitalocean"
       version = "~> 2.0"
     }
     namecheap = {
@@ -1010,7 +1010,7 @@ delivery platform.
    [https://opentofu.org/docs/language/providers/](https://opentofu.org/docs/language/providers/)
 
 [^4]: Provider: DigitalOcean — OpenTofu Registry, accessed on 1 September 2025,
-   [https://search.opentofu.org/provider/opentofu/digitalocean/latest](https://search.opentofu.org/provider/opentofu/digitalocean/latest)
+   <https://registry.opentofu.org/providers/opentofu/digitalocean/latest>
 
 [^5]: digitalocean_kubernetes_cluster | Resources | digitalocean …, accessed on
    1 September 2025,

--- a/docs/declarative-tls-guide.md
+++ b/docs/declarative-tls-guide.md
@@ -5,8 +5,9 @@
 The modern cloud-native landscape, orchestrated by platforms like Kubernetes,
 demands a paradigm shift from imperative, manual operations to declarative,
 automated workflows. A foundational element of this shift, detailed in the
-complementary guide "Declarative DNS," is the automation of DNS management
-using a GitOps-centric architecture.[^1] This approach establishes a Git
+complementary guide [Declarative DNS](../declarative-dns-guide.md), is the
+automation of DNS management using a GitOps-centric architecture. This approach
+establishes a Git
 repository as the single source of truth (SSOT), with controllers like FluxCD
 and ExternalDNS continuously reconciling the cluster's state to match the
 declarative configurations committed to Git. This model successfully decouples
@@ -38,7 +39,7 @@ intervention.
 This solution leverages a synergistic stack of components, each with a
 well-defined role, to create a resilient and secure system. This report will
 provide a deep dive into the provisioning of the foundational infrastructure on
-Digital Ocean Kubernetes (DOKS) using OpenTofu, the secure deployment of the
+DigitalOcean Kubernetes (DOKS) using OpenTofu, the secure deployment of the
 TLS automation stack via FluxCD, the intricacies of integrating with a
 Namecheap-provided domain, and advanced strategies for overcoming
 provider-specific challenges to ensure operational excellence.
@@ -50,7 +51,7 @@ integrated system.
 | Component                          | Primary Role                   | Scope of Control                                                                    | Managed By                           |
 | ---------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------- | ------------------------------------ |
 | Kubernetes                         | Application Orchestration      | Manages the lifecycle of containers, Pods, Services, and Ingresses.                 | Platform/Application Teams           |
-| Digital Ocean                      | Cloud & IaaS Provider          | Hosts the DOKS cluster, VPC networking, and optional NAT Gateways.                  | OpenTofu                             |
+| DigitalOcean                      | Cloud & IaaS Provider          | Hosts the DOKS cluster, VPC networking, and optional NAT Gateways.                  | OpenTofu                             |
 | Namecheap                          | Domain Registrar & DNS         | Hosts the authoritative domain and provides an API for DNS record management.       | OpenTofu (Domain), Webhook (Records) |
 | OpenTofu                           | Infrastructure as Code Tool    | Provisions and manages the foundational DOKS cluster and Namecheap domain settings. | Platform Team                        |
 | FluxCD                             | GitOps Operator                | Synchronizes the entire Kubernetes cluster state with a Git repository.             | Platform Team                        |
@@ -134,7 +135,7 @@ The `client_ip` argument in the Namecheap provider configuration is
 particularly noteworthy, as it directly relates to a significant operational
 constraint that will be addressed later in this report.
 
-### 1.2 Provisioning the Digital Ocean Kubernetes (DOKS) Cluster
+### 1.2 Provisioning the DigitalOcean Kubernetes (DOKS) Cluster
 
 The DOKS cluster is the heart of the platform. Using the
 `digitalocean_kubernetes_cluster` resource, its entire configuration can be
@@ -240,7 +241,7 @@ like DOKS, where egress IPs are non-deterministic.
   be on the whitelist, causing all API calls from the webhook to fail until an
   operator manually intervenes to update the whitelist. This breaks the core
   principle of automation and makes any direct integration inherently brittle
-  and unsuitable for production.[^10]
+  and unsuitable for production.[^9]
 
 This constraint is the single most significant technical challenge in this
 architecture. A robust, production-grade solution _must_ incorporate a strategy
@@ -251,12 +252,12 @@ to mitigate this issue, which will be the focus of Part 5.
 While dynamic, application-specific DNS records will be managed by in-cluster
 controllers, foundational records (like those for email) or the nameserver
 delegation itself can be managed via OpenTofu using the
-`namecheap_domain_records` resource.[^11]
+`namecheap_domain_records` resource.[^10]
 
 A crucial detail of this resource is that the `record` and `nameservers`
 arguments are mutually exclusive. A single `namecheap_domain_records` resource
 block cannot be used to set both custom nameservers and other record types like
-`A` or `TXT` simultaneously.[^11] This is an important consideration for the DNS
+`A` or `TXT` simultaneously.[^10] This is an important consideration for the DNS
 delegation strategy discussed in Part 5, as it implies that managing the
 delegation will require a dedicated resource block separate from any other
 record management.
@@ -274,19 +275,19 @@ manifests stored in the Git repository and reconciled by FluxCD.[^1]
 The Namecheap API credentials are highly sensitive and must never be stored in
 plain text in the Git repository. Mozilla SOPS (Secrets OPerationS) is a
 powerful tool that integrates seamlessly with FluxCD to enable end-to-end
-encryption for secrets.[^12] The workflow ensures that secrets are encrypted
+encryption for secrets.[^11] The workflow ensures that secrets are encrypted
 before being committed to Git and are only decrypted by the FluxCD controller
-in-memory just before being applied to the cluster.[^12]
+in-memory just before being applied to the cluster.[^11]
 
 The SOPS workflow proceeds as follows:
 
 1. **Generate an Encryption Key:** A GPG key (or an alternative like Age) is
    generated locally. This key will be used to encrypt and decrypt the
-   secrets.[^13]
+   secrets.[^12]
 2. **Store the Decryption Key in the Cluster:** The private portion of the GPG
    key is stored in the Kubernetes cluster as a standard `Secret` resource,
    typically in the `flux-system` namespace. This allows the FluxCD
-   `kustomize-controller` to access it for decryption.[^12]
+   `kustomize-controller` to access it for decryption.[^11]
 
     ```bash
     # (Assuming GPG key is already generated)
@@ -344,22 +345,22 @@ The SOPS workflow proceeds as follows:
 
 This setup ensures that sensitive credentials remain encrypted at rest in Git
 and are only handled in plain text within the secure confines of the cluster's
-control plane.[^12]
+control plane.[^11]
 
 | Key in Secret | Description                                                   | Example Value                     |
 | ------------- | ------------------------------------------------------------- | --------------------------------- |
-| `api-key`     | The API Key generated from the Namecheap dashboard.           | `52b4c87ef7fd49cb96a915c0db68124` |
+| `api-key`     | The API key generated from the Namecheap dashboard.           | `<REDACTED_API_KEY>`              |
 | `api-user`    | The Namecheap account username, which serves as the API user. | `mynamecheapuser`                 |
 
 ### 2.2 Deploying cert-manager via HelmRelease
 
 FluxCD manages Helm chart deployments declaratively using the `HelmRepository`
 and `HelmRelease` custom resources. This approach treats Helm releases as
-version-controlled artifacts, enabling automated, repeatable deployments.[^14]
+version-controlled artifacts, enabling automated, repeatable deployments.[^13]
 
 First, a `HelmRepository` source is defined to tell FluxCD where to find the
 cert-manager charts. The official OCI registry provided by Jetstack is the
-recommended source.[^15]
+recommended source.[^14]
 
 `HelmRepository`**for cert-manager (**`infrastructure/sources/helm.yaml`**):**
 
@@ -380,7 +381,7 @@ Next, a `HelmRelease` manifest is created to deploy cert-manager. This manifest
 specifies the chart version, release configuration, and values that override
 the chart's defaults. For a production deployment, it is crucial to configure
 for high availability by increasing the replica counts for the controller and
-webhook components.[^16]
+webhook components.[^15]
 
 `HelmRelease`**for cert-manager
 (**`infrastructure/controllers/cert-manager.yaml`**):**
@@ -396,22 +397,20 @@ spec:
   chart:
     spec:
       chart: cert-manager
-      version: "v1.15.1" # Pin to a stable version
+      version: "v1.18.2" # Pin to a stable version (align with [^15]) ([cert-manager.io](https://cert-manager.io/docs/installation/helm/?utm_source=openai))
       sourceRef:
         kind: HelmRepository
         name: jetstack
         namespace: flux-system
   install:
+    crds:
+      enabled: true # cert-manager.io/docs/installation/helm/?utm_source=openai
     remediation:
       retries: 3
   upgrade:
     remediation:
       retries: 3
   values:
-    # This is critical for Helm-based installations
-    crds:
-      enabled: true
-
     # Production-grade settings for high availability
     replicaCount: 3
     resources:
@@ -482,12 +481,12 @@ Cert-manager's core distribution does not include a DNS-01 solver for
 Namecheap. To integrate with Namecheap, a third-party webhook solver is
 required. This webhook is an external service that cert-manager calls to
 fulfill the DNS-01 challenge by creating and deleting the necessary TXT records
-via the Namecheap API.[^17]
+via the Namecheap API.[^16]
 
 A critical security assessment of the available community-provided webhooks is
 necessary. The options available on public repositories like ArtifactHub and
 GitHub are often several years old, are not signed by their authors, and come
-from unverified publishers.[^18] Deploying an unmaintained and untrusted container
+from unverified publishers.[^17] Deploying an unmaintained and untrusted container
 image directly into a production cluster, especially one that handles API
 credentials, represents a significant supply chain security risk.
 
@@ -533,7 +532,7 @@ spec:
     # Ensure the webhook runs with multiple replicas for availability
     replicaCount: 2
     # The groupName must match what is configured in the ClusterIssuer
-    groupName: acme.your-company.com
+    groupName: acme.example.com
 
 ```
 
@@ -543,7 +542,7 @@ With the cert-manager controller and the Namecheap webhook deployed, the next
 step is to configure the resources that define how certificates will be issued.
 The `ClusterIssuer` resource is the central point of this configuration, acting
 as a certificate authority that can be used to sign certificate requests from
-any namespace in the cluster.[^19]
+any namespace in the cluster.[^18]
 
 ### 3.1 Crafting the Let's Encrypt `ClusterIssuer`
 
@@ -572,14 +571,14 @@ spec:
   acme:
     # The ACME server URL for Let's Encrypt's staging environment.
     server: https://acme-staging-v02.api.letsencrypt.org/directory
-    email: platform-eng@your-domain.com
+    email: platform-eng@example.com
     privateKeySecretRef:
       # Secret resource that will be used to store the ACME account's private key.
       name: letsencrypt-staging-account-key
     solvers:
       - dns01:
           webhook:
-            groupName: acme.your-company.com # Must match the groupName in the webhook's HelmRelease
+            groupName: acme.example.com # Must match the groupName in the webhook's HelmRelease
             solverName: namecheap
             config:
               apiKeySecretRef:
@@ -603,13 +602,13 @@ spec:
   acme:
     # The ACME server URL for Let's Encrypt's production environment.
     server: https://acme-v02.api.letsencrypt.org/directory
-    email: platform-eng@your-domain.com
+    email: platform-eng@example.com
     privateKeySecretRef:
       name: letsencrypt-production-account-key
     solvers:
       - dns01:
           webhook:
-            groupName: acme.your-company.com
+            groupName: acme.example.com
             solverName: namecheap
             config:
               apiKeySecretRef:
@@ -625,8 +624,8 @@ spec:
 
 The `solvers` block is the most critical part of the `ClusterIssuer`
 configuration. It instructs cert-manager on how to satisfy the ACME challenges
-required to prove domain ownership.[^20] For the Namecheap integration, the
-`dns01` solver is configured to use the deployed webhook.[^17].
+required to prove domain ownership.[^19] For the Namecheap integration, the
+`dns01` solver is configured to use the deployed webhook.[^16].
 
 - `dns01`: Specifies that the DNS-01 challenge type will be used. This involves
   creating a specific TXT record in the domain's DNS zone.
@@ -666,7 +665,7 @@ To enable automated TLS, two key sections are added to the Ingress manifest:
    `letsencrypt-production`).
 2. **TLS Block:** The `spec.tls` block defines which hosts on the Ingress
    should be secured and provides the name of the Kubernetes `Secret` where the
-   signed certificate and private key will be stored.[^21]
+   signed certificate and private key will be stored.[^20]
 
 **Example Ingress with TLS Automation (**`my-app/ingress.yaml`**):**
 
@@ -680,16 +679,16 @@ metadata:
     # This annotation triggers cert-manager
     cert-manager.io/cluster-issuer: letsencrypt-production
     # This annotation triggers ExternalDNS (from the complementary DNS solution)
-    external-dns.alpha.kubernetes.io/hostname: my-app.your-domain.com
+    external-dns.alpha.kubernetes.io/hostname: my-app.example.com
 spec:
   ingressClassName: nginx
   tls:
     - hosts:
-        - my-app.your-domain.com
+        - my-app.example.com
       # cert-manager will store the certificate in this secret
       secretName: my-app-tls-secret
   rules:
-    - host: "my-app.your-domain.com"
+    - host: "my-app.example.com"
       http:
         paths:
           - path: /
@@ -711,12 +710,12 @@ and begins the issuance process, creating the necessary `Certificate`,
 
 Wildcard certificates are invaluable for environments with dynamic, per-tenant
 subdomains or for simplifying the management of multiple services under a
-single domain. A single wildcard certificate for `*.your-domain.com` can secure
-any number of subdomains like `api.your-domain.com`,
-`dashboard.your-domain.com`, etc.
+single domain. A single wildcard certificate for `*.example.com` can secure
+any number of subdomains like `api.example.com`,
+`dashboard.example.com`, etc.
 
 A critical requirement from Let's Encrypt is that wildcard certificates can
-**only** be issued using the DNS-01 challenge method.[^22] The HTTP-01 challenge,
+**only** be issued using the DNS-01 challenge method.[^21] The HTTP-01 challenge,
 which involves serving a file from a web server, cannot prove control over an
 entire domain and is therefore not supported for wildcards. This makes the
 successful integration of the DNS-01 webhook solver a mandatory prerequisite
@@ -740,11 +739,11 @@ spec:
   tls:
     - hosts:
         # Specify the wildcard domain
-        - "*.apps.your-domain.com"
+        - "*.apps.example.com"
       secretName: wildcard-apps-tls-secret
   rules:
     # This rule is just an example; the certificate is valid for any subdomain
-    - host: "foo.apps.your-domain.com"
+    - host: "foo.apps.example.com"
       http:
         #... backend configuration
 
@@ -763,8 +762,8 @@ by inspecting the custom resources that cert-manager creates.
    kubectl describe certificate <cert-name> -n <namespace>
    ```
 
-   Look for a `Ready` condition with a status of `True` and an event of
-   `Certificate issued successfully`.[^23]
+   A `Ready` condition with status `True` and an event
+   `Certificate issued successfully` indicates success.[^22]
 
 2. **Check the **`CertificateRequest`**:** This resource represents a single
    attempt to obtain a certificate. A new one is created for each issuance or
@@ -783,7 +782,7 @@ by inspecting the custom resources that cert-manager creates.
    ```
 
    The output will list the associated `Challenge` resources and their current
-   state.[^24]
+   state.[^23]
 
 4. **Check the **`Challenge`**:** This is the most critical resource for
    debugging DNS-01 issues. It represents the specific ACME challenge (e.g.,
@@ -794,8 +793,8 @@ by inspecting the custom resources that cert-manager creates.
    kubectl describe challenge <challenge-name> -n <namespace>
    ```
 
-   Look for messages like `Presented the DNS01 challenge for domain...` or error
-   messages indicating API failures.[^24]
+   Messages such as `Presented the DNS01 challenge for domain…` or error
+   messages indicating API failures are informative.[^23]
 
 5. **Check the Webhook Logs:** The logs from the Namecheap webhook pod are the
    final source of truth for API interactions.
@@ -831,7 +830,7 @@ architecting solutions to inherent platform limitations.
   `cert-manager` namespace. These policies should enforce rules such as:
 
   - Allowing ingress to the webhook Service only from the Kubernetes API server
-    on TCP 443 (or the configured webhook Service port).[^25]
+    on TCP 443 (or the configured webhook Service port).[^24]
 - Allowing egress from the controller and webhook pods only to the Kubernetes
   API server and the required external endpoints (Let's Encrypt API and
   Namecheap API on TCP port 443).
@@ -846,14 +845,14 @@ architecting solutions to inherent platform limitations.
 
 A systematic approach to troubleshooting is key to minimizing downtime. The
 following table provides a guide for diagnosing common issues in the TLS
-issuance pipeline.[^24]
+issuance pipeline.[^23]
 
 <!-- markdownlint-disable MD013 -->
 
 | Symptom                                                                       | Diagnostic Command(s)                                                                                                                                                 | Likely Cause & Resolution                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `Certificate` is stuck in `Issuing` state for a long time.                    | `kubectl describe certificate <cert-name>` `kubectl describe order <order-name>`                                                                                      | **Stalled ACME Order:** The `Order` is likely waiting for a `Challenge` to complete. Use the `describe order` command to find the name of the pending `Challenge` resource and investigate it further.                                                                                                                                                                                                                                                                           |
-| `Challenge` fails with DNS propagation error.                                 | `kubectl describe challenge <challenge-name>` `kubectl logs -n cert-manager -l app.kubernetes.io/name=cert-manager-webhook-namecheap,app.kubernetes.io/instance=cert-manager` `dig TXT _acme-challenge.your-domain.com @8.8.8.8` | **Webhook API Failure:** Check the webhook logs for authentication errors (invalid credentials) or connection errors (IP not whitelisted). **Slow DNS Propagation:** The DNS provider may be slow to propagate the TXT record. Some webhooks allow configuring a longer propagation delay. **Incorrect Nameservers:** cert-manager's self-check may be failing. Consider configuring recursive nameservers for the controller via Helm values (`--dns01-recursive-nameservers`). |
+| `Challenge` fails with DNS propagation error.                                 | `kubectl describe challenge <challenge-name>` `kubectl logs -n cert-manager -l app.kubernetes.io/name=cert-manager-webhook-namecheap,app.kubernetes.io/instance=cert-manager` `dig TXT _acme-challenge.example.com @8.8.8.8` | **Webhook API Failure:** Check the webhook logs for authentication errors (invalid credentials) or connection errors (IP not whitelisted). **Slow DNS Propagation:** The DNS provider may be slow to propagate the TXT record. Some webhooks allow configuring a longer propagation delay. **Incorrect Nameservers:** cert-manager's self-check may be failing. Consider configuring recursive nameservers for the controller via Helm values (`--dns01-recursive-nameservers`). |
 | Webhook pod is in `CrashLoopBackOff`.                                         | `kubectl logs -n cert-manager <webhook-pod-name> --previous` `kubectl describe pod -n cert-manager <webhook-pod-name>`                                                | **Missing Secret:** The pod cannot find the Kubernetes secret containing the API credentials. Verify the secret exists in the correct namespace and its name matches the `ClusterIssuer` configuration. **RBAC Permissions:** The webhook's `ServiceAccount` may lack the necessary permissions to read secrets or interact with the Kubernetes API. Check the `ClusterRole` associated with it.                                                                                 |
 | `kubectl` commands fail with `x509: certificate signed by unknown authority`. | `kubectl get apiservice v1.webhook.cert-manager.io`                                                                                                                   | **Webhook Not Ready:** This is common immediately after installation. The cert-manager webhook needs time to generate its self-signed CA and inject it into the `APIService` resource. Wait a few minutes and retry. If it persists, the `cainjector` component may be failing.                                                                                                                                                                                                  |
 <!-- markdownlint-enable MD013 -->
@@ -885,7 +884,7 @@ strategies provide robust solutions to this problem.
 
 - **Concept:** This more nuanced strategy avoids the need for a static IP
   altogether. It leverages the fact that the DNS-01 challenge only requires
-  control over a specific TXT record: `_acme-challenge.your-domain.com`.
+  control over a specific TXT record: `_acme-challenge.example.com`.
   Instead of giving the Namecheap webhook control over the entire domain,
   authority for just this specific subdomain is delegated to a different, more
   API-friendly DNS provider that has native support in cert-manager (e.g.,
@@ -893,15 +892,15 @@ strategies provide robust solutions to this problem.
 - **Implementation:**
 
   1. **Create a DNS Zone:** In the secondary provider (e.g., DigitalOcean),
-     create a DNS zone for `your-domain.com`.
+     create a DNS zone for `example.com`.
   2. **Delegate with NS Records:** In Namecheap, using the
      `namecheap_domain_records` OpenTofu resource, create `NS` (nameserver)
      records for the hostname `_acme-challenge`, pointing to the nameservers of
      the secondary provider.
   3. **Configure solvers on one issuer:** Define multiple `dns01` solvers on a
      single `ClusterIssuer`, using a `selector` (for example,
-     `dnsZones: ["your-domain.com"]`) to route challenges for
-     `_acme-challenge.your-domain.com` to the DigitalOcean solver.
+     `dnsZones: ["example.com"]`) to route challenges for
+     `_acme-challenge.example.com` to the DigitalOcean solver.
   4. **Alternative:** Create two issuers and reference the intended issuer
      explicitly on each `Certificate`/Ingress via `cert-manager.io/cluster-issuer`.
 
@@ -915,7 +914,7 @@ strategies provide robust solutions to this problem.
               webhook: { ... Namecheap ... }
           - selector:
               dnsZones:
-                - your-domain.com
+                - example.com
             dns01:
               digitalocean:
                 tokenSecretRef:
@@ -956,14 +955,14 @@ approaches.
 
 The architecture detailed in this report successfully extends the principles of
 the GitOps-driven DNS solution to create a comprehensive, declarative, and
-fully automated system for managing the entire TLS lifecycle in a Digital Ocean
+fully automated system for managing the entire TLS lifecycle in a DigitalOcean
 Kubernetes environment. By integrating OpenTofu for foundational
 infrastructure, FluxCD as the GitOps reconciler, and cert-manager with a
 specialized webhook, this solution transforms certificate management from a
 manual, error-prone task into a seamless, reliable, and secure workflow.
 
 The primary benefits of this integrated approach are a direct reflection of the
-core tenets of GitOps 1:
+core tenets of GitOps:
 
 - **Velocity:** Developer teams are empowered to secure their applications
   through self-service, using familiar tools like Git and Kubernetes manifests.
@@ -1000,7 +999,8 @@ for a production environment. By implementing this strategy, the organization
 can achieve a truly automated, secure, and operationally excellent application
 delivery platform.
 
-[^1]: Kubernetes Dynamic DNS With Cloudflare
+[^1]: Kubernetes Dynamic DNS With Cloudflare — Cloudflare Blog, accessed on 1 September 2025,
+<https://blog.cloudflare.com/kubernetes-dynamic-dns-with-cloudflare/>
 
 [^2]: cert-manager/cert-manager: Automatically provision and manage TLS
    certificates in Kubernetes — GitHub, accessed on 1 September 2025,
@@ -1023,66 +1023,62 @@ delivery platform.
     2025,
     [https://doc.yunohost.org/admin/get_started/providers/registrar/namecheap/](https://doc.yunohost.org/admin/get_started/providers/registrar/namecheap/)
 
-[^8]: [www.namecheap.com](http://www.namecheap.com), accessed on 1 September
-    2025,
-    [https://www.namecheap.com/support/api/intro/](https://www.namecheap.com/support/api/intro/)
-
-  [^9]: Namecheap API introduction, accessed on 1 September 2025,
+[^8]: Namecheap API introduction, accessed on 1 September 2025,
     <https://www.namecheap.com/support/api/intro/>
 
-  [^10]: Enable Dynamic DNS for your domain — Namecheap Knowledgebase, accessed on 1 September 2025,
+[^9]: Enable Dynamic DNS for your domain — Namecheap Knowledgebase, accessed on 1 September 2025,
     <https://www.namecheap.com/support/knowledgebase/article.aspx/29/11/enable-dynamic-dns>
 
-[^11]: namecheap_domain_records | resources | namecheap/namecheap | Providers |
+[^10]: namecheap_domain_records | resources | namecheap/namecheap | Providers |
     OpenTofu and Terraform Registry — [Library.tf](http://Library.tf), accessed
     on 1 September 2025,
     [https://library.tf/providers/namecheap/namecheap/latest/docs/resources/domain_records](https://library.tf/providers/namecheap/namecheap/latest/docs/resources/domain_records)
 
-[^12]: Manage Kubernetes secrets with SOPS | Flux — Flux CD, accessed on 1
+[^11]: Manage Kubernetes secrets with SOPS | Flux — Flux CD, accessed on 1
     September 2025,
     [https://fluxcd.io/flux/guides/mozilla-sops/](https://fluxcd.io/flux/guides/mozilla-sops/)
 
-[^13]: Setting Up Flux CD in a Kubernetes Cluster with SOPS Encryption. — Medium,
+[^12]: Setting Up Flux CD in a Kubernetes Cluster with SOPS Encryption. — Medium,
     accessed on 1 September 2025,
     [https://medium.com/@deepakraajesh/setting-up-flux-cd-in-a-kubernetes-cluster-with-sops-encryption-bd72b2d0e468](https://medium.com/@deepakraajesh/setting-up-flux-cd-in-a-kubernetes-cluster-with-sops-encryption-bd72b2d0e468)
 
-[^14]: Manage Helm Releases — Flux CD, accessed on 1 September 2025,
+[^13]: Manage Helm Releases — Flux CD, accessed on 1 September 2025,
     [https://fluxcd.io/flux/guides/helmreleases/](https://fluxcd.io/flux/guides/helmreleases/)
 
-[^15]: Helm — cert-manager Documentation, accessed on 1 September 2025,
+[^14]: Helm — cert-manager Documentation, accessed on 1 September 2025,
     [https://cert-manager.io/docs/installation/helm/](https://cert-manager.io/docs/installation/helm/)
 
-[^16]: cert-manager 1.18.2 — Artifact Hub, accessed on 1 September 2025,
+[^15]: cert-manager 1.18.2 — Artifact Hub, accessed on 1 September 2025,
     [https://artifacthub.io/packages/helm/cert-manager/cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager)
 
-[^17]: Webhook — cert-manager Documentation, accessed on 1 September 2025,
+[^16]: Webhook — cert-manager Documentation, accessed on 1 September 2025,
     [https://cert-manager.io/docs/configuration/acme/dns01/webhook/](https://cert-manager.io/docs/configuration/acme/dns01/webhook/)
 
-[^18]: jamesgoodhouse/cert-manager-webhook-namecheap: A … — GitHub, accessed on
+[^17]: jamesgoodhouse/cert-manager-webhook-namecheap: A … — GitHub, accessed on
     1 September 2025,
     [https://github.com/jamesgoodhouse/cert-manager-webhook-namecheap](https://github.com/jamesgoodhouse/cert-manager-webhook-namecheap)
 
-[^19]: Issuer Configuration — cert-manager Documentation, accessed on 1 September
+[^18]: Issuer Configuration — cert-manager Documentation, accessed on 1 September
     2025,
     [https://cert-manager.io/docs/configuration/](https://cert-manager.io/docs/configuration/)
 
-[^20]: DNS01 — cert-manager Documentation, accessed on 1 September 2025,
+[^19]: DNS01 — cert-manager Documentation, accessed on 1 September 2025,
     [https://cert-manager.io/docs/configuration/acme/dns01/](https://cert-manager.io/docs/configuration/acme/dns01/)
 
-[^21]: Certificate resource — cert-manager Documentation, accessed on 1 September
+[^20]: Certificate resource — cert-manager Documentation, accessed on 1 September
     2025,
     [https://cert-manager.io/docs/usage/certificate/](https://cert-manager.io/docs/usage/certificate/)
 
-[^22]: DNS Domain Validation (dns-01) | Certify The Web Docs, accessed on 1
+[^21]: DNS Domain Validation (dns-01) | Certify The Web Docs, accessed on 1
     September 2025,
     [https://docs.certifytheweb.com/docs/dns/validation/](https://docs.certifytheweb.com/docs/dns/validation/)
 
-[^23]: Verifying the Installation — cert-manager Documentation, accessed on 1
+[^22]: Verifying the Installation — cert-manager Documentation, accessed on 1
     September 2025,
     [https://cert-manager.io/v1.6-docs/installation/verify/](https://cert-manager.io/v1.6-docs/installation/verify/)
 
-[^24]: Troubleshooting Issuing ACME Certificates — cert-manager Documentation,
+[^23]: Troubleshooting Issuing ACME Certificates — cert-manager Documentation,
     accessed on 1 September 2025,
     [https://cert-manager.io/v1.0-docs/faq/acme/](https://cert-manager.io/v1.0-docs/faq/acme/)
-[^25]: Best Practice — cert-manager Documentation, accessed on 1 September 2025,
+[^24]: Best Practice — cert-manager Documentation, accessed on 1 September 2025,
     [https://cert-manager.io/docs/installation/best-practice/](https://cert-manager.io/docs/installation/best-practice/)

--- a/docs/declarative-tls-guide.md
+++ b/docs/declarative-tls-guide.md
@@ -77,7 +77,7 @@ configuration of their respective providers. This is defined within a
 addresses, and version constraints to ensure predictable and repeatable
 deployments.[^3]
 
-It is a critical security best practice to manage API credentials outside of
+It is a critical security best practice to manage API credentials outside
 version-controlled configuration files. The DigitalOcean and Namecheap
 providers can be configured to read credentials from environment variables,
 which is the recommended approach.[^4]

--- a/docs/declarative-tls-guide.md
+++ b/docs/declarative-tls-guide.md
@@ -6,13 +6,13 @@ The modern cloud-native landscape, orchestrated by platforms like Kubernetes,
 demands a paradigm shift from imperative, manual operations to declarative,
 automated workflows. A foundational element of this shift, detailed in the
 complementary guide "Declarative DNS," is the automation of DNS management
-using a GitOps-centric architecture.1 This approach establishes a Git
+using a GitOps-centric architecture.[^1] This approach establishes a Git
 repository as the single source of truth (SSOT), with controllers like FluxCD
 and ExternalDNS continuously reconciling the cluster's state to match the
 declarative configurations committed to Git. This model successfully decouples
 application deployment from the once-manual process of creating public DNS
 records, dramatically increasing development velocity and operational
-reliability.1
+reliability.[^1]
 
 However, a publicly accessible endpoint is incomplete without robust security.
 The logical and necessary next step in this automation journey is to apply the
@@ -25,7 +25,7 @@ and untrusted by clients until a valid TLS certificate is in place.
 This report details a comprehensive, production-grade architecture for
 achieving "TLS-as-Code." By integrating cert-manager, the de-facto standard for
 certificate automation in Kubernetes, into the existing GitOps ecosystem, we
-can complete the application exposure pipeline.2 The architectural vision is to
+can complete the application exposure pipeline.[^2] The architectural vision is to
 enable a seamless, end-to-end workflow where a single
 
 `git push` of a standard Kubernetes Ingress manifest triggers a chain of
@@ -67,7 +67,7 @@ declaratively. OpenTofu, as the Infrastructure as Code (IaC) tool, is
 responsible for managing these long-lived, foundational resources. This ensures
 a clear separation of concerns between the underlying infrastructure managed by
 the platform team and the dynamic, in-cluster resources managed by the GitOps
-workflow.1
+workflow.[^1]
 
 ### 1.1 OpenTofu Provider Configuration
 
@@ -75,12 +75,12 @@ To interact with the APIs of DigitalOcean and Namecheap, OpenTofu requires the
 configuration of their respective providers. This is defined within a
 `terraform` block, which specifies the required providers, their source
 addresses, and version constraints to ensure predictable and repeatable
-deployments.3
+deployments.[^3]
 
 It is a critical security best practice to manage API credentials outside of
 version-controlled configuration files. The DigitalOcean and Namecheap
 providers can be configured to read credentials from environment variables,
-which is the recommended approach.5
+which is the recommended approach.[^5]
 
 **OpenTofu Provider Configuration (**`providers.tf`**):**
 
@@ -139,7 +139,7 @@ constraint that will be addressed later in this report.
 The DOKS cluster is the heart of the platform. Using the
 `digitalocean_kubernetes_cluster` resource, its entire configuration can be
 managed as code. For a production environment, it is essential to configure the
-cluster for high availability and resilience.7
+cluster for high availability and resilience.[^7]
 
 **DOKS Cluster Configuration (**`doks.tf`**):**
 
@@ -180,7 +180,7 @@ This configuration defines a cluster with a high-availability control plane
 (`ha = true`), which mitigates the risk of a single-point-of-failure for the
 Kubernetes API server. It also enables automatic patch upgrades
 (`auto_upgrade = true`) during a non-critical maintenance window, ensuring the
-cluster remains secure and up-to-date with minimal operational overhead.7
+cluster remains secure and up-to-date with minimal operational overhead.[^7]
 
 ### 1.3 Managing the Namecheap Domain and API
 
@@ -191,7 +191,7 @@ automation.
 
 To enable programmatic access, API access must be activated within the
 Namecheap account dashboard. This process has specific prerequisites that must
-be met.8
+be met.[^8]
 
 1. **Meet Prerequisites:** Ensure the account meets at least one of the
    following criteria:
@@ -207,7 +207,7 @@ be met.8
    - Scroll to the "Business & Dev Tools" section and click `MANAGE` next to
      "Namecheap API Access."
    - Toggle the feature `ON`, accept the terms, and enter the account
-     password.10
+     password.[^10]
 
 3. **Retrieve Credentials:** Once enabled, the system will provide an `APIKey`.
    The `API User` is the same as the Namecheap account username. These two
@@ -223,12 +223,12 @@ like DOKS, where egress IPs are non-deterministic.
 
 - **The Requirement:** The Namecheap API will only accept requests from IP
   addresses that have been explicitly added to a whitelist in the account's API
-  settings.13
+  settings.[^13]
 - **The Limitations:** This whitelist has several restrictive limitations:
 
 - It only supports single, static IPv4 addresses. CIDR ranges are not
-  permitted.16
-- A maximum of 20 IP addresses can be whitelisted.16
+  permitted.[^16]
+- A maximum of 20 IP addresses can be whitelisted.[^16]
 - The process of adding an IP to the whitelist is manual, via the Namecheap
   dashboard.
 - **The Conflict:** The `cert-manager-webhook-namecheap` pod, which is
@@ -241,7 +241,7 @@ like DOKS, where egress IPs are non-deterministic.
   be on the whitelist, causing all API calls from the webhook to fail until an
   operator manually intervenes to update the whitelist. This breaks the core
   principle of automation and makes any direct integration inherently brittle
-  and unsuitable for production.9
+  and unsuitable for production.[^9]
 
 This constraint is the single most significant technical challenge in this
 architecture. A robust, production-grade solution _must_ incorporate a strategy
@@ -252,12 +252,12 @@ to mitigate this issue, which will be the focus of Part 5.
 While dynamic, application-specific DNS records will be managed by in-cluster
 controllers, foundational records (like those for email) or the nameserver
 delegation itself can be managed via OpenTofu using the
-`namecheap_domain_records` resource.17
+`namecheap_domain_records` resource.[^17]
 
 A crucial detail of this resource is that the `record` and `nameservers`
 arguments are mutually exclusive. A single `namecheap_domain_records` resource
 block cannot be used to set both custom nameservers and other record types like
-`A` or `TXT` simultaneously.17 This is an important consideration for the DNS
+`A` or `TXT` simultaneously.[^17] This is an important consideration for the DNS
 delegation strategy discussed in Part 5, as it implies that managing the
 delegation will require a dedicated resource block separate from any other
 record management.
@@ -268,26 +268,26 @@ With the foundational infrastructure in place, the focus shifts to deploying
 the in-cluster controllers that will perform the TLS automation. Adhering to
 GitOps principles, the entire lifecycle of these components—installation,
 configuration, and upgrades—will be managed declaratively through Kubernetes
-manifests stored in the Git repository and reconciled by FluxCD.1
+manifests stored in the Git repository and reconciled by FluxCD.[^1]
 
 ### 2.1 Secure Credential Management with Mozilla SOPS
 
 The Namecheap API credentials are highly sensitive and must never be stored in
 plain text in the Git repository. Mozilla SOPS (Secrets OPerationS) is a
 powerful tool that integrates seamlessly with FluxCD to enable end-to-end
-encryption for secrets.18 The workflow ensures that secrets are encrypted
+encryption for secrets.[^18] The workflow ensures that secrets are encrypted
 before being committed to Git and are only decrypted by the FluxCD controller
-in-memory just before being applied to the cluster.18
+in-memory just before being applied to the cluster.[^18]
 
 The SOPS workflow proceeds as follows:
 
 1. **Generate an Encryption Key:** A GPG key (or an alternative like Age) is
    generated locally. This key will be used to encrypt and decrypt the
-   secrets.20
+   secrets.[^20]
 2. **Store the Decryption Key in the Cluster:** The private portion of the GPG
    key is stored in the Kubernetes cluster as a standard `Secret` resource,
    typically in the `flux-system` namespace. This allows the FluxCD
-   `kustomize-controller` to access it for decryption.18
+   `kustomize-controller` to access it for decryption.[^18]
 
     ```bash
     # (Assuming GPG key is already generated)
@@ -345,7 +345,7 @@ The SOPS workflow proceeds as follows:
 
 This setup ensures that sensitive credentials remain encrypted at rest in Git
 and are only handled in plain text within the secure confines of the cluster's
-control plane.18
+control plane.[^18]
 
 | Key in Secret | Description                                                   | Example Value                     |
 | ------------- | ------------------------------------------------------------- | --------------------------------- |
@@ -356,11 +356,11 @@ control plane.18
 
 FluxCD manages Helm chart deployments declaratively using the `HelmRepository`
 and `HelmRelease` custom resources. This approach treats Helm releases as
-version-controlled artifacts, enabling automated, repeatable deployments.21
+version-controlled artifacts, enabling automated, repeatable deployments.[^21]
 
 First, a `HelmRepository` source is defined to tell FluxCD where to find the
 cert-manager charts. The official OCI registry provided by Jetstack is the
-recommended source.22
+recommended source.[^22]
 
 `HelmRepository`**for cert-manager (**`infrastructure/sources/helm.yaml`**):**
 
@@ -381,7 +381,7 @@ Next, a `HelmRelease` manifest is created to deploy cert-manager. This manifest
 specifies the chart version, release configuration, and values that override
 the chart's defaults. For a production deployment, it is crucial to configure
 for high availability by increasing the replica counts for the controller and
-webhook components.23
+webhook components.[^23]
 
 `HelmRelease`**for cert-manager
 (**`infrastructure/controllers/cert-manager.yaml`**):**
@@ -454,7 +454,6 @@ spec:
       app.kubernetes.io/name: webhook
       app.kubernetes.io/instance: cert-manager
 ---
-# examples/pdb-cert-manager-cainjector.yaml
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -468,18 +467,28 @@ spec:
       app.kubernetes.io/instance: cert-manager
 ```
 
+Reference these manifests in the controllers' kustomization to apply them with FluxCD:
+
+```yaml
+# infrastructure/controllers/kustomization.yaml
+resources:
+  - cert-manager.yaml
+  - pdb-cert-manager-webhook.yaml
+  - pdb-cert-manager-cainjector.yaml
+```
+
 ### 2.3 Deploying the Namecheap DNS-01 Webhook Solver
 
 Cert-manager's core distribution does not include a DNS-01 solver for
 Namecheap. To integrate with Namecheap, a third-party webhook solver is
 required. This webhook is an external service that cert-manager calls to
 fulfill the DNS-01 challenge by creating and deleting the necessary TXT records
-via the Namecheap API.25
+via the Namecheap API.[^25]
 
 A critical security assessment of the available community-provided webhooks is
 necessary. The options available on public repositories like ArtifactHub and
 GitHub are often several years old, are not signed by their authors, and come
-from unverified publishers.26 Deploying an unmaintained and untrusted container
+from unverified publishers.[^26] Deploying an unmaintained and untrusted container
 image directly into a production cluster, especially one that handles API
 credentials, represents a significant supply chain security risk.
 
@@ -535,9 +544,9 @@ With the cert-manager controller and the Namecheap webhook deployed, the next
 step is to configure the resources that define how certificates will be issued.
 The `ClusterIssuer` resource is the central point of this configuration, acting
 as a certificate authority that can be used to sign certificate requests from
-any namespace in the cluster.30
+any namespace in the cluster.[^30]
 
-### 3.1 Crafting the Let's Encrypt ,`ClusterIssuer`
+### 3.1 Crafting the Let's Encrypt `ClusterIssuer`
 
 It is a crucial best practice to use the Let's Encrypt staging environment for
 all development and testing. The staging API has much higher rate limits and
@@ -617,9 +626,9 @@ spec:
 
 The `solvers` block is the most critical part of the `ClusterIssuer`
 configuration. It instructs cert-manager on how to satisfy the ACME challenges
-required to prove domain ownership.31 For the Namecheap integration, the
+required to prove domain ownership.[^31] For the Namecheap integration, the
 
-`dns01` solver is configured to use the deployed webhook.25
+`dns01` solver is configured to use the deployed webhook.[^25]
 
 - `dns01`: Specifies that the DNS-01 challenge type will be used. This involves
   creating a specific TXT record in the domain's DNS zone.
@@ -659,7 +668,7 @@ To enable automated TLS, two key sections are added to the Ingress manifest:
    `letsencrypt-production`).
 2. **TLS Block:** The `spec.tls` block defines which hosts on the Ingress
    should be secured and provides the name of the Kubernetes `Secret` where the
-   signed certificate and private key will be stored.33
+   signed certificate and private key will be stored.[^33]
 
 **Example Ingress with TLS Automation (**`my-app/ingress.yaml`**):**
 
@@ -709,7 +718,7 @@ any number of subdomains like `api.your-domain.com`,
 `dashboard.your-domain.com`, etc.
 
 A critical requirement from Let's Encrypt is that wildcard certificates can
-**only** be issued using the DNS-01 challenge method.34 The HTTP-01 challenge,
+**only** be issued using the DNS-01 challenge method.[^34] The HTTP-01 challenge,
 which involves serving a file from a web server, cannot prove control over an
 entire domain and is therefore not supported for wildcards. This makes the
 successful integration of the DNS-01 webhook solver a mandatory prerequisite
@@ -752,55 +761,50 @@ by inspecting the custom resources that cert-manager creates.
 1. **Check the **`Certificate`**:** This is the top-level resource representing
    the user's request. Its status provides a high-level overview of the process.
 
-```bash
-kubectl describe certificate <cert-name> -n <namespace>
+   ```bash
+   kubectl describe certificate <cert-name> -n <namespace>
+   ```
 
-```
+   Look for a `Ready` condition with a status of `True` and an event of
+   `Certificate issued successfully`.[^36]
 
-Look for a `Ready` condition with a status of `True` and an event of
-`Certificate issued successfully`.36
-
-1. **Check the **`CertificateRequest`**:** This resource represents a single
+2. **Check the **`CertificateRequest`**:** This resource represents a single
    attempt to obtain a certificate. A new one is created for each issuance or
    renewal.
 
-    ```bash
-    kubectl get certificaterequest -n <namespace>
+   ```bash
+   kubectl get certificaterequest -n <namespace>
+   ```
 
-    ```
-
-2. **Check the **`Order`**:** For ACME issuers like Let's Encrypt, an `Order`
+3. **Check the **`Order`**:** For ACME issuers like Let's Encrypt, an `Order`
    resource is created to manage the ACME order process. It tracks the status
    of the required challenges.
 
-    ```bash
-    kubectl describe order <order-name> -n <namespace>
+   ```bash
+   kubectl describe order <order-name> -n <namespace>
+   ```
 
-    ```
+   The output will list the associated `Challenge` resources and their current
+   state.[^38]
 
-The output will list the associated `Challenge` resources and their current
-state.38
-
-1. **Check the **`Challenge`**:** This is the most critical resource for
+4. **Check the **`Challenge`**:** This is the most critical resource for
    debugging DNS-01 issues. It represents the specific ACME challenge (e.g.,
    creating a TXT record). Its events and status will contain detailed error
    messages from the webhook or the ACME server.
 
-```bash
-kubectl describe challenge <challenge-name> -n <namespace>
+   ```bash
+   kubectl describe challenge <challenge-name> -n <namespace>
+   ```
 
-```
+   Look for messages like `Presented the DNS01 challenge for domain...` or error
+   messages indicating API failures.[^38]
 
-Look for messages like `Presented the DNS01 challenge for domain...` or error
-messages indicating API failures.38
-
-1. **Check the Webhook Logs:** The logs from the Namecheap webhook pod are the
+5. **Check the Webhook Logs:** The logs from the Namecheap webhook pod are the
    final source of truth for API interactions.
 
-```bash
-kubectl logs -n cert-manager -l app.kubernetes.io/name=cert-manager-webhook-namecheap -f
-
-```
+   ```bash
+   kubectl logs -n cert-manager -l app.kubernetes.io/name=cert-manager-webhook-namecheap -f
+   ```
 
 These logs will show if the webhook is receiving challenge requests from
 cert-manager and the outcome of its API calls to Namecheap.
@@ -827,7 +831,7 @@ architecting solutions to inherent platform limitations.
   `cert-manager` namespace. These policies should enforce rules such as:
 
 - Allowing ingress to the webhook pod only from the Kubernetes API server on
-  its designated port (typically 10250).24
+  its designated port (typically 10250).[^24]
 - Allowing egress from the controller and webhook pods only to the Kubernetes
   API server and the required external endpoints (Let's Encrypt API and
   Namecheap API on TCP port 443).
@@ -842,7 +846,7 @@ architecting solutions to inherent platform limitations.
 
 A systematic approach to troubleshooting is key to minimizing downtime. The
 following table provides a guide for diagnosing common issues in the TLS
-issuance pipeline.38
+issuance pipeline.[^38]
 
 | Symptom                                                                       | Diagnostic Command(s)                                                                                                                                                 | Likely Cause & Resolution                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
 | ----------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
@@ -886,19 +890,19 @@ strategies provide robust solutions to this problem.
   DigitalOcean DNS or Cloudflare).
 - **Implementation:**
 
-1. **Create a DNS Zone:** In the secondary provider (e.g., DigitalOcean),
-   create a DNS zone for `your-domain.com`.
-2. **Delegate with NS Records:** In Namecheap, using the
-   `namecheap_domain_records` OpenTofu resource, create `NS` (nameserver)
-   records for the hostname `_acme-challenge`, pointing to the nameservers of
-   the secondary provider.
-3. **Configure a Second **`ClusterIssuer`**:** In cert-manager, create a new
-   `ClusterIssuer` (e.g., `letsencrypt-digitalocean`). This issuer will use the
-   native `digitalocean` solver, configured with DigitalOcean API credentials.
-4. **Use a **`selector`**:** In the primary `Certificate` resource, use a
-   `selector` in the `dns01` configuration to instruct cert-manager to use the
-   `letsencrypt-digitalocean` issuer specifically for challenges involving
-   `your-domain.com`.
+  1. **Create a DNS Zone:** In the secondary provider (e.g., DigitalOcean),
+     create a DNS zone for `your-domain.com`.
+  2. **Delegate with NS Records:** In Namecheap, using the
+     `namecheap_domain_records` OpenTofu resource, create `NS` (nameserver)
+     records for the hostname `_acme-challenge`, pointing to the nameservers of
+     the secondary provider.
+  3. **Configure a Second **`ClusterIssuer`**:** In cert-manager, create a new
+     `ClusterIssuer` (e.g., `letsencrypt-digitalocean`). This issuer will use the
+     native `digitalocean` solver, configured with DigitalOcean API credentials.
+  4. **Use a `selector`:** In the primary `Certificate` resource, use a
+     `selector` in the `dns01` configuration to instruct cert-manager to use the
+     `letsencrypt-digitalocean` issuer specifically for challenges involving
+     `your-domain.com`.
 
 - **Analysis:** This is an elegant, cloud-native solution. It has no additional
   infrastructure cost and aligns well with microservice principles by
@@ -974,162 +978,92 @@ for a production environment. By implementing this strategy, the organization
 can achieve a truly automated, secure, and operationally excellent application
 delivery platform.
 
-## Works cited
+[^1]: Kubernetes Dynamic DNS With Cloudflare
 
-1. Kubernetes Dynamic DNS With Cloudflare
-
-2. cert-manager/cert-manager: Automatically provision and manage TLS
+[^2]: cert-manager/cert-manager: Automatically provision and manage TLS
    certificates in Kubernetes - GitHub, accessed on 1 September 2025,
    [https://github.com/cert-manager/cert-manager](https://github.com/cert-manager/cert-manager)
 
-3. Providers - OpenTofu, accessed on 1 September 2025,
+[^3]: Providers - OpenTofu, accessed on 1 September 2025,
    [https://opentofu.org/docs/language/providers/](https://opentofu.org/docs/language/providers/)
 
-4. Provider Requirements | OpenTofu, accessed on 1 September 2025,
-   [https://opentofu.org/docs/language/providers/requirements/](https://opentofu.org/docs/language/providers/requirements/)
-
-5. Provider: DigitalOcean - OpenTofu Registry, accessed on 1 September 2025,
+[^5]: Provider: DigitalOcean - OpenTofu Registry, accessed on 1 September 2025,
    [https://search.opentofu.org/provider/opentofu/digitalocean/latest](https://search.opentofu.org/provider/opentofu/digitalocean/latest)
 
-6. Namecheap provider - OpenTofu Registry, accessed on 1 September 2025,
-   [https://search.opentofu.org/provider/namecheap/namecheap/v2.2.0](https://search.opentofu.org/provider/namecheap/namecheap/v2.2.0)
-
-7. digitalocean_kubernetes_cluster | Resources | digitalocean …, accessed on
+[^7]: digitalocean_kubernetes_cluster | Resources | digitalocean …, accessed on
    1 September 2025,
    [https://docs.digitalocean.com/reference/terraform/reference/resources/kubernetes_cluster/](https://docs.digitalocean.com/reference/terraform/reference/resources/kubernetes_cluster/)
 
-8. Namecheap Terraform Provider - Domains, accessed on 1 September 2025,
+[^8]: Namecheap Terraform Provider - Domains, accessed on 1 September 2025,
    [https://www.namecheap.com/support/knowledgebase/article.aspx/10502/2208/namecheap-terraform-provider/](https://www.namecheap.com/support/knowledgebase/article.aspx/10502/2208/namecheap-terraform-provider/)
 
-9. A warning about Namecheap when using dynamic DNS, Let's Encrypt and DNS
+[^9]: A warning about Namecheap when using dynamic DNS, Let's Encrypt and DNS
    challenge : r/selfhosted - Reddit, accessed on 1 September 2025,
    [https://www.reddit.com/r/selfhosted/comments/184fhrv/a_warning_about_namecheap_when_using_dynamic_dns/](https://www.reddit.com/r/selfhosted/comments/184fhrv/a_warning_about_namecheap_when_using_dynamic_dns/)
 
-10. Obtaining an API key from Namecheap | Yunohost, accessed on 1 September
+[^10]: Obtaining an API key from Namecheap | Yunohost, accessed on 1 September
     2025,
     [https://doc.yunohost.org/admin/get_started/providers/registrar/namecheap/](https://doc.yunohost.org/admin/get_started/providers/registrar/namecheap/)
 
-11. Intro to API for Developers | [Namecheap.com](http://Namecheap.com),
-    accessed on 1 September 2025,
-    [https://www.namecheap.com/support/api/intro/](https://www.namecheap.com/support/api/intro/)
-
-12. Obtaining an API key from Namecheap - Yunohost, accessed on 1 September
-    2025,
-    [https://doc.yunohost.org/oc/admin/self_hosting/providers/registrar/namecheap/](https://doc.yunohost.org/oc/admin/self_hosting/providers/registrar/namecheap/)
-
-13. [www.namecheap.com](http://www.namecheap.com), accessed on 1 September
+[^13]: [www.namecheap.com](http://www.namecheap.com), accessed on 1 September
     2025,
     [https://www.namecheap.com/support/api/intro/](https://www.namecheap.com/support/api/intro/)
 
-14. Namecheap API Integration - Peerclick Help Center, accessed on 1 September
-    2025,
-    [https://help-center.peerclick.com/en/articles/10305681-namecheap-api-integration](https://help-center.peerclick.com/en/articles/10305681-namecheap-api-integration)
-
-15. API Documentation - Global Parameters - Namecheap, accessed on 1 September
-    2025,
-    [https://www.namecheap.com/support/api/global-parameters/](https://www.namecheap.com/support/api/global-parameters/)
-
-16. Any way around the API whitelisting yet? : r/NameCheap - Reddit, accessed
+[^16]: Any way around the API whitelisting yet? : r/NameCheap - Reddit, accessed
     on 1 September 2025,
     [https://www.reddit.com/r/NameCheap/comments/19b0dek/any_way_around_the_api_whitelisting_yet/](https://www.reddit.com/r/NameCheap/comments/19b0dek/any_way_around_the_api_whitelisting_yet/)
 
-17. namecheap_domain_records | resources | namecheap/namecheap | Providers |
+[^17]: namecheap_domain_records | resources | namecheap/namecheap | Providers |
     OpenTofu and Terraform Registry - [Library.tf](http://Library.tf), accessed
     on 1 September 2025,
     [https://library.tf/providers/namecheap/namecheap/latest/docs/resources/domain_records](https://library.tf/providers/namecheap/namecheap/latest/docs/resources/domain_records)
 
-18. Manage Kubernetes secrets with SOPS | Flux - Flux CD, accessed on 1
+[^18]: Manage Kubernetes secrets with SOPS | Flux - Flux CD, accessed on 1
     September 2025,
     [https://fluxcd.io/flux/guides/mozilla-sops/](https://fluxcd.io/flux/guides/mozilla-sops/)
 
-19. Secrets Management - Flux CD, accessed on 1 September 2025,
-    [https://fluxcd.io/flux/security/secrets-management/](https://fluxcd.io/flux/security/secrets-management/)
-
-20. Setting Up Flux CD in a Kubernetes Cluster with SOPS Encryption. - Medium,
+[^20]: Setting Up Flux CD in a Kubernetes Cluster with SOPS Encryption. - Medium,
     accessed on 1 September 2025,
     [https://medium.com/@deepakraajesh/setting-up-flux-cd-in-a-kubernetes-cluster-with-sops-encryption-bd72b2d0e468](https://medium.com/@deepakraajesh/setting-up-flux-cd-in-a-kubernetes-cluster-with-sops-encryption-bd72b2d0e468)
 
-21. Manage Helm Releases - Flux CD, accessed on 1 September 2025,
+[^21]: Manage Helm Releases - Flux CD, accessed on 1 September 2025,
     [https://fluxcd.io/flux/guides/helmreleases/](https://fluxcd.io/flux/guides/helmreleases/)
 
-22. Helm - cert-manager Documentation, accessed on 1 September 2025,
+[^22]: Helm - cert-manager Documentation, accessed on 1 September 2025,
     [https://cert-manager.io/docs/installation/helm/](https://cert-manager.io/docs/installation/helm/)
 
-23. cert-manager 1.18.2 - Artifact Hub, accessed on 1 September 2025,
+[^23]: cert-manager 1.18.2 - Artifact Hub, accessed on 1 September 2025,
     [https://artifacthub.io/packages/helm/cert-manager/cert-manager](https://artifacthub.io/packages/helm/cert-manager/cert-manager)
 
-24. Best Practice - cert-manager Documentation, accessed on 1 September 2025,
+[^24]: Best Practice - cert-manager Documentation, accessed on 1 September 2025,
     [https://cert-manager.io/docs/installation/best-practice/](https://cert-manager.io/docs/installation/best-practice/)
 
-25. Webhook - cert-manager Documentation, accessed on 1 September 2025,
+[^25]: Webhook - cert-manager Documentation, accessed on 1 September 2025,
     [https://cert-manager.io/docs/configuration/acme/dns01/webhook/](https://cert-manager.io/docs/configuration/acme/dns01/webhook/)
 
-26. jamesgoodhouse/cert-manager-webhook-namecheap: A … - GitHub, accessed on
+[^26]: jamesgoodhouse/cert-manager-webhook-namecheap: A … - GitHub, accessed on
     1 September 2025,
     [https://github.com/jamesgoodhouse/cert-manager-webhook-namecheap](https://github.com/jamesgoodhouse/cert-manager-webhook-namecheap)
 
-27. cert-manager-webhook-namecheap 0.1.2 - Artifact Hub, accessed on 1
-    September 2025,
-    [https://artifacthub.io/packages/helm/cert-manager-webhook-namecheap/cert-manager-webhook-namecheap](https://artifacthub.io/packages/helm/cert-manager-webhook-namecheap/cert-manager-webhook-namecheap)
-
-28. letsencrypt-namecheap-issuer 0.1.1 ·
-    zvonimirbedi/cert-manager-webhook-namecheap, accessed on 1 September 2025,
-    [https://artifacthub.io/packages/helm/cert-manager-webhook-namecheap/letsencrypt-namecheap-issuer](https://artifacthub.io/packages/helm/cert-manager-webhook-namecheap/letsencrypt-namecheap-issuer)
-
-29. kelvie/cert-manager-webhook-namecheap: A cert-manager … - GitHub,
-    accessed on 1 September 2025,
-    [https://github.com/kelvie/cert-manager-webhook-namecheap](https://github.com/kelvie/cert-manager-webhook-namecheap)
-
-30. Issuer Configuration - cert-manager Documentation, accessed on 1 September
+[^30]: Issuer Configuration - cert-manager Documentation, accessed on 1 September
     2025,
     [https://cert-manager.io/docs/configuration/](https://cert-manager.io/docs/configuration/)
 
-31. DNS01 - cert-manager Documentation, accessed on 1 September 2025,
+[^31]: DNS01 - cert-manager Documentation, accessed on 1 September 2025,
     [https://cert-manager.io/docs/configuration/acme/dns01/](https://cert-manager.io/docs/configuration/acme/dns01/)
 
-32. cert-manager adding my domain to DNS lookup of
-    [acme-v02.api.letsencrypt.org](http://acme-v02.api.letsencrypt.org) causing
-    failures : r/kubernetes - Reddit, accessed on 1 September 2025,
-    [https://www.reddit.com/r/kubernetes/comments/16ji2l0/certmanager_adding_my_domain_to_dns_lookup_of/](https://www.reddit.com/r/kubernetes/comments/16ji2l0/certmanager_adding_my_domain_to_dns_lookup_of/)
-
-33. Certificate resource - cert-manager Documentation, accessed on 1 September
+[^33]: Certificate resource - cert-manager Documentation, accessed on 1 September
     2025,
     [https://cert-manager.io/docs/usage/certificate/](https://cert-manager.io/docs/usage/certificate/)
 
-34. DNS Domain Validation (dns-01) | Certify The Web Docs, accessed on 1
+[^34]: DNS Domain Validation (dns-01) | Certify The Web Docs, accessed on 1
     September 2025,
     [https://docs.certifytheweb.com/docs/dns/validation/](https://docs.certifytheweb.com/docs/dns/validation/)
 
-35. Automation of certificate renewal with manual dns-01 and NameCheap -
-    Reddit, accessed on 1 September 2025,
-    [https://www.reddit.com/r/letsencrypt/comments/1dyq5gw/automation_of_certificate_renewal_with_manual/](https://www.reddit.com/r/letsencrypt/comments/1dyq5gw/automation_of_certificate_renewal_with_manual/)
-
-36. Verifying the Installation - cert-manager Documentation, accessed on 1
+[^36]: Verifying the Installation - cert-manager Documentation, accessed on 1
     September 2025,
     [https://cert-manager.io/v1.6-docs/installation/verify/](https://cert-manager.io/v1.6-docs/installation/verify/)
 
-37. Kubectl plugin - cert-manager Documentation, accessed on 1 September 2025,
-    [https://cert-manager.io/v1.0-docs/usage/kubectl-plugin/](https://cert-manager.io/v1.0-docs/usage/kubectl-plugin/)
-
-38. Troubleshooting Issuing ACME Certificates - cert-manager Documentation,
+[^38]: Troubleshooting Issuing ACME Certificates - cert-manager Documentation,
     accessed on 1 September 2025,
     [https://cert-manager.io/v1.0-docs/faq/acme/](https://cert-manager.io/v1.0-docs/faq/acme/)
-
-39. Creating an ACME resolver webhook for responses to DNS01 checks - Yandex
-    Cloud, accessed on 1 September 2025,
-    [https://yandex.cloud/en/docs/tutorials/infrastructure-management/cert-manager-webhook](https://yandex.cloud/en/docs/tutorials/infrastructure-management/cert-manager-webhook)
-
-40. Troubleshooting Certificate Manager | Google Cloud, accessed on 1 September
-    2025,
-    [https://cloud.google.com/certificate-manager/docs/troubleshooting](https://cloud.google.com/certificate-manager/docs/troubleshooting)
-
-41. Cert Manager Troubleshooting - Giant Swarm Handbook, accessed on 1
-    September 2025,
-    [https://handbook.giantswarm.io/docs/support-and-ops/ops-recipes/troubleshooting-cert-manager/](https://handbook.giantswarm.io/docs/support-and-ops/ops-recipes/troubleshooting-cert-manager/)
-
-42. FAQ - cert-manager Documentation, accessed on 1 September 2025,
-    [https://cert-manager.io/v1.9-docs/faq/](https://cert-manager.io/v1.9-docs/faq/)
-
-43. Troubleshooting certificate management service - IBM, accessed on 1
-    September 2025,
-    [https://www.ibm.com/docs/en/cloud-private/3.2.0?topic=service-troubleshooting-certificate-management](https://www.ibm.com/docs/en/cloud-private/3.2.0?topic=service-troubleshooting-certificate-management)

--- a/docs/srgn.md
+++ b/docs/srgn.md
@@ -42,14 +42,14 @@ overloaded across different domains. This guide is exclusively dedicated to
 `alexpovel/srgn`, the command-line code search and manipulation utility.[^1]
 Other projects bearing a similar name are unrelated to the tool discussed here.
 These include, but are not limited to, SRGAN, a Generative Adversarial Network
-for image super-resolution[^3]; SRGN, a high-energy physics technique for
-parameter estimation[^4]; and SRGN (SolRagon), a cryptocurrency token.[^6] This
+for image super-resolution[^2]; SRGN, a high-energy physics technique for
+parameter estimation[^3]; and SRGN (SolRagon), a cryptocurrency token.[^4] This
 report focuses solely on the code refactoring tool.
 
 ### 1.3 Core Philosophy: Scopes, Actions, and Intentional Simplicity
 
 The design of `srgn` is built upon two foundational pillars: **Scopes** and
-**Actions**.[^2] Scopes define
+**Actions**.[^5] Scopes define
 
 *where* in the code an operation should take place, while Actions define *what*
 should be done to the text within that scope. This separation of concerns is
@@ -57,11 +57,11 @@ central to the tool's power and usability.
 
 A core tenet of `srgn` is its intentional simplicity. The documentation states
 its design goal clearly: "if you know regex and the basics of the language you
-are working with, you are good to go".[^2] This philosophy distinguishes
+are working with, you are good to go".[^5] This philosophy distinguishes
 
 `srgn` from other advanced code-querying tools. While tools like Semgrep use a
 declarative, template-based syntax with metavariables (`$X`) and ellipses
-(`...`) to find code that matches an abstract pattern[^8],
+(`...`) to find code that matches an abstract pattern[^6],
 
 `srgn` employs a more direct approach.
 
@@ -173,7 +173,7 @@ When a language flag (e.g., `--python` or its shorthand `--py` 9) is provided
 without any accompanying actions or a replacement string,
 
 `srgn` enters search mode.[^1] The documentation describes this mode as
-"'ripgrep but with syntactical language elements'".[^2]
+"'ripgrep but with syntactical language elements'".[^5]
 
 For instance, to find all class definitions in a Python project, one could run:
 
@@ -185,7 +185,7 @@ srgn --python 'class'
 
 The output mimics `grep` and `ripgrep`, prepending the file name and line
 number to each match, making it easy to integrate into standard command-line
-workflows.[^2]
+workflows.[^5]
 
 This mode is not only precise but also exceptionally fast. A benchmark cited in
 the documentation demonstrates its performance: `srgn` can find approximately
@@ -201,14 +201,14 @@ precision makes search mode a formidable tool for code exploration and auditing.
 The term "scope" carries significant weight in programming, often referring to
 semantic concepts of visibility and lifetime, such as Python's LEGB rule
 (Local, Enclosing, Global, Built-in) or Rust's complex ownership and lifetime
-scopes.[^10] A critical step in mastering
+scopes.[^7] A critical step in mastering
 
 `srgn` is understanding that its use of the term is different.
 
 In `srgn`, a "language grammar-aware scope" does not refer to a semantic
 namespace but to a **textual region** of the source code that corresponds to a
 specific node in its Abstract Syntax Tree (AST), as parsed by
-`tree-sitter`.[^2] For example, the
+`tree-sitter`.[^5] For example, the
 
 `--python 'function'` scope selects the entire block of text that constitutes a
 function definition, from the `def` keyword to the end of its body. It does not
@@ -224,7 +224,7 @@ of its capabilities.
 ### 3.2 The Scoping Pipeline: Layering with Logical AND
 
 The precision of `srgn` comes from its default mechanism of combining scopes: a
-left-to-right, progressively narrowing filter that acts as a logical AND.[^2]
+left-to-right, progressively narrowing filter that acts as a logical AND.[^5]
 Each subsequent scope operates only on the text that was passed through by the
 previous one.
 
@@ -260,7 +260,7 @@ intersectional pipeline.
 
 While the default AND logic is excellent for drilling down, some tasks require
 a broader search across different types of syntax. For this, `srgn` provides
-the `--join-language-scopes` flag (or its shorthand, `-j`).[^2] This flag
+the `--join-language-scopes` flag (or its shorthand, `-j`).[^5] This flag
 alters the behavior for language scopes, changing the operation from
 intersection (AND) to a union (OR).
 
@@ -293,7 +293,7 @@ scopes:
 2. **Regular Expression Scope**: This is the mandatory, positional argument
    that provides the final, fine-grained pattern matching. It is always the
    last filter applied in the pipeline, operating only on the text selected by
-   the preceding language scopes.[^2]
+   the preceding language scopes.[^5]
 
 ## Part 4: Taking Action - Manipulation and Refactoring
 
@@ -303,7 +303,7 @@ The simplest action in `srgn` is replacement, specified with the
 `-- 'replacement'` syntax. However, for any meaningful refactoring, dynamic
 replacements are essential. `srgn` supports this through regex capture groups
 (`$1`, `$2`, etc.), which substitute parts of the matched text into the
-replacement string.[^2]
+replacement string.[^5]
 
 A rich example from the documentation showcases several advanced features at
 once 2:
@@ -331,16 +331,16 @@ This command deconstructs as follows:
 
 Beyond simple replacement, `srgn` offers a suite of built-in actions specified
 via command-line flags. These actions are applied in a defined order *after*
-the main replacement has occurred.[^2]
+the main replacement has occurred.[^5]
 
 The command `srgn --upper '[wW]orld' -- 'you'` illustrates this two-stage
 process. First, the regex match `World` is replaced with `you`. Second, the
-`--upper` action is applied to that result, yielding the final output `YOU`.[^2]
+`--upper` action is applied to that result, yielding the final output `YOU`.[^5]
 
 Common built-in action flags include:
 
 - `--upper`, `--lower`, `--titlecase`: For changing the case of matched
-  text.[^2]
+  text.[^5]
 
 - `--delete`: Removes the matched text. As a safety measure, this action will
   produce an error if no scope is specified, preventing the accidental deletion
@@ -351,7 +351,7 @@ Common built-in action flags include:
 
 - `--german`: A specialized action that correctly handles German orthography,
   such as converting "Ueberflieger" to "Überflieger," demonstrating the
-  potential for domain-specific transformations.[^7]
+  potential for domain-specific transformations.[^8]
 
 ### 4.3 In-place File Modification and Operational Safety
 
@@ -470,7 +470,7 @@ showcasing `srgn`'s versatility across different languages.
   `#[expect(some_lint)]`. This ensures that if the underlying code is fixed and
   no longer triggers the lint, the build will fail, forcing the removal of the
   now-unnecessary attribute. This exact use case is mentioned as an example in
-  the `srgn` documentation.[^2]
+  the `srgn` documentation.[^5]
 
 - **Command**:
 
@@ -544,7 +544,7 @@ showcasing `srgn`'s versatility across different languages.
 
 For the most demanding refactoring tasks, `srgn` offers an escape hatch beyond
 the command line. It is a dual-use tool, available not only as a binary but
-also as a Rust library that can be added to a project with `cargo add srgn`.[^7]
+also as a Rust library that can be added to a project with `cargo add srgn`.[^8]
 
 This library interface provides the ultimate level of control for power users.
 For extremely complex, multi-pass, or stateful refactoring scenarios where the
@@ -618,10 +618,10 @@ ______________________________________________________________________
 
 The following tables list the known language grammar scopes for Python and
 Rust. This reference has been meticulously compiled from the official `srgn`
-documentation, README examples, and GitHub release notes.[^2] As direct
+documentation, README examples, and GitHub release notes.[^5] As direct
 inspection of the
 
-`PreparedQuery` source enum was not possible during research[^15], this list
+`PreparedQuery` source enum was not possible during research[^10], this list
 should be considered comprehensive but potentially subject to change in future
 
 `srgn` versions. Users can often discover available scopes by providing an
@@ -629,7 +629,7 @@ invalid one, as `srgn` will helpfully list the valid options.[^9]
 
 ### A. Table: Rust grammar scopes (`--rust <SCOPE>` or `--rs <SCOPE>`)
 
-[^2]
+[^5]
 
 | Scope Name | Description | Example Command |
 | -------------------------- | ---------------------------------------------------------- | ------------------------------------------------------ |
@@ -651,32 +651,32 @@ invalid one, as `srgn` will helpfully list the valid options.[^9]
 allows for manipulation in addition to search - GitHub, accessed on July
 11, 2025, <https://github.com/alexpovel/srgn>
 
-[^2]: srgn/README.md at main · alexpovel/srgn · GitHub, accessed on July 11,
-2025, <https://github.com/alexpovel/srgn/blob/main/README.md>
-
-[^3]: Lornatang/SRGAN-PyTorch: A simple and complete implementation of
+[^2]: Lornatang/SRGAN-PyTorch: A simple and complete implementation of
 super-resolution paper. - GitHub, accessed on July 11, 2025,
 <https://github.com/Lornatang/SRGAN-PyTorch>
 
-[^4]: hep-lbdl/SRGN - GitHub, accessed on July 11, 2025,
+[^3]: hep-lbdl/SRGN - GitHub, accessed on July 11, 2025,
 <https://github.com/hep-lbdl/SRGN>
 
-[^6]: How to Open and Manage Leveraged $SRGN (SolRagon) Trades on Hyperliquid: A
+[^4]: How to Open and Manage Leveraged $SRGN (SolRagon) Trades on Hyperliquid: A
     Beginner's Tutorial · Issue #5 ·
     synthesizearrayHSy/generatemonitorGhZ - GitHub, accessed on July 11, 2025,
     <https://github.com/synthesizearrayHSy/generatemonitorGhZ/issues/5>
 
-[^7]: srgn - Rust - Docs.rs, accessed on July 11, 2025,
-<https://docs.rs/srgn>
+[^5]: srgn/README.md at main · alexpovel/srgn · GitHub, accessed on July 11,
+2025, <https://github.com/alexpovel/srgn/blob/main/README.md>
 
-[^8]: Pattern syntax - Semgrep, accessed on July 11, 2025,
+[^6]: Pattern syntax - Semgrep, accessed on July 11, 2025,
 <https://semgrep.dev/docs/writing-rules/pattern-syntax>
+
+[^7]: Python Scope & the LEGB Rule: Resolving Names in Your Code, accessed on
+    July 11, 2025, <https://realpython.com/python-scope-legb-rule/>
+
+[^8]: srgn - Rust - Docs.rs, accessed on July 11, 2025,
+<https://docs.rs/srgn>
 
 [^9]: Releases · alexpovel/srgn - GitHub, accessed on July 11, 2025,
 <https://github.com/alexpovel/srgn/releases>
 
-[^10]: Python Scope & the LEGB Rule: Resolving Names in Your Code, accessed on
-    July 11, 2025, <https://realpython.com/python-scope-legb-rule/>
-
-[^15]: srgn language scopes, accessed on July 11, 2025,
+[^10]: srgn language scopes, accessed on July 11, 2025,
     <https://github.com/alexpovel/srgn/tree/main/src/scoping/langs>

--- a/docs/srgn.md
+++ b/docs/srgn.md
@@ -82,7 +82,7 @@ line.
 
 `srgn` can be installed across various platforms, catering to the diverse
 environments of command-line users. The following methods are officially
-supported 1:
+supported.[^1]
 
 - **Prebuilt Binaries**: The most straightforward method is to download a
   prebuilt binary for your specific architecture directly from the project's
@@ -96,10 +96,10 @@ supported 1:
   Bash
 
   ```sh
-  # Install the Rust toolchain if you haven't already
-  # Then, install cargo-binstall
+  # Install the Rust toolchain if not already present.
+  # Then install cargo-binstall.
   cargo install cargo-binstall
-  # Finally, install srgn
+  # Finally install srgn.
   cargo binstall srgn
 
   ```
@@ -137,8 +137,8 @@ tools, making it intuitive for experienced users. The general syntax is:
 
 `srgn '' -- ''`
 
-Each component has a distinct role, as illustrated by the canonical `tr`-like
-example from the documentation 1:
+Each component has a distinct role, as illustrated by the canonical `tr`‑like
+example from the documentation.[^1]
 
 Bash
 

--- a/docs/srgn.md
+++ b/docs/srgn.md
@@ -622,7 +622,7 @@ documentation, README examples, and GitHub release notes.[^5] As direct
 inspection of the
 
 `PreparedQuery` source enum was not possible during research[^10], this list
-should be considered comprehensive but potentially subject to change in future
+should be considered comprehensive but potentially subject to change in future.
 
 `srgn` versions. Users can often discover available scopes by providing an
 invalid one, as `srgn` will helpfully list the valid options.[^9]

--- a/docs/srgn.md
+++ b/docs/srgn.md
@@ -612,7 +612,7 @@ ______________________________________________________________________
 
 ## Appendix: Grammar Scope Reference
 
-### A. Note on this list
+### A. A note on this list
 
 [^1]
 

--- a/docs/srgn.md
+++ b/docs/srgn.md
@@ -619,13 +619,11 @@ ______________________________________________________________________
 The following tables list the known language grammar scopes for Python and
 Rust. This reference has been meticulously compiled from the official `srgn`
 documentation, README examples, and GitHub release notes.[^5] As direct
-inspection of the
-
-`PreparedQuery` source enum was not possible during research[^10], this list
-should be considered comprehensive but potentially subject to change in future.
-
-`srgn` versions. Users can often discover available scopes by providing an
-invalid one, as `srgn` will helpfully list the valid options.[^9]
+inspection of the `PreparedQuery` source enum was not possible during
+research[^10], this list should be considered comprehensive but
+potentially subject to change in future `srgn` versions. Users can often
+discover available scopes by providing an invalid one, as `srgn` will
+helpfully list the valid options.[^9]
 
 ### A. Table: Rust grammar scopes (`--rust <SCOPE>` or `--rs <SCOPE>`)
 

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -80,6 +80,33 @@ graph TD
     EngineLib -- Requires data from --> DB
 ```
 
+For screen readers: This sequence diagram traces a request from browser to
+backend, including how the service reads its signing key and manages session
+cookies.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  actor Browser
+  participant Ingress
+  participant Backend
+  participant SecretStore as Mounted_Secret_File
+
+  rect rgb(235,245,255)
+    note right of Ingress: Routes updated to /api/v1 and /ws
+  end
+
+  Browser->>Ingress: HTTPS request to /api/v1/endpoint
+  Ingress->>Backend: Proxy request
+  Backend->>SecretStore: Read signing key from mounted file (startup / refresh)
+  Backend->>Backend: Sign/validate session cookie\n(Secure, HttpOnly, SameSite, Max-Age)
+  Backend-->>Browser: Response (+Set-Cookie)
+
+  Browser->>Ingress: WS upgrade to /ws
+  Ingress->>Backend: Upgrade proxy
+  Backend-->>Browser: WebSocket messages
+```
+
 ## 3. Core Components & Implementation Plan
 
 This section details each functional component of the backend, its current

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -61,7 +61,7 @@ graph TD
     end
 
     User -- HTTPS/WSS --> Ingress
-    Ingress -- /api, /ws --> API
+    Ingress -- /api/v1, /ws --> API
     Ingress -- /tiles --> Martin
 
     API -- CRUD Ops --> DB
@@ -113,11 +113,11 @@ API and WebSocket traffic.
 - **Implementation Tasks:**
 
   - [ ] **Session Management:** Implement stateless, signed-cookie sessions.
-    Use the `actix-session` crate with a cookie-based backend. Load the signing
-    key from a secret store (for example, a Kubernetes Secret or Vault) and
-    mount or inject it for the service at runtime. Configure the session cookie
-    with `Secure=true`, `HttpOnly=true`, `SameSite=Lax` (or `Strict`), and
-    explicit `domain` and `path`.
+    Use `actix-session` with a cookie backend configured as:
+    `Secure=true`, `HttpOnly=true`, `SameSite=Lax` (or `Strict`), and explicit
+    `domain` and `path`. Load the signing key from a managed secret (for
+    example, a Kubernetes `Secret` or Vault) and mount or inject it for the
+    service at runtime—avoid sourcing it from a plain environment variable.
 
     ```rust
     use actix_session::{SessionMiddleware, storage::CookieSessionStore};

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -112,10 +112,11 @@ API and WebSocket traffic.
 
 - **Implementation Tasks:**
 
-  - [ ] **Session Management:** Implement stateless, signed-cookie sessions.
-    Use `actix-session` with a cookie backend configured as:
-    `Secure=true`, `HttpOnly=true`, `SameSite=Lax` (or `Strict`), and explicit
-    `domain` and `path`. Set a bounded `Max-Age` to limit session lifetime.
+  - [ ] **Session Management:** Implement stateless, encrypted, authenticated
+    cookie sessions. Use `actix-session` with a cookie backend configured as:
+    `Secure=true`, `HttpOnly=true`, `SameSite=Lax` (or `Strict`), an explicit
+    `path`, and set `domain` only when sharing across subdomains. Set a bounded
+    `Max-Age` to limit session lifetime.
     Load the signing key from a high-entropy (≥64-byte), read-only managed
     secret (for example, a Kubernetes `Secret` or Vault) and mount or inject it
     for the service at runtime—avoid sourcing it from a plain environment
@@ -151,6 +152,11 @@ API and WebSocket traffic.
     deploying new secrets and reloading the service so the fresh key takes
     effect while the previous key remains available for validating existing
     sessions during the rollout.
+
+    For seamless rotation, run at least two replicas and perform a rolling
+    update so pods with the prior key continue to validate existing cookies
+    until expiry. A single-replica restart replaces the key atomically and will
+    invalidate all existing sessions immediately.
 
   - [ ] **Observability:**
 

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -120,8 +120,8 @@ API and WebSocket traffic.
     Load the signing key from a high-entropy (≥64-byte), read-only managed
     secret (for example, a Kubernetes `Secret` or Vault) and mount or inject it
     for the service at runtime—avoid sourcing it from a plain environment
-    variable. Rotate the key regularly by rolling the secret and reloading it so
-    stale cookies are invalidated.
+      variable. Rotate the key regularly by rolling the secret and reloading it,
+      so stale cookies are invalidated.
 
     ```rust
     use actix_session::{storage::CookieSessionStore, SessionMiddleware};
@@ -149,14 +149,14 @@ API and WebSocket traffic.
     Deployment manifests in `deploy/k8s/` should mount the secret read-only and
     expose its path to the service (for instance, via a `SESSION_KEY_FILE`
     environment variable). Use high-entropy (≥64-byte) keys and rotate them by
-    deploying new secrets and reloading the service so the fresh key takes
-    effect while the previous key remains available for validating existing
-    sessions during the rollout.
+      deploying new secrets and reloading the service, so the fresh key takes
+      effect while the previous key remains available for validating existing
+      sessions during the rollout.
 
     For seamless rotation, run at least two replicas and perform a rolling
-    update so pods with the prior key continue to validate existing cookies
-    until expiry. A single-replica restart replaces the key atomically and will
-    invalidate all existing sessions immediately.
+      update, so pods with the prior key continue to validate existing cookies
+      until expiry. A single-replica restart replaces the key atomically and will
+      invalidate all existing sessions immediately.
 
   - [ ] **Observability:**
 


### PR DESCRIPTION
## Summary
- convert TLS guide to footnote citations and prune unused references
- enable ExternalDNS CRD and fix dig note
- correct Buildx context keys and backend session guidance

## Testing
- `make fmt`
- `make lint`
- `make test`
- `make markdownlint`


------
https://chatgpt.com/codex/tasks/task_e_68b9f5d9a3148322a4366abc65c9affa

## Summary by Sourcery

Clean up and standardize documentation references, update sample configuration snippets, and fix minor inconsistencies across multiple design and tutorial guides.

Documentation:
- Convert inline citations to numbered footnotes and prune unused references in the declarative TLS guide
- Enable CRD creation for ExternalDNS and clarify DNS resolution example in the declarative DNS guide
- Update Ingress path and refine Actix session management guidance in the backend design doc
- Correct indentation of Docker build contexts in CI/CD pipeline examples
- Fix a minor heading typo in the SRGN appendix