### PR TITLE
Remove unused Biome suppression comments

### DIFF
--- a/frontend-pwa/src/api/fetcher.ts
+++ b/frontend-pwa/src/api/fetcher.ts
@@ -133,8 +133,6 @@ function getContentTypeForBody(body: unknown): string | null {
   if (isBinary(body)) return null;
   return 'application/json';
 }
-
-// biome-ignore lint/complexity/noExcessiveCognitiveComplexity: complexity reduced via helper function
 export const customFetch = async <T>(input: string, init?: RequestInit): Promise<T> => {
   const url = new URL(input, apiBase());
 

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -7,17 +7,14 @@
 import { z } from 'zod';
 
 /** Runtime schema for a branded user identifier. */
-/* biome-ignore lint/style/useNamingConvention: PascalCase aids readability for schema identifiers */
 export const UserIdSchema = z.string().brand<'UserId'>();
 /** Unique identifier for a user. */
 export type UserId = z.infer<typeof UserIdSchema>;
 
 /** Runtime schema for a user record. */
-/* biome-ignore lint/style/useNamingConvention: PascalCase aids readability for schema identifiers */
 export const UserSchema = z
   .object({
     id: UserIdSchema,
-    /* biome-ignore lint/style/useNamingConvention: API field uses snake_case */
     display_name: z.string().trim().min(1, 'display_name must not be empty'),
   })
   .strict();
@@ -25,7 +22,6 @@ export const UserSchema = z
 export type User = z.infer<typeof UserSchema>;
 
 /** Runtime schema for a list of user records. */
-/* biome-ignore lint/style/useNamingConvention: PascalCase aids readability for schema identifiers */
 export const UsersSchema = z.array(UserSchema);
 /** Collection of user records. */
 export type Users = z.infer<typeof UsersSchema>;


### PR DESCRIPTION
## Summary
- remove unused Biome ignore in custom fetch helper
- drop redundant naming-convention suppressions from shared user types

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb118bb4648322846b593a4dd2147f