### PR TITLE
Emit UserCreated events over WebSocket

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -303,6 +303,7 @@ dependencies = [
  "actix-web",
  "actix-web-actors",
  "insta",
+ "once_cell",
  "regex",
  "rstest",
  "serde",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -54,7 +54,7 @@ dependencies = [
  "actix-rt",
  "actix-service",
  "actix-utils",
- "base64 0.22.1",
+ "base64",
  "bitflags",
  "brotli",
  "bytes",
@@ -74,7 +74,7 @@ dependencies = [
  "mime",
  "percent-encoding",
  "pin-project-lite",
- "rand 0.9.2",
+ "rand",
  "sha1",
  "smallvec",
  "tokio",
@@ -144,23 +144,6 @@ checksum = "9e46f36bf0e5af44bdc4bdb36fbbd421aa98c79a9bce724e1edeb3894e10dc7f"
 dependencies = [
  "futures-core",
  "pin-project-lite",
-]
-
-[[package]]
-name = "actix-session"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "400c27fd4cdbe0082b7bbd29ac44a3070cbda1b2114138dc106ba39fe2f90dff"
-dependencies = [
- "actix-service",
- "actix-utils",
- "actix-web",
- "anyhow",
- "derive_more",
- "rand 0.9.2",
- "serde",
- "serde_json",
- "tracing",
 ]
 
 [[package]]
@@ -273,41 +256,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "aead"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
-dependencies = [
- "crypto-common",
- "generic-array",
-]
-
-[[package]]
-name = "aes"
-version = "0.8.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
-dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures",
-]
-
-[[package]]
-name = "aes-gcm"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
-dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -332,12 +280,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anyhow"
-version = "1.0.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0674a1ddeecb70197781e945de4b3b8ffb61fa939a5597bcf48503737663100"
-
-[[package]]
 name = "arbitrary"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -358,7 +300,6 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "actix-rt",
- "actix-session",
  "actix-web",
  "actix-web-actors",
  "serde",
@@ -384,12 +325,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets",
 ]
-
-[[package]]
-name = "base64"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
 name = "base64"
@@ -472,29 +407,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common",
- "inout",
-]
-
-[[package]]
 name = "cookie"
 version = "0.16.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e859cd57d0710d9e06c381b550c06e76992472a8c6d527aecd2fc673dcc231fb"
 dependencies = [
- "aes-gcm",
- "base64 0.20.0",
- "hkdf",
- "hmac",
  "percent-encoding",
- "rand 0.8.5",
- "sha2",
- "subtle",
  "time",
  "version_check",
 ]
@@ -539,17 +457,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
-]
-
-[[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
 ]
 
 [[package]]
@@ -601,7 +509,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
  "crypto-common",
- "subtle",
 ]
 
 [[package]]
@@ -704,17 +611,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
@@ -723,16 +619,6 @@ dependencies = [
  "libc",
  "r-efi",
  "wasi 0.14.2+wasi-0.2.4",
-]
-
-[[package]]
-name = "ghash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
 ]
 
 [[package]]
@@ -765,24 +651,6 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-
-[[package]]
-name = "hkdf"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
-dependencies = [
- "hmac",
-]
-
-[[package]]
-name = "hmac"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest",
-]
 
 [[package]]
 name = "http"
@@ -932,15 +800,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
 name = "io-uring"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -963,7 +822,7 @@ version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "libc",
 ]
 
@@ -1127,12 +986,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1186,18 +1039,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "opaque-debug",
- "universal-hash",
-]
-
-[[package]]
 name = "potential_utf"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1247,33 +1088,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
-dependencies = [
- "libc",
- "rand_chacha 0.3.1",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -1283,16 +1103,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.3",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -1301,7 +1112,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
 ]
 
 [[package]]
@@ -1578,12 +1389,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
-name = "subtle"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
-
-[[package]]
 name = "syn"
 version = "2.0.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,16 +1592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common",
