### PR TITLE
Use UUID for user IDs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,26 +40,26 @@ fmt:
 	bun x biome format --write
 
 lint:
-    	cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings
-    	bun x biome ci --formatter-enabled=true --reporter=github frontend-pwa packages
-    	$(MAKE) lint-asyncapi
-    	$(MAKE) lint-openapi
-    	$(MAKE) lint-makefile
+	cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings
+	bun x biome ci --formatter-enabled=true --reporter=github frontend-pwa packages
+	$(MAKE) lint-asyncapi
+	$(MAKE) lint-openapi
+	$(MAKE) lint-makefile
 
 # Lint AsyncAPI spec if present. Split to keep `lint` target concise per checkmake rules.
 lint-asyncapi:
-    	if [ -f spec/asyncapi.yaml ]; then bun x -y @asyncapi/cli@$(ASYNCAPI_CLI_VERSION) validate spec/asyncapi.yaml; fi
+	if [ -f spec/asyncapi.yaml ]; then bun x -y @asyncapi/cli@$(ASYNCAPI_CLI_VERSION) validate spec/asyncapi.yaml; fi
 
 # Lint OpenAPI spec with Redocly CLI
 lint-openapi:
-    	bun x -y @redocly/cli@latest lint spec/openapi.json
+	bun x -y @redocly/cli@latest lint spec/openapi.json
 
 # Validate Makefile style and structure
 lint-makefile:
-    	command -v checkmake >/dev/null || { echo "checkmake is not installed" >&2; exit 1; }
-    	command -v mbake >/dev/null || { echo "mbake is not installed" >&2; exit 1; }
-    	checkmake Makefile
-    	mbake validate Makefile
+	command -v checkmake >/dev/null || { echo "checkmake is not installed" >&2; exit 1; }
+	command -v mbake >/dev/null || { echo "mbake is not installed" >&2; exit 1; }
+	checkmake Makefile
+	mbake validate Makefile
 
 test:
 	RUSTFLAGS="-D warnings" cargo test --manifest-path backend/Cargo.toml --all-targets --all-features

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,8 @@ SHELL := bash
 KUBE_VERSION ?= 1.31.0
 ASYNCAPI_CLI_VERSION ?= 3.4.2
 .PHONY: all clean be fe fe-build openapi gen docker-up docker-down fmt lint test typecheck deps \
-        check-fmt markdownlint markdownlint-docs mermaid-lint nixie yamllint audit
+        check-fmt markdownlint markdownlint-docs mermaid-lint nixie yamllint audit \
+        lint-asyncapi lint-openapi lint-makefile
 all: fmt lint test
 
 clean:
@@ -39,14 +40,26 @@ fmt:
 	bun x biome format --write
 
 lint:
-	cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings
-	bun x biome ci --formatter-enabled=true --reporter=github frontend-pwa packages
-	command -v checkmake >/dev/null || { echo "checkmake is not installed" >&2; exit 1; }
-	command -v mbake >/dev/null || { echo "mbake is not installed" >&2; exit 1; }
-	if [ -f spec/asyncapi.yaml ]; then bun x -y @asyncapi/cli@$(ASYNCAPI_CLI_VERSION) validate spec/asyncapi.yaml; fi
-	bun x -y @redocly/cli@latest lint spec/openapi.json
-	checkmake Makefile
-	mbake validate Makefile
+    	cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings
+    	bun x biome ci --formatter-enabled=true --reporter=github frontend-pwa packages
+    	$(MAKE) lint-asyncapi
+    	$(MAKE) lint-openapi
+    	$(MAKE) lint-makefile
+
+# Lint AsyncAPI spec if present. Split to keep `lint` target concise per checkmake rules.
+lint-asyncapi:
+    	if [ -f spec/asyncapi.yaml ]; then bun x -y @asyncapi/cli@$(ASYNCAPI_CLI_VERSION) validate spec/asyncapi.yaml; fi
+
+# Lint OpenAPI spec with Redocly CLI
+lint-openapi:
+    	bun x -y @redocly/cli@latest lint spec/openapi.json
+
+# Validate Makefile style and structure
+lint-makefile:
+    	command -v checkmake >/dev/null || { echo "checkmake is not installed" >&2; exit 1; }
+    	command -v mbake >/dev/null || { echo "mbake is not installed" >&2; exit 1; }
+    	checkmake Makefile
+    	mbake validate Makefile
 
 test:
 	RUSTFLAGS="-D warnings" cargo test --manifest-path backend/Cargo.toml --all-targets --all-features

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -308,6 +308,7 @@ dependencies = [
  "tracing-subscriber",
  "utoipa",
  "utoipa-swagger-ui",
+ "uuid",
 ]
 
 [[package]]
@@ -1663,6 +1664,7 @@ version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
+ "getrandom",
  "js-sys",
  "serde",
  "wasm-bindgen",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,6 +12,8 @@ serde_json = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 
