### PR TITLE
Add shared Rust setup action to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
         run: make typecheck
 
       # Backend
+      - uses: leynos/shared-actions/.github/actions/setup-rust@c2b856998a4438bfdaa71c90cde1b03044e5d260
       - name: Rust build
         run: cargo build --manifest-path backend/Cargo.toml --release
       - name: Cache cargo


### PR DESCRIPTION
## Summary
- ensure Rust toolchain is set up in CI before backend build and tests

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb6aa340dc8322b572563f8a86fad1

## Summary by Sourcery

CI:
- Introduce a step to run the shared Rust setup action prior to the backend cargo build