### PR TITLE
Add AsyncAPI and Makefile lint checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,7 @@ lint:
 	command -v checkmake >/dev/null || { echo "checkmake is not installed" >&2; exit 1; }
 	command -v mbake >/dev/null || { echo "mbake is not installed" >&2; exit 1; }
 	if [ -f spec/asyncapi.yaml ]; then bun x -y @asyncapi/cli@$(ASYNCAPI_CLI_VERSION) validate spec/asyncapi.yaml; fi
+	bun x -y @redocly/cli@latest lint spec/openapi.json
 	checkmake Makefile
 	mbake validate Makefile
 


### PR DESCRIPTION
## Summary
- validate AsyncAPI spec during lint
- lint Makefile with checkmake and mbake
- refactor markdownlint and yamllint targets for checkmake compliance

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bacaf045b483228b69ab63c5f34ffa

## Summary by Sourcery

Enhance the Makefile lint pipeline by adding AsyncAPI spec validation, Makefile lint checks, and improving existing markdown and YAML lint targets

New Features:
- Add AsyncAPI specification validation in the lint step
- Integrate Makefile linting with checkmake and mbake

Enhancements:
- Refactor markdownlint target to consolidate prune patterns
- Simplify yamllint invocation using an explicit if statement