### PR TITLE
Add documentation index

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -1,0 +1,35 @@
+# Documentation index
+
+## Project architecture
+- [Wildside high-level design](wildside-high-level-design.md) – strategic blueprint and product vision. *Audience: stakeholders and all contributors.*
+- [Repository design guide](repository-structure.md) – explains repository layout and request flow. *Audience: new contributors.*
+- [Wildside backend: functional design specification](wildside-backend-design.md) – outlines backend components and tasks. *Audience: backend developers.*
+- [Backend MVP architecture and observability](backend-design.md) – details monolithic backend and observability plan. *Audience: backend developers.*
+- [Values class diagram](values-class-diagram.mmd) – Mermaid diagram of Helm chart values. *Audience: platform engineers.*
+
+## Frontend development
+- [Pure, accessible, and localisable React components](pure-accessible-and-localizable-react-components.md) – building accessible, localised components with Radix, TanStack and DaisyUI. *Audience: frontend developers.*
+- [Architecting resilient local-first applications in React](local-first-react.md) – strategies for offline-first apps using Zustand and TanStack Query. *Audience: frontend developers.*
+- [High-velocity, accessibility-first component testing](high-velocity-accessibility-first-component-testing.md) – Vitest and Playwright strategy for accessible components. *Audience: frontend developers and QA engineers.*
+
+## Rust testing practices
+- [Reliable testing in Rust via dependency injection](reliable-testing-in-rust-via-dependency-injection.md) – using the `mockable` crate for deterministic tests. *Audience: Rust developers.*
+- [A systematic guide to effective, ergonomic, and DRY doctests in Rust](rust-doctest-dry-guide.md) – patterns for maintainable doctests. *Audience: Rust developers.*
+- [Mastering test fixtures in Rust with `rstest`](rust-testing-with-rstest-fixtures.md) – fixture and parameterised testing techniques. *Audience: Rust developers.*
+
+## Infrastructure and delivery
+- [A cloud-native architecture for on-demand ephemeral preview environments](cloud-native-ephemeral-previews.md) – GitOps-driven preview platform design. *Audience: platform engineers.*
+- [Ephemeral previews infrastructure roadmap](ephemeral-previews-roadmap.md) – phased plan for preview environment infrastructure. *Audience: platform engineers and project managers.*
+- [Architecting a modern CI/CD pipeline](ci-cd-container-pipeline-design.md) – GitHub Actions to Kubernetes workflow. *Audience: DevOps engineers.*
+- [Declarative DNS guide](declarative-dns-guide.md) – automating Cloudflare DNS with FluxCD, ExternalDNS and OpenTofu. *Audience: platform engineers.*
+- [Declarative TLS guide](declarative-tls-guide.md) – automating certificate management with cert-manager. *Audience: platform engineers.*
+- [Using Cloudflare DNS with OpenTofu](using-cloudflare-dns-with-opentofu.md) – practical steps for managing DNS records. *Audience: infrastructure developers.*
+- [A comprehensive developer’s guide to HCL for OpenTofu](opentofu-hcl-syntax-guide.md) – HCL syntax and workflows. *Audience: infrastructure developers.*
+- [Unit testing OpenTofu modules and scripts](opentofu-module-unit-testing-guide.md) – strategies for testing IaC modules. *Audience: infrastructure developers.*
+- [DOKS OpenTofu module design](doks-module-design.md) – design decisions for the DigitalOcean Kubernetes module. *Audience: infrastructure developers.*
+
+## Developer guidelines and tooling
+- [Documentation style guide](documentation-style-guide.md) – conventions for clear, consistent docs. *Audience: all contributors.*
+- [Complexity antipatterns and refactoring strategies](complexity-antipatterns-and-refactoring-strategies.md) – managing code complexity. *Audience: implementers and maintainers.*
+- [A command-line wizard’s guide to srgn](srgn.md) – using `srgn` for syntactic code refactoring. *Audience: developers performing code changes.*
+- [Biome configuration schema](biome-schema.json) – JSON schema for `biome.json`. *Audience: contributors editing Biome settings.*


### PR DESCRIPTION
## Summary
- index project documentation by grouping files and clarifying the target audience

## Testing
- `make check-fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc8517dd348322b94517c8febb480a