### PR TITLE
Harden DOKS node pool validation and tooling checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,8 +113,11 @@ yamllint:
         (set -o pipefail; helm template wildside ./deploy/charts/wildside -f <(yq e '.spec.values' deploy/k8s/overlays/production/patch-helmrelease-values.yaml) --kube-version $(KUBE_VERSION) | yamllint -f parsable -)
 
 .PHONY: conftest tofu doks-test
-conftest tofu:
-	$(call ensure_tool,$@)
+conftest:
+        $(call ensure_tool,conftest)
+
+tofu:
+        $(call ensure_tool,tofu)
 
 doks-test:
 	tofu fmt -check infra/modules/doks

--- a/infra/modules/doks/main.tf
+++ b/infra/modules/doks/main.tf
@@ -13,7 +13,7 @@ resource "digitalocean_kubernetes_cluster" "this" {
       auto_scale = node_pool.value.auto_scale
       min_nodes  = node_pool.value.min_nodes
       max_nodes  = node_pool.value.max_nodes
-      tags       = node_pool.value.tags
+      tags       = coalesce(node_pool.value.tags, [])
     }
   }
 }

--- a/infra/modules/doks/outputs.tf
+++ b/infra/modules/doks/outputs.tf
@@ -11,5 +11,5 @@ output "endpoint" {
 output "kubeconfig" {
   description = "Raw kubeconfig for the cluster"
   sensitive   = true
-  value       = var.expose_kubeconfig ? digitalocean_kubernetes_cluster.this.kube_config[0].raw_config : null
+  value       = var.expose_kubeconfig && length(digitalocean_kubernetes_cluster.this.kube_config) > 0 ? digitalocean_kubernetes_cluster.this.kube_config[0].raw_config : null
 }

--- a/infra/modules/doks/tests/doks_test.go
+++ b/infra/modules/doks/tests/doks_test.go
@@ -15,23 +15,23 @@ import (
 )
 
 func testVars() map[string]interface{} {
-        return map[string]interface{}{
-                "cluster_name":       "terratest-cluster",
-                "region":             "nyc1",
-                "kubernetes_version": "1.28.0-do.0",
-                "node_pools": []map[string]interface{}{
-                        {
-                                "name":       "default",
-                                "size":       "s-2vcpu-2gb",
-                                "node_count": 2,
-                                "auto_scale": false,
-                                "min_nodes":  2,
-                                "max_nodes":  2,
-                        },
-                },
-                "tags": []string{"terratest"},
-                "expose_kubeconfig": true,
-        }
+	return map[string]interface{}{
+		"cluster_name":       "terratest-cluster",
+		"region":             "nyc1",
+		"kubernetes_version": "1.28.0-do.0",
+		"node_pools": []map[string]interface{}{
+			{
+				"name":       "default",
+				"size":       "s-2vcpu-2gb",
+				"node_count": 2,
+				"auto_scale": false,
+				"min_nodes":  2,
+				"max_nodes":  2,
+			},
+		},
+		"tags":              []string{"terratest"},
+		"expose_kubeconfig": true,
+	}
 }
 
 func setupTerraform(t *testing.T, vars map[string]interface{}, env map[string]string) (string, *terraform.Options) {
@@ -57,18 +57,18 @@ func TestDoksModuleValidate(t *testing.T) {
 }
 
 func TestDoksModulePlanUnauthenticated(t *testing.T) {
-        t.Parallel()
+	t.Parallel()
 
-        vars := testVars()
-        vars["cluster_name"] = fmt.Sprintf("terratest-%s", strings.ToLower(random.UniqueId()))
-       _, opts := setupTerraform(t, vars, map[string]string{"DIGITALOCEAN_TOKEN": ""})
+	vars := testVars()
+	vars["cluster_name"] = fmt.Sprintf("terratest-%s", strings.ToLower(random.UniqueId()))
+	_, opts := setupTerraform(t, vars, map[string]string{"DIGITALOCEAN_TOKEN": ""})
 
-        _, err := terraform.InitAndPlanE(t, opts)
-        if err == nil {
-                _, err = terraform.ApplyE(t, opts)
-        }
-        require.Error(t, err, "expected error when DIGITALOCEAN_TOKEN is missing")
-        require.Contains(t, err.Error(), "Unable to authenticate", "error message should mention authentication failure")
+	_, err := terraform.InitAndPlanE(t, opts)
+	if err == nil {
+		_, err = terraform.ApplyE(t, opts)
+	}
+	require.Error(t, err, "expected error when DIGITALOCEAN_TOKEN is missing")
+	require.Contains(t, err.Error(), "Unable to authenticate", "error message should mention authentication failure")
 }
 
 func TestDoksModuleApplyIfTokenPresent(t *testing.T) {
@@ -109,12 +109,12 @@ func TestDoksModulePolicy(t *testing.T) {
 	require.NoError(t, err)
 	jsonPath := filepath.Join(tfDir, "plan.json")
 	require.NoError(t, os.WriteFile(jsonPath, []byte(show), 0600))
-        policyPath, err := filepath.Abs(filepath.Join("..", "policy"))
-        require.NoError(t, err)
-        cmd := exec.Command("conftest", "test", jsonPath, "--policy", policyPath)
-        cmd.Dir = tfDir
-        output, err := cmd.CombinedOutput()
-        require.NoErrorf(t, err, "conftest failed: %s", string(output))
+	policyPath, err := filepath.Abs(filepath.Join("..", "policy"))
+	require.NoError(t, err)
+	cmd := exec.Command("conftest", "test", jsonPath, "--policy", policyPath)
+	cmd.Dir = tfDir
+	output, err := cmd.CombinedOutput()
+	require.NoErrorf(t, err, "conftest failed: %s", string(output))
 }
 
 func TestDoksModuleInvalidInputs(t *testing.T) {
@@ -149,14 +149,14 @@ func TestDoksModuleInvalidInputs(t *testing.T) {
 			},
 			ErrContains: "kubernetes_version must match",
 		},
-                "MissingKubernetesVersion": {
-                        Vars: map[string]interface{}{
-                                "cluster_name": "terratest-cluster",
-                                "region":       "nyc1",
-                                "node_pools":   testVars()["node_pools"],
-                        },
-                        ErrContains: "kubernetes_version",
-                },
+		"MissingKubernetesVersion": {
+			Vars: map[string]interface{}{
+				"cluster_name": "terratest-cluster",
+				"region":       "nyc1",
+				"node_pools":   testVars()["node_pools"],
+			},
+			ErrContains: "kubernetes_version",
+		},
 		"EmptyNodePools": {
 			Vars: map[string]interface{}{
 				"cluster_name":       "terratest-cluster",
@@ -164,7 +164,7 @@ func TestDoksModuleInvalidInputs(t *testing.T) {
 				"kubernetes_version": "1.28.0-do.0",
 				"node_pools":         []map[string]interface{}{},
 			},
-			ErrContains: "each node pool requires at least one node",
+			ErrContains: "node_pools must not be empty",
 		},
 		"ZeroNodes": {
 			Vars: map[string]interface{}{
@@ -182,7 +182,7 @@ func TestDoksModuleInvalidInputs(t *testing.T) {
 					},
 				},
 			},
-			ErrContains: "each node pool requires at least one node",
+			ErrContains: "node_count >= 2",
 		},
 	}
 

--- a/infra/modules/doks/variables.tf
+++ b/infra/modules/doks/variables.tf
@@ -45,11 +45,14 @@ variable "node_pools" {
   validation {
     condition = length(var.node_pools) > 0 && alltrue([
       for np in var.node_pools :
-      np.node_count >= 1 &&
-      np.min_nodes >= 1 &&
-      np.max_nodes >= np.min_nodes
+      (
+        np.auto_scale ?
+        (np.min_nodes >= 2 && np.max_nodes >= np.min_nodes)
+        :
+        (np.node_count >= 2)
+      )
     ])
-    error_message = "each node pool requires at least one node with min_nodes >= 1 and max_nodes >= min_nodes"
+    error_message = "node_pools must not be empty and each node pool must have node_count >= 2 when auto_scale is false, or min_nodes >= 2 and max_nodes >= min_nodes when auto_scale is true"
   }
 }
 


### PR DESCRIPTION
## Summary
- separate conftest and tofu tooling checks
- enforce HA semantics in DOKS node pool validation and tests
- guard against null tags and empty kube configs

## Testing
- `make check-fmt`
- `cargo clippy --manifest-path backend/Cargo.toml --all-targets --all-features -- -D warnings`
- `make lint` *(fails: interrupt during @asyncapi/studio installation)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0f0fc0ac83229407f0551cab54c6