### PR TITLE
Document database and cache metrics for observability

### DIFF
--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -571,7 +571,8 @@ An in-memory cache is used to improve performance and reduce database load.
 The system must be fully instrumented to provide insight into its performance,
 reliability, and user behaviour.
 
-- **Technology:** Prometheus, Grafana, Loki, PostHog, `tracing` crate.
+- **Technology:** Prometheus, Grafana, Loki, PostHog, `tracing` crate,
+  `postgres_exporter`, `redis_exporter`.
 
 - **Current Status:** `tracing` is integrated for basic logging. The Kubernetes
   manifests are configured to support the Prometheus Operator.
@@ -606,6 +607,15 @@ reliability, and user behaviour.
 
     - A gauge (`pois_total`) for the total number of POIs in the local
       database, to observe growth over time.
+
+  - [ ] **Database metrics:** Deploy `postgres_exporter` and scrape
+    `pg_up`, `pg_database_size_bytes`, and
+    `pg_stat_database_xact_commit_total` to monitor database health and
+    growth.
+
+  - [ ] **Cache metrics:** Deploy `redis_exporter` and track
+    `redis_keyspace_hits_total` and `redis_keyspace_misses_total` to measure
+    Redis cache hit ratios.
 
   - [ ] **Logging:** Ensure all logs are emitted as structured JSON and
     include the `trace_id` propagated from the initial API request, even into


### PR DESCRIPTION
## Summary
- expand backend observability plan with postgres_exporter and redis_exporter
- note key Prometheus metrics for PostgreSQL health and Redis cache efficiency

## Testing
- `make check-fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc85a8ad8083228f536644fc08526b

## Summary by Sourcery

Expand backend observability documentation to include Postgres and Redis exporters and specify key Prometheus metrics for database health and cache efficiency

Documentation:
- Add `postgres_exporter` and `redis_exporter` to the observability technology stack
- Document deployment of `postgres_exporter` with key metrics (`pg_up`, `pg_database_size_bytes`, `pg_stat_database_xact_commit_total`) for database health monitoring
- Document deployment of `redis_exporter` with key metrics (`redis_keyspace_hits_total`, `redis_keyspace_misses_total`) for cache hit ratio measurement