### PR TITLE
Add quick start README for DOKS module

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,8 @@
 SHELL := bash
 KUBE_VERSION ?= 1.31.0
+# Supported DigitalOcean Kubernetes release. Update to a current patch from
+# the 1.33.x, 1.32.x or 1.31.x series as listed in the DigitalOcean docs.
+DOKS_KUBERNETES_VERSION ?= 1.33.9-do.0
 
 define ensure_tool
 	@command -v $(1) >/dev/null 2>&1 || { \
@@ -131,7 +134,7 @@ doks-test:
 	tofu -chdir=infra/modules/doks/examples/basic plan -detailed-exitcode \
 	-var cluster_name=test \
 	-var region=nyc1 \
-	-var kubernetes_version=1.28.0-do.0 \
+        -var kubernetes_version=$(DOKS_KUBERNETES_VERSION) \
 	-var 'node_pools=[{"name"="default","size"="s-2vcpu-2gb","node_count"=2,"auto_scale"=false,"min_nodes"=2,"max_nodes"=2}]' \
 	|| test $$? -eq 2
 	$(MAKE) doks-policy
@@ -141,7 +144,7 @@ doks-policy: conftest tofu
 	tofu -chdir=infra/modules/doks/examples/basic plan -out=tfplan.binary -detailed-exitcode \
 	-var cluster_name=test \
 	-var region=nyc1 \
-	-var kubernetes_version=1.28.0-do.0 \
+        -var kubernetes_version=$(DOKS_KUBERNETES_VERSION) \
 	-var 'node_pools=[{"name"="default","size"="s-2vcpu-2gb","node_count"=2,"auto_scale"=false,"min_nodes"=2,"max_nodes"=2}]' \
 	|| test $$? -eq 2
 	tofu -chdir=infra/modules/doks/examples/basic show -json tfplan.binary > infra/modules/doks/examples/basic/plan.json

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -1,0 +1,44 @@
+# DOKS Module
+
+Provision a DigitalOcean Kubernetes (DOKS) cluster.
+
+## Quick start
+
+Set the DigitalOcean token so the provider can authenticate:
+
+```sh
+export DIGITALOCEAN_TOKEN="your-token"
+```
+
+Configure the provider and call the module:
+
+```hcl
+terraform {
+  required_providers {
+    digitalocean = {
+      source  = "digitalocean/digitalocean"
+      version = "~> 2.0"
+    }
+  }
+}
+
+provider "digitalocean" {}
+
+module "doks" {
+  source = "git::https://github.com/OWNER/wildside.git//infra/modules/doks?ref=main"
+
+  cluster_name       = "example"
+  region             = "nyc1"
+  kubernetes_version = "1.28.0-do.0"
+
+  node_pools = [{
+    name       = "default"
+    size       = "s-2vcpu-4gb"
+    node_count = 3
+    auto_scale = false
+    min_nodes  = 1
+    max_nodes  = 3
+  }]
+}
+```
+

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -64,7 +64,8 @@ terraform output -raw kubeconfig > kubeconfig.yaml
 terraform output endpoint
 ```
 
-For advanced provider configuration, consult the [DigitalOcean provider documentation](https://registry.terraform.io/providers/opentofu/digitalocean/latest/docs).
+Consult the DigitalOcean provider docs for advanced configuration:
+<https://registry.terraform.io/providers/opentofu/digitalocean/latest/docs>
 
-For modules published under a different account, substitute `OWNER` with the GitHub account name that hosts the repository.
-
+For modules published under a different account, substitute `OWNER`
+with the GitHub account name that hosts the repository.

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -2,22 +2,26 @@
 
 Provision a DigitalOcean Kubernetes (DOKS) cluster.
 
+Requires [OpenTofu](https://opentofu.org/docs/intro/install/) 1.6 or later.
+
 ## Quick start
 
-Set the DigitalOcean token so the provider can authenticate:
+Set the `DIGITALOCEAN_TOKEN` environment variable to allow provider authentication:
 
 ```sh
-export DIGITALOCEAN_TOKEN="your-token"
+export DIGITALOCEAN_TOKEN="<DIGITALOCEAN_TOKEN>"
 ```
 
-Configure the provider and call the module:
+Configure the provider, call the module, and expose outputs:
 
 ```hcl
 terraform {
+  required_version = ">= 1.6.0"
+
   required_providers {
     digitalocean = {
-      source  = "digitalocean/digitalocean"
-      version = "~> 2.0"
+      source  = "opentofu/digitalocean"
+      version = "~> 2.36"
     }
   }
 }
@@ -39,6 +43,28 @@ module "doks" {
     min_nodes  = 1
     max_nodes  = 3
   }]