+uuid = { version = "1", features = ["serde", "v4"] }
+
 # OpenAPI
 utoipa = { version = "5", features = ["macros", "uuid", "yaml", "actix_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }

--- a/backend/src/api/users.rs
+++ b/backend/src/api/users.rs
@@ -2,6 +2,7 @@
 
 use crate::models::User;
 use actix_web::{get, web, Result};
+use uuid::Uuid;
 
 /// List known users.
 #[utoipa::path(
@@ -18,7 +19,7 @@ use actix_web::{get, web, Result};
 #[get("/api/users")]
 pub async fn list_users() -> Result<web::Json<Vec<User>>> {
     let data = vec![User {
-        id: "u_1".into(),
+        id: Uuid::nil(),
         display_name: "Ada".into(),
     }];
     Ok(web::Json(data))

--- a/backend/src/api/users.rs
+++ b/backend/src/api/users.rs
@@ -13,13 +13,13 @@ use uuid::Uuid;
         (status = 401, description = "Unauthorised"),
         (status = 500, description = "Internal server error")
     ),
-    tags = ["Users"],
+    tags = ["users"],
     operation_id = "listUsers"
 )]
 #[get("/api/users")]
 pub async fn list_users() -> Result<web::Json<Vec<User>>> {
     let data = vec![User {
-        id: Uuid::nil(),
+        id: Uuid::new_v4(),
         display_name: "Ada".into(),
     }];
     Ok(web::Json(data))

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -2,14 +2,15 @@
 
 use serde::{Deserialize, Serialize};
 use utoipa::ToSchema;
+use uuid::Uuid;
 
 /// Application user.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, ToSchema)]
 #[serde(deny_unknown_fields)]
 pub struct User {
     /// Stable user identifier
-    #[schema(example = "u_1")]
-    pub id: String,
+    #[schema(example = "00000000-0000-0000-0000-000000000000")]
+    pub id: Uuid,
     /// Display name shown to other users
     #[schema(example = "Ada")]
     pub display_name: String,

--- a/backend/src/models/user.rs
+++ b/backend/src/models/user.rs
@@ -9,7 +9,7 @@ use uuid::Uuid;
 #[serde(deny_unknown_fields)]
 pub struct User {
     /// Stable user identifier
-    #[schema(example = "00000000-0000-0000-0000-000000000000")]
+    #[schema(example = "3fa85f64-5717-4562-b3fc-2c963f66afa6")]
     pub id: Uuid,
     /// Display name shown to other users
     #[schema(example = "Ada")]

--- a/packages/types/index.js
+++ b/packages/types/index.js
@@ -5,7 +5,7 @@
 import { z } from 'zod';
 
 /** Runtime schema for a branded user identifier. */
-export const UserIdSchema = z.string().brand();
+export const UserIdSchema = z.string().uuid().brand();
 /** Runtime schema for a user record. */
 export const UserSchema = z
   .object({

--- a/packages/types/src/user.ts
+++ b/packages/types/src/user.ts
@@ -7,7 +7,8 @@
 import { z } from 'zod';
 
 /** Runtime schema for a branded user identifier. */
-export const UserIdSchema = z.string().brand<'UserId'>();
+/* biome-ignore lint/style/useNamingConvention: PascalCase aids readability for schema identifiers */
+export const UserIdSchema = z.string().uuid().brand<'UserId'>();
 /** Unique identifier for a user. */
 export type UserId = z.infer<typeof UserIdSchema>;
 

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -105,13 +105,7 @@
         "description": "Stable machine-readable error code",
         "example": "invalid_request",
         "pattern": "^[a-z0-9_.:-]+$",
-        "enum": [
-          "invalid_request",
-          "unauthorized",
-          "forbidden",
-          "not_found",
-          "internal_error"
-        ],
+        "enum": ["invalid_request", "unauthorized", "forbidden", "not_found", "internal_error"],
         "x-enumDescriptions": [
           "The request is malformed or fails validation",
           "Authentication failed or is missing",

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -50,11 +50,11 @@
                     "summary": "Two users",
                     "value": [
                       {
-                        "id": "123e4567-e89b-12d3-a456-426614174000",
+                        "id": "00000000-0000-0000-0000-000000000000",
                         "display_name": "Ada Lovelace"
                       },
                       {
-                        "id": "123e4567-e89b-12d3-a456-426614174001",
+                        "id": "00000000-0000-0000-0000-000000000001",
                         "display_name": "Alan Turing"
                       }
                     ]
@@ -164,7 +164,7 @@
           "id": {
             "type": "string",
             "description": "Stable user identifier",
-            "example": "123e4567-e89b-12d3-a456-426614174000",
+            "example": "00000000-0000-0000-0000-000000000000",
             "format": "uuid"
           }
         }

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -50,11 +50,11 @@
                     "summary": "Two users",
                     "value": [
                       {
-                        "id": "00000000-0000-0000-0000-000000000000",
+                        "id": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
                         "display_name": "Ada Lovelace"
                       },
                       {
-                        "id": "00000000-0000-0000-0000-000000000001",
+                        "id": "7b1d3a62-0e3d-4f2f-8f94-3a5b5db02f0f",
                         "display_name": "Alan Turing"
                       }
                     ]
@@ -164,7 +164,7 @@
           "id": {
             "type": "string",
             "description": "Stable user identifier",
-            "example": "00000000-0000-0000-0000-000000000000",
+            "example": "3fa85f64-5717-4562-b3fc-2c963f66afa6",
             "format": "uuid"
           }
         }


### PR DESCRIPTION
## Summary
- replace user `id` string with `uuid::Uuid`
- generate nil UUID in user API example
- update OpenAPI examples to UUID
- add `uuid` crate dependency

## Testing
- `make fmt`
- `make lint` *(fails: mbake is not installed)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb13c1b6908322af02bac3ebdd48cf

## Summary by Sourcery

Use UUIDs for user identifiers throughout the backend by replacing String IDs with uuid::Uuid, updating examples and OpenAPI specs, and adding the uuid dependency.

New Features:
- Use uuid::Uuid for the User.id field instead of a String

Enhancements:
- Update API example to generate a nil UUID for user IDs
- Refresh OpenAPI spec examples to use UUID format

Build:
- Add uuid crate with serde and v4 support