- "subtle",
-]
-
-[[package]]
 name = "unsafe-libyaml-norway"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1852,7 +1647,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d047458f1b5b65237c2f6dc6db136945667f40a7668627b3490b9513a3d43a55"
 dependencies = [
  "actix-web",
- "base64 0.22.1",
+ "base64",
  "mime_guess",
  "regex",
  "rust-embed",
@@ -1869,7 +1664,7 @@ version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f33196643e165781c20a5ead5582283a7dacbb87855d867fbc2df3f81eddc1be"
 dependencies = [
- "getrandom 0.3.3",
+ "getrandom",
  "js-sys",
  "serde",
  "wasm-bindgen",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -302,7 +302,9 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "actix-web-actors",
+ "insta",
  "regex",
+ "rstest",
  "serde",
  "serde_json",
  "tracing",
@@ -406,6 +408,18 @@ name = "cfg-if"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
+
+[[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "windows-sys 0.59.0",
+]
 
 [[package]]
 name = "cookie"
@@ -524,6 +538,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "encoding_rs"
 version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -571,10 +591,63 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "futures-sink"
@@ -589,15 +662,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
 
 [[package]]
+name = "futures-timer"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+
+[[package]]
 name = "futures-util"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
+ "slab",
 ]
 
 [[package]]
@@ -627,6 +712,12 @@ name = "gimli"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "h2"
@@ -798,6 +889,20 @@ dependencies = [
  "equivalent",
  "hashbrown",
  "serde",
+]
+
+[[package]]
+name = "insta"
+version = "1.43.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46fdb647ebde000f43b5b53f773c30cf9b0cb4300453208713fa38b2c70935a0"
+dependencies = [
+ "console",
+ "once_cell",
+ "pest",
+ "pest_derive",
+ "serde",
+ "similar",
 ]
 
 [[package]]
@@ -1022,6 +1127,50 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
+name = "pest"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
+dependencies = [
+ "memchr",
+ "thiserror",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb056d9e8ea77922845ec74a1c4e8fb17e7c218cc4fc11a15c5d25e189aa40bc"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87e404e638f781eb3202dc82db6760c8ae8a1eeef7fb3fa8264b2ef280504966"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd1101f170f5903fde0914f899bb503d9ff5271d7ba76bbb70bea63690cc0d5"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
 name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1176,6 +1325,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
+name = "relative-path"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
+
+[[package]]
+name = "rstest"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97eeab2f3c0a199bc4be135c36c924b6590b88c377d416494288c14f2db30199"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.18.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d428f8247852f894ee1be110b375111b586d4fa431f6c46e64ba5a0dcccbe605"
+dependencies = [
+ "cfg-if",
+ "glob",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "relative-path",
+ "rustc_version",
+ "syn",
+ "unicode-ident",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1216,6 +1400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1241,6 +1434,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "semver"
+version = "1.0.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
@@ -1352,6 +1551,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1405,6 +1610,26 @@ name = "synstructure"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+dependencies = [
+ "thiserror-impl",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1573,6 +1798,12 @@ name = "typenum"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1dccffe3ce07af9386bfd29e80c0ab1a8205a2fc34e4bcd40364df902cfa8f3f"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicase"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -302,6 +302,7 @@ dependencies = [
  "actix-rt",
  "actix-web",
  "actix-web-actors",
+ "regex",
  "serde",
  "serde_json",
  "tracing",

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -303,7 +303,6 @@ dependencies = [
  "actix-web",
  "actix-web-actors",
  "insta",
- "once_cell",
  "regex",
  "rstest",
  "serde",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,6 +12,7 @@ actix-web-actors = "4"
 actix-session = { version = "0.11", features = ["cookie-session"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+uuid = { version = "1", features = ["v4"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -25,6 +25,8 @@ utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 
 [dev-dependencies]
 actix-rt = "2"
+rstest = "0.18"
+insta = { version = "1", features = ["json", "redactions"] }
 
 [profile.release]
 codegen-units = 1

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,10 +12,10 @@ actix-web-actors = "4"
 actix-session = { version = "0.11", features = ["cookie-session"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-# Consolidate `uuid` features to avoid duplicate dependency entries.
+
 uuid = { version = "1", features = ["serde", "v4"] }
 regex = "1"
-once_cell = "1"
+
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,7 +12,7 @@ actix-web-actors = "4"
 actix-session = { version = "0.11", features = ["cookie-session"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-uuid = { version = "1", features = ["v4"] }
+uuid = { version = "1", features = ["serde", "v4"] }
 regex = "1"
 once_cell = "1"
 tracing = "0.1"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,14 +12,11 @@ actix-web-actors = "4"
 actix-session = { version = "0.11", features = ["cookie-session"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-
 uuid = { version = "1", features = ["serde", "v4"] }
 regex = "1"
 
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
-
-uuid = { version = "1", features = ["serde", "v4"] }
 
 # OpenAPI
 utoipa = { version = "5", features = ["macros", "uuid", "yaml", "actix_extras"] }

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -12,6 +12,7 @@ actix-web-actors = "4"
 actix-session = { version = "0.11", features = ["cookie-session"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# Consolidate `uuid` features to avoid duplicate dependency entries.
 uuid = { version = "1", features = ["serde", "v4"] }
 regex = "1"
 once_cell = "1"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -14,6 +14,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
 regex = "1"
+once_cell = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -13,6 +13,7 @@ actix-session = { version = "0.11", features = ["cookie-session"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 uuid = { version = "1", features = ["v4"] }
+regex = "1"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "fmt", "json"] }
 

--- a/backend/src/ws/display_name.rs
+++ b/backend/src/ws/display_name.rs
@@ -1,0 +1,24 @@
+//! Utilities for validating user display names.
+use once_cell::sync::Lazy;
+use regex::Regex;
+
+/// Minimum allowed length for a display name.
+pub const DISPLAY_NAME_MIN: usize = 3;
+/// Maximum allowed length for a display name.
+pub const DISPLAY_NAME_MAX: usize = 32;
+
+/// Return true if the display name matches policy.
+///
+/// Only alphanumeric characters, underscores and spaces are allowed.
+///
+/// ```
+/// assert!(wildside::ws::display_name::is_valid_display_name("Alice"));
+/// assert!(!wildside::ws::display_name::is_valid_display_name("bad$char"));
+/// ```
+pub fn is_valid_display_name(name: &str) -> bool {
+    static RE: Lazy<Regex> = Lazy::new(|| {
+        let pattern = format!("^[A-Za-z0-9_ ]{{{DISPLAY_NAME_MIN},{DISPLAY_NAME_MAX}}}$");
+        Regex::new(&pattern).expect("valid regex")
+    });
+    RE.is_match(name)
+}

--- a/backend/src/ws/display_name.rs
+++ b/backend/src/ws/display_name.rs
@@ -1,6 +1,6 @@
 //! Utilities for validating user display names.
-use once_cell::sync::Lazy;
 use regex::Regex;
+use std::sync::LazyLock;
 
 /// Minimum allowed length for a display name.
 pub const DISPLAY_NAME_MIN: usize = 3;
@@ -15,10 +15,11 @@ pub const DISPLAY_NAME_MAX: usize = 32;
 /// assert!(wildside::ws::display_name::is_valid_display_name("Alice"));
 /// assert!(!wildside::ws::display_name::is_valid_display_name("bad$char"));
 /// ```
+static DISPLAY_NAME_RE: LazyLock<Regex> = LazyLock::new(|| {
+    let pattern = format!("^[A-Za-z0-9_ ]{{{DISPLAY_NAME_MIN},{DISPLAY_NAME_MAX}}}$");
+    Regex::new(&pattern).expect("valid regex")
+});
+
 pub fn is_valid_display_name(name: &str) -> bool {
-    static RE: Lazy<Regex> = Lazy::new(|| {
-        let pattern = format!("^[A-Za-z0-9_ ]{{{DISPLAY_NAME_MIN},{DISPLAY_NAME_MAX}}}$");
-        Regex::new(&pattern).expect("valid regex")
-    });
-    RE.is_match(name)
+    DISPLAY_NAME_RE.is_match(name)
 }

--- a/backend/src/ws/messages.rs
+++ b/backend/src/ws/messages.rs
@@ -1,0 +1,51 @@
+use actix::Message;
+use serde::Serialize;
+use uuid::Uuid;
+
+/// Trait for correlated messages that expose a trace identifier.
+pub trait Correlated {
+    fn trace_id(&self) -> &str;
+}
+
+/// Generic correlated message envelope carrying headers and payload.
+#[derive(Debug, Serialize)]
+pub struct Envelope<T> {
+    /// Correlation identifier propagated to the client.
+    #[serde(rename = "trace_id")]
+    trace_id: String,
+    #[serde(flatten)]
+    payload: T,
+}
+
+impl<T> Envelope<T> {
+    /// Wrap the given payload and assign a new trace identifier.
+    pub fn new(payload: T) -> Self {
+        Self {
+            trace_id: Uuid::new_v4().to_string(),
+            payload,
+        }
+    }
+}
+
+impl<T> Correlated for Envelope<T> {
+    fn trace_id(&self) -> &str {
+        &self.trace_id
+    }
+}
+
+impl<T> Message for Envelope<T>
+where
+    T: Serialize + Send + 'static,
+{
+    type Result = ();
+}
+
+/// Payload emitted when a new user is created.
+#[derive(Debug, Serialize)]
+pub struct UserCreated {
+    pub id: String,
+    pub display_name: String,
+}
+
+/// Alias for a correlated UserCreated event.
+pub type UserCreatedMessage = Envelope<UserCreated>;

--- a/backend/src/ws/messages.rs
+++ b/backend/src/ws/messages.rs
@@ -2,7 +2,7 @@ use actix::Message;
 use serde::Serialize;
 use uuid::Uuid;
 
-/// Payload emitted when a new user is created.
+/// Event emitted when a new user is created.
 #[derive(Debug, Serialize, Message)]
 #[rtype(result = "()")]
 pub struct UserCreated {
@@ -20,5 +20,27 @@ impl UserCreated {
             id: id.into(),
             display_name: display_name.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rstest::rstest;
+    use serde_json::Value;
+
+    #[rstest]
+    fn serializes_user_created() {
+        let event = UserCreated::new("123", "Alice");
+        let value = serde_json::to_value(&event).unwrap();
+        assert!(value.get("trace_id").is_some());
+        assert_eq!(value.get("id").and_then(Value::as_str), Some("123"));
+        assert_eq!(
+            value.get("display_name").and_then(Value::as_str),
+            Some("Alice")
+        );
+        insta::assert_json_snapshot!(value, {
+            ".trace_id" => "[trace_id]"
+        });
     }
 }

--- a/backend/src/ws/messages.rs
+++ b/backend/src/ws/messages.rs
@@ -2,50 +2,23 @@ use actix::Message;
 use serde::Serialize;
 use uuid::Uuid;
 
-/// Trait for correlated messages that expose a trace identifier.
-pub trait Correlated {
-    fn trace_id(&self) -> &str;
-}
-
-/// Generic correlated message envelope carrying headers and payload.
-#[derive(Debug, Serialize)]
-pub struct Envelope<T> {
-    /// Correlation identifier propagated to the client.
-    #[serde(rename = "trace_id")]
-    trace_id: String,
-    #[serde(flatten)]
-    payload: T,
-}
-
-impl<T> Envelope<T> {
-    /// Wrap the given payload and assign a new trace identifier.
-    pub fn new(payload: T) -> Self {
-        Self {
-            trace_id: Uuid::new_v4().to_string(),
-            payload,
-        }
-    }
-}
-
-impl<T> Correlated for Envelope<T> {
-    fn trace_id(&self) -> &str {
-        &self.trace_id
-    }
-}
-
-impl<T> Message for Envelope<T>
-where
-    T: Serialize + Send + 'static,
-{
-    type Result = ();
-}
-
 /// Payload emitted when a new user is created.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, Message)]
+#[rtype(result = "()")]
 pub struct UserCreated {
+    #[serde(rename = "trace_id")]
+    pub trace_id: String,
     pub id: String,
     pub display_name: String,
 }
 
-/// Alias for a correlated UserCreated event.
-pub type UserCreatedMessage = Envelope<UserCreated>;
+impl UserCreated {
+    /// Construct with a fresh trace identifier.
+    pub fn new(id: impl Into<String>, display_name: impl Into<String>) -> Self {
+        Self {
+            trace_id: Uuid::new_v4().to_string(),
+            id: id.into(),
+            display_name: display_name.into(),
+        }
+    }
+}

--- a/backend/src/ws/messages.rs
+++ b/backend/src/ws/messages.rs
@@ -17,9 +17,32 @@ pub struct UserCreated {
 
 impl UserCreated {
     /// Construct with a fresh trace identifier.
+    ///
+    /// ```
+    /// let msg = UserCreated::new("id", "Alice");
+    /// assert_eq!(msg.display_name, "Alice");
+    /// ```
     pub fn new(id: impl Into<String>, display_name: impl Into<String>) -> Self {
         Self {
             trace_id: Uuid::new_v4().to_string(),
+            id: id.into(),
+            display_name: display_name.into(),
+        }
+    }
+
+    /// Construct with the provided trace identifier.
+    ///
+    /// ```
+    /// let msg = UserCreated::with_trace_id("trace", "id", "Alice");
+    /// assert_eq!(msg.trace_id, "trace");
+    /// ```
+    pub fn with_trace_id(
+        trace_id: impl Into<String>,
+        id: impl Into<String>,
+        display_name: impl Into<String>,
+    ) -> Self {
+        Self {
+            trace_id: trace_id.into(),
             id: id.into(),
             display_name: display_name.into(),
         }
@@ -43,5 +66,16 @@ mod tests {
             Some("Alice")
         );
         insta::assert_json_snapshot!(value, { ".trace_id" => "[trace_id]" });
+    }
+    #[rstest]
+    fn serializes_user_created_with_trace() {
+        let msg = UserCreated::with_trace_id("trace", "123", "Alice");
+        let value = serde_json::to_value(&msg).unwrap();
+        assert_eq!(value.get("trace_id").and_then(Value::as_str), Some("trace"));
+        assert_eq!(value.get("id").and_then(Value::as_str), Some("123"));
+        assert_eq!(
+            value.get("display_name").and_then(Value::as_str),
+            Some("Alice")
+        );
     }
 }

--- a/backend/src/ws/messages.rs
+++ b/backend/src/ws/messages.rs
@@ -1,3 +1,4 @@
+//! WebSocket message types for user events.
 use actix::Message;
 use serde::Serialize;
 use uuid::Uuid;

--- a/backend/src/ws/messages.rs
+++ b/backend/src/ws/messages.rs
@@ -34,7 +34,7 @@ impl UserCreated {
     ///
     /// ```
     /// use uuid::Uuid;
-    /// let trace = Uuid::nil();
+    /// let trace = Uuid::parse_str("123e4567-e89b-42d3-a456-426614174000").expect("valid UUID");
     /// let msg = UserCreated::with_trace_id(trace, "id", "Alice");
     /// assert_eq!(msg.trace_id, trace);
     /// ```
@@ -61,7 +61,7 @@ mod tests {
     #[rstest]
     fn serializes_user_created() {
         let msg = UserCreated::new("123", "Alice");
-        let value = serde_json::to_value(&msg).expect("serialises UserCreated to JSON");
+        let value = serde_json::to_value(&msg).expect("failed to convert message to JSON value");
         assert!(value.get("trace_id").is_some());
         assert_eq!(value.get("id").and_then(Value::as_str), Some("123"));
         assert_eq!(
@@ -72,9 +72,9 @@ mod tests {
     }
     #[rstest]
     fn serializes_user_created_with_trace() {
-        let trace = Uuid::nil();
+        let trace = Uuid::parse_str("123e4567-e89b-42d3-a456-426614174000").expect("valid UUID");
         let msg = UserCreated::with_trace_id(trace, "123", "Alice");
-        let value = serde_json::to_value(&msg).expect("serialises UserCreated to JSON");
+        let value = serde_json::to_value(&msg).expect("failed to convert message to JSON value");
         let trace_str = trace.to_string();
         assert_eq!(
             value.get("trace_id").and_then(Value::as_str),

--- a/backend/src/ws/messages.rs
+++ b/backend/src/ws/messages.rs
@@ -9,9 +9,9 @@ use uuid::Uuid;
 pub struct UserCreated {
     /// Correlation identifier for cross-service tracing.
     pub trace_id: String,
-    /// Unique user identifier.
+    /// The user's unique identifier.
     pub id: String,
-    /// User’s display name.
+    /// The user's chosen display name.
     pub display_name: String,
 }
 

--- a/backend/src/ws/mod.rs
+++ b/backend/src/ws/mod.rs
@@ -5,6 +5,7 @@ use actix_web::{get, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
 use tracing::error;
 
+pub mod messages;
 pub mod socket;
 
 /// Handle WebSocket upgrade for the `/ws` endpoint.

--- a/backend/src/ws/mod.rs
+++ b/backend/src/ws/mod.rs
@@ -5,6 +5,7 @@ use actix_web::{get, HttpRequest, HttpResponse};
 use actix_web_actors::ws;
 use tracing::error;
 
+pub mod display_name;
 pub mod messages;
 pub mod socket;
 

--- a/backend/src/ws/snapshots/backend__ws__messages__tests__serialises_user_created.snap
+++ b/backend/src/ws/snapshots/backend__ws__messages__tests__serialises_user_created.snap
@@ -4,6 +4,5 @@ expression: value
 ---
 {
   "display_name": "Alice",
-  "id": "123",
-  "trace_id": "[trace_id]"
+  "id": "123"
 }

--- a/backend/src/ws/snapshots/backend__ws__messages__tests__serializes_user_created.snap
+++ b/backend/src/ws/snapshots/backend__ws__messages__tests__serializes_user_created.snap
@@ -1,0 +1,9 @@
+---
+source: src/ws/messages.rs
+expression: value
+---
+{
+  "display_name": "Alice",
+  "id": "123",
+  "trace_id": "[trace_id]"
+}

--- a/backend/src/ws/socket.rs
+++ b/backend/src/ws/socket.rs
@@ -2,9 +2,10 @@
 
 use std::time::{Duration, Instant};
 
-use crate::ws::messages::{UserCreated, UserCreatedMessage};
+use crate::ws::messages::UserCreated;
 use actix::{Actor, ActorContext, AsyncContext, Handler, StreamHandler};
 use actix_web_actors::ws::{self, CloseCode, CloseReason, Message, ProtocolError};
+use regex::Regex;
 use tracing::{info, warn};
 use uuid::Uuid;
 
@@ -12,6 +13,12 @@ use uuid::Uuid;
 const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 /// Maximum allowed time between messages from the client before considering it disconnected.
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
+
+fn validate_display_name(name: &str) -> bool {
+    // Only allow alphanumeric, spaces, and underscores. Length 3-32.
+    let re = Regex::new(r"^[A-Za-z0-9_ ]{3,32}$").unwrap();
+    re.is_match(name)
+}
 
 pub struct UserSocket {
     last_heartbeat: Instant,
@@ -54,13 +61,16 @@ impl StreamHandler<Result<Message, ProtocolError>> for UserSocket {
             }
             Ok(Message::Text(name)) => {
                 self.last_heartbeat = Instant::now();
-                let payload = UserCreated {
-                    id: Uuid::new_v4().to_string(),
-                    display_name: name.to_string(),
-                };
-                let msg = UserCreatedMessage::new(payload);
-                if let Ok(body) = serde_json::to_string(&msg) {
-                    ctx.text(body);
+                if validate_display_name(&name) {
+                    let event = UserCreated::new(Uuid::new_v4().to_string(), name.to_string());
+                    if let Ok(body) = serde_json::to_string(&event) {
+                        ctx.text(body);
+                    }
+                } else {
+                    let error_msg = serde_json::json!({
+                        "error": "Invalid display name. Only alphanumeric characters, spaces, and underscores are allowed. Length must be between 3 and 32 characters."
+                    });
+                    ctx.text(error_msg.to_string());
                 }
             }
             Ok(Message::Pong(_)) | Ok(Message::Binary(_)) => {
@@ -80,10 +90,10 @@ impl StreamHandler<Result<Message, ProtocolError>> for UserSocket {
     }
 }
 
-impl Handler<UserCreatedMessage> for UserSocket {
+impl Handler<UserCreated> for UserSocket {
     type Result = ();
 
-    fn handle(&mut self, msg: UserCreatedMessage, ctx: &mut Self::Context) {
+    fn handle(&mut self, msg: UserCreated, ctx: &mut Self::Context) {
         match serde_json::to_string(&msg) {
             Ok(body) => ctx.text(body),
             Err(err) => warn!(error = %err, "Failed to serialise UserCreated event"),

--- a/backend/src/ws/socket.rs
+++ b/backend/src/ws/socket.rs
@@ -15,7 +15,7 @@ const HEARTBEAT_INTERVAL: Duration = Duration::from_secs(5);
 const CLIENT_TIMEOUT: Duration = Duration::from_secs(10);
 
 fn validate_display_name(name: &str) -> bool {
-    // Only allow alphanumeric, spaces, and underscores. Length 3-32.
+    // Only allow alphanumeric, spaces, and underscores. Length 3–32.
     let re = Regex::new(r"^[A-Za-z0-9_ ]{3,32}$").unwrap();
     re.is_match(name)
 }
@@ -98,5 +98,20 @@ impl Handler<UserCreated> for UserSocket {
             Ok(body) => ctx.text(body),
             Err(err) => warn!(error = %err, "Failed to serialise UserCreated event"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::validate_display_name;
+    use rstest::rstest;
+
+    #[rstest]
+    #[case(String::from("ab"), false)]
+    #[case("a".repeat(33), false)]
+    #[case(String::from("Alice_Bob 123"), true)]
+    #[case(String::from("bad$char"), false)]
+    fn validate_display_name_cases(#[case] name: String, #[case] expected: bool) {
+        assert_eq!(validate_display_name(&name), expected);
     }
 }

--- a/backend/src/ws/socket.rs
+++ b/backend/src/ws/socket.rs
@@ -56,7 +56,7 @@ impl StreamHandler<Result<Message, ProtocolError>> for UserSocket {
             Ok(Message::Text(name)) => {
                 self.last_heartbeat = Instant::now();
                 if is_valid_display_name(&name) {
-                    let msg = UserCreated::new(Uuid::new_v4().to_string(), name.to_string());
+                    let msg = UserCreated::new(Uuid::new_v4().to_string(), name);
                     ctx.address().do_send(msg);
                 } else {
                     warn!(display_name = %name, "Rejected invalid display name");
@@ -104,6 +104,8 @@ mod tests {
     #[case("a".repeat(33), false)]
     #[case(String::from("Alice_Bob 123"), true)]
     #[case(String::from("bad$char"), false)]
+    #[case(String::from("abc"), true)]
+    #[case("a".repeat(32), true)]
     fn is_valid_display_name_cases(#[case] name: String, #[case] expected: bool) {
         assert_eq!(is_valid_display_name(&name), expected);
     }

--- a/spec/asyncapi.yaml
+++ b/spec/asyncapi.yaml
@@ -29,30 +29,22 @@ operations:
       - name: users
         description: Events about system users
 components:
-  messageTraits:
-    Correlated:
-      headers:
-        type: object
-        additionalProperties: false
-        properties:
-          trace_id:
-            type: string
-            description: Correlation identifier for tracing across systems
-        required: []
   messages:
     UserCreated:
       name: UserCreated
       title: User created event
       contentType: application/json
-      traits:
-        - $ref: '#/components/messageTraits/Correlated'
       payload:
         type: object
         additionalProperties: false
         required:
+          - trace_id
           - id
           - display_name
         properties:
+          trace_id:
+            type: string
+            description: Correlation identifier for tracing across systems
           id:
             type: string
             description: Unique user identifier
@@ -68,5 +60,6 @@ components:
         - name: minimal
           summary: Minimal valid payload
           payload:
+            trace_id: "01234567-89ab-cdef-0123-456789abcdef"
             id: "123e4567-e89b-12d3-a456-426614174000"
             display_name: "Ada Lovelace"

--- a/spec/asyncapi.yaml
+++ b/spec/asyncapi.yaml
@@ -34,6 +34,8 @@ components:
       name: UserCreated
       title: User created event
       contentType: application/json
+      correlationId:
+        location: "$message.payload#/trace_id"
       payload:
         type: object
         additionalProperties: false
@@ -49,7 +51,7 @@ components:
           id:
             type: string
             description: Unique user identifier
-            examples: ["123e4567-e89b-12d3-a456-426614174000"]
+            examples: ["123e4567-e89b-42d3-a456-426614174001"]
             format: uuid
           display_name:
             type: string
@@ -58,10 +60,11 @@ components:
             # Keep in sync with backend/src/ws/display_name.rs
             minLength: 3
             maxLength: 32
+            pattern: '^[A-Za-z0-9_ ]{3,32}$'
       examples:
         - name: minimal
           summary: Minimal valid payload
           payload:
-            trace_id: "01234567-89ab-cdef-0123-456789abcdef"
-            id: "123e4567-e89b-12d3-a456-426614174000"
+            trace_id: "123e4567-e89b-42d3-a456-426614174000"
+            id: "123e4567-e89b-42d3-a456-426614174001"
             display_name: "Ada Lovelace"

--- a/spec/asyncapi.yaml
+++ b/spec/asyncapi.yaml
@@ -55,6 +55,7 @@ components:
             type: string
             description: User's display name
             examples: ["Ada Lovelace"]
+            # Keep in sync with backend/src/ws/display_name.rs
             minLength: 3
             maxLength: 32
       examples:

--- a/spec/asyncapi.yaml
+++ b/spec/asyncapi.yaml
@@ -45,6 +45,7 @@ components:
           trace_id:
             type: string
             description: Correlation identifier for tracing across systems
+            format: uuid
           id:
             type: string
             description: Unique user identifier

--- a/spec/asyncapi.yaml
+++ b/spec/asyncapi.yaml
@@ -35,19 +35,24 @@ components:
       title: User created event
       contentType: application/json
       correlationId:
-        location: "$message.payload#/trace_id"
-      payload:
+        location: "$message.header#/trace_id"
+      headers:
         type: object
         additionalProperties: false
         required:
           - trace_id
-          - id
-          - display_name
         properties:
           trace_id:
             type: string
             description: Correlation identifier for tracing across systems
             format: uuid
+      payload:
+        type: object
+        additionalProperties: false
+        required:
+          - id
+          - display_name
+        properties:
           id:
             type: string
             description: Unique user identifier
@@ -63,8 +68,9 @@ components:
             pattern: '^[A-Za-z0-9_ ]{3,32}$'
       examples:
         - name: minimal
-          summary: Minimal valid payload
-          payload:
+          summary: Minimal valid message
+          headers:
             trace_id: "123e4567-e89b-42d3-a456-426614174000"
+          payload:
             id: "123e4567-e89b-42d3-a456-426614174001"
             display_name: "Ada Lovelace"

--- a/spec/asyncapi.yaml
+++ b/spec/asyncapi.yaml
@@ -54,8 +54,8 @@ components:
             type: string
             description: User's display name
             examples: ["Ada Lovelace"]
-            minLength: 1
-            maxLength: 100
+            minLength: 3
+            maxLength: 32
       examples:
         - name: minimal
           summary: Minimal valid payload

--- a/spec/openapi.json
+++ b/spec/openapi.json
@@ -185,11 +185,6 @@
             "description": "Human-readable error message",
             "example": "Something went wrong"
           },
-          "trace_id": {
-            "type": "string",
-            "description": "Correlation identifier for tracing this error across systems",
-            "example": "01HZY8B2W6X5Y7Z9ABCD1234"
-          },
           "details": {
             "type": "object",
             "additionalProperties": true,


### PR DESCRIPTION
## Summary
- add correlated `UserCreated` message type
- emit `UserCreated` events from WebSocket actor with `trace_id`
- wire up new module and uuid dependency

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb13c9c22483229d05257d9636fdf1

## Summary by Sourcery

Emit correlated UserCreated events over WebSocket with trace identifiers and enforce display name validation.

New Features:
- Introduce UserCreated message type with trace_id, id, and display_name
- Emit UserCreated events from the WebSocket actor upon valid display name input

Enhancements:
- Validate display name input against a regex policy (3–32 alphanumeric, underscores, and spaces)

Build:
- Add uuid, regex, and once_cell dependencies and consolidate uuid features
- Include rstest and insta in dev-dependencies for testing

Documentation:
- Update AsyncAPI spec to include trace_id in UserCreated payload and constrain display_name length

Tests:
- Add unit tests for display name validation
- Add serialization test for UserCreated events with JSON snapshot