+
+  expose_kubeconfig = true
+}
+
+output "endpoint" {
+  value = module.doks.cluster_endpoint
+}
+
+output "kubeconfig" {
+  value     = module.doks.kubeconfig
+  sensitive = true
 }
 ```
+
+Retrieve the kubeconfig and cluster endpoint after applying the configuration:
+
+```sh
+terraform output -raw kubeconfig > kubeconfig.yaml
+terraform output endpoint
+```
+
+For advanced provider configuration, consult the [DigitalOcean provider documentation](https://registry.terraform.io/providers/opentofu/digitalocean/latest/docs).
+
+For modules published under a different account, substitute `OWNER` with the GitHub account name that hosts the repository.
 

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -65,8 +65,8 @@ tofu output -raw kubeconfig > kubeconfig.yaml
 tofu output endpoint
 ```
 
-Consult the DigitalOcean provider docs for advanced configuration:
-<https://registry.terraform.io/providers/opentofu/digitalocean/latest/docs>
+Consult the DigitalOcean provider documentation for advanced configuration:
+<https://search.opentofu.org/provider/opentofu/digitalocean/latest>
 
 For modules published under a different account, substitute `OWNER`
 with the GitHub account name that hosts the repository.

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -29,11 +29,12 @@ terraform {
 provider "digitalocean" {}
 
 module "doks" {
-  source = "git::https://github.com/OWNER/wildside.git//infra/modules/doks?ref=v0.1.0"
+  # Prefer a released tag or a commit SHA for reproducibility
+  source = "git::https://github.com/OWNER/wildside.git//infra/modules/doks?ref=<TAG_OR_SHA>"
 
   cluster_name       = "example"
   region             = "nyc1"
-  kubernetes_version = "<1.33.x-do.0>" # choose a supported release
+  kubernetes_version = "<SUPPORTED_DOKS_VERSION>"
 
   node_pools = [{
     name       = "default"
@@ -55,13 +56,15 @@ output "kubeconfig" {
 }
 ```
 
-Select a supported Kubernetes version (1.33.x, 1.32.x, or 1.31.x). See the
-DigitalOcean version table for current releases:
-<https://docs.digitalocean.com/products/kubernetes/details/supported-releases/>.
-
-Marking the `kubeconfig` output as `sensitive` hides it in the CLI but not in
-state. Store state in an encrypted, access‑controlled backend and rotate the
-DigitalOcean token and cluster credentials if exposure is suspected.
+> Note: Select a supported Kubernetes version from DigitalOcean's current list
+> of DOKS releases (typically the latest three minor versions). See the version
+> table for current releases:
+> <https://docs.digitalocean.com/products/kubernetes/details/supported-releases/>.
+>
+> Caution: Sensitive outputs persist in state. Store state in an encrypted,
+> access‑controlled backend and restrict state access to authorised
+> principals. Rotate the DigitalOcean token and cluster credentials if state
+> exposure is suspected.
 
 Enable `auto_scale` and define `min_nodes` and `max_nodes` to scale between
 bounds. These settings have no effect when `auto_scale` is `false`.
@@ -77,5 +80,5 @@ tofu output endpoint
 Consult the DigitalOcean provider documentation for advanced configuration:
 <https://search.opentofu.org/provider/opentofu/digitalocean/latest>
 
-Substitute `OWNER` with the GitHub account name and `v0.1.0` with the tagged
-release or commit to use.
+Substitute `OWNER` with the GitHub account name and `<TAG_OR_SHA>` with the
+tagged release or commit to use.

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -40,8 +40,6 @@ module "doks" {
     size       = "s-2vcpu-4gb"
     node_count = 3
     auto_scale = false
-    min_nodes  = 1
-    max_nodes  = 3
   }]
 
   expose_kubeconfig = true
@@ -56,6 +54,9 @@ output "kubeconfig" {
   sensitive = true
 }
 ```
+
+Enable `auto_scale` and define `min_nodes` and `max_nodes` to scale between
+bounds. These settings have no effect when `auto_scale` is `false`.
 
 Retrieve the kubeconfig and cluster endpoint after applying the configuration:
 

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -33,7 +33,7 @@ module "doks" {
 
   cluster_name       = "example"
   region             = "nyc1"
-  kubernetes_version = "1.33.4-do.0"
+  kubernetes_version = "<1.33.x-do.0>" # choose a supported release
 
   node_pools = [{
     name       = "default"
@@ -55,6 +55,10 @@ output "kubeconfig" {
 }
 ```
 
+Select a supported Kubernetes version (1.33.x, 1.32.x, or 1.31.x). See the
+DigitalOcean version table for current releases:
+<https://docs.digitalocean.com/products/kubernetes/details/supported-releases/>.
+
 Marking the `kubeconfig` output as `sensitive` hides it in the CLI but not in
 state. Store state in an encrypted, access‑controlled backend and rotate the
 DigitalOcean token and cluster credentials if exposure is suspected.
@@ -66,6 +70,7 @@ Retrieve the kubeconfig and cluster endpoint after applying the configuration:
 
 ```sh
 tofu output -raw kubeconfig > kubeconfig.yaml
+chmod 600 kubeconfig.yaml
 tofu output endpoint
 ```
 

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -60,8 +60,8 @@ output "kubeconfig" {
 Retrieve the kubeconfig and cluster endpoint after applying the configuration:
 
 ```sh
-terraform output -raw kubeconfig > kubeconfig.yaml
-terraform output endpoint
+tofu output -raw kubeconfig > kubeconfig.yaml
+tofu output endpoint
 ```
 
 Consult the DigitalOcean provider docs for advanced configuration:

--- a/infra/modules/doks/README.md
+++ b/infra/modules/doks/README.md
@@ -29,11 +29,11 @@ terraform {
 provider "digitalocean" {}
 
 module "doks" {
-  source = "git::https://github.com/OWNER/wildside.git//infra/modules/doks?ref=main"
+  source = "git::https://github.com/OWNER/wildside.git//infra/modules/doks?ref=v0.1.0"
 
   cluster_name       = "example"
   region             = "nyc1"
-  kubernetes_version = "1.28.0-do.0"
+  kubernetes_version = "1.33.4-do.0"
 
   node_pools = [{
     name       = "default"
@@ -55,6 +55,10 @@ output "kubeconfig" {
 }
 ```
 
+Marking the `kubeconfig` output as `sensitive` hides it in the CLI but not in
+state. Store state in an encrypted, access‑controlled backend and rotate the
+DigitalOcean token and cluster credentials if exposure is suspected.
+
 Enable `auto_scale` and define `min_nodes` and `max_nodes` to scale between
 bounds. These settings have no effect when `auto_scale` is `false`.
 
@@ -68,5 +72,5 @@ tofu output endpoint
 Consult the DigitalOcean provider documentation for advanced configuration:
 <https://search.opentofu.org/provider/opentofu/digitalocean/latest>
 
-For modules published under a different account, substitute `OWNER`
-with the GitHub account name that hosts the repository.
+Substitute `OWNER` with the GitHub account name and `v0.1.0` with the tagged
+release or commit to use.

--- a/infra/modules/doks/examples/basic/main.tf
+++ b/infra/modules/doks/examples/basic/main.tf
@@ -33,7 +33,7 @@ variable "node_pools" {
 
 variable "kubernetes_version" {
   type        = string
-  description = "Exact Kubernetes version slug supported by DigitalOcean (e.g., 1.28.0-do.0)"
+  description = "Exact Kubernetes version slug supported by DigitalOcean (e.g., <1.33.x-do.0>). Choose a supported release from the version table (1.33.x, 1.32.x, 1.31.x)."
 }
 
 variable "tags" {

--- a/infra/modules/doks/tests/doks_test.go
+++ b/infra/modules/doks/tests/doks_test.go
@@ -15,11 +15,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+const supportedVersion = "1.33.9-do.0" // update to a supported release from the 1.33.x, 1.32.x or 1.31.x series
+
 func testVars() map[string]interface{} {
 	return map[string]interface{}{
 		"cluster_name":       "terratest-cluster",
 		"region":             "nyc1",
-		"kubernetes_version": "1.28.0-do.0",
+		"kubernetes_version": supportedVersion,
 		"node_pools": []map[string]interface{}{
 			{
 				"name":       "default",
@@ -139,7 +141,7 @@ func getInvalidInputTestCases() map[string]struct {
 			Vars: map[string]interface{}{
 				"cluster_name":       "",
 				"region":             "nyc1",
-				"kubernetes_version": "1.28.0-do.0",
+				"kubernetes_version": supportedVersion,
 				"node_pools":         testVars()["node_pools"],
 			},
 			ErrContains: "cluster_name must not be empty",
@@ -148,7 +150,7 @@ func getInvalidInputTestCases() map[string]struct {
 			Vars: map[string]interface{}{
 				"cluster_name":       "terratest-cluster",
 				"region":             "invalid",
-				"kubernetes_version": "1.28.0-do.0",
+				"kubernetes_version": supportedVersion,
 				"node_pools":         testVars()["node_pools"],
 			},
 			ErrContains: "region must be a valid DigitalOcean slug",
@@ -174,7 +176,7 @@ func getInvalidInputTestCases() map[string]struct {
 			Vars: map[string]interface{}{
 				"cluster_name":       "terratest-cluster",
 				"region":             "nyc1",
-				"kubernetes_version": "1.28.0-do.0",
+				"kubernetes_version": supportedVersion,
 				"node_pools":         []map[string]interface{}{},
 			},
 			ErrContains: "node_pools must not be empty",
@@ -183,7 +185,7 @@ func getInvalidInputTestCases() map[string]struct {
 			Vars: map[string]interface{}{
 				"cluster_name":       "terratest-cluster",
 				"region":             "nyc1",
-				"kubernetes_version": "1.28.0-do.0",
+				"kubernetes_version": supportedVersion,
 				"node_pools": []map[string]interface{}{
 					{
 						"name":       "default",


### PR DESCRIPTION
## Summary
- add README for DOKS module showing how to configure the DigitalOcean provider and supply the token

## Testing
- `make check-fmt`
- `make lint` *(fails: @asyncapi/cli dependency stalled)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0f154cb48322a6f815fc3221cc80

## Summary by Sourcery

Documentation:
- Add README for DOKS module with environment variable setup and sample Terraform configuration