### PR TITLE
Document Martin tile server deployment

### DIFF
--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -66,6 +66,16 @@ the frontend could send them) to record user actions (e.g. “RouteGenerated”,
 will have robust logging and metrics: Prometheus for low-level performance and
 error monitoring, and PostHog for high-level user behavior tracking.
 
+## Martin Tile Server
+
+To deliver map tiles without burdening the core API, Wildside deploys the
+**Martin** tile server as a distinct service. Martin connects to the same
+PostGIS database as the main backend and exposes vector tiles on `/tiles`.
+Running it separately allows independent scaling, caching and availability
+controls. Requests such as `/tiles/{z}/{x}/{y}.pbf` are served directly from
+PostGIS, enabling clients to fetch map data while the monolith focuses on
+business logic.
+
 ## Route Generation Engine Integration
 
 At the heart of Wildside is the **route recommendation engine**, provided by

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -66,7 +66,7 @@ the frontend could send them) to record user actions (e.g. “RouteGenerated”,
 will have robust logging and metrics: Prometheus for low-level performance and
 error monitoring, and PostHog for high-level user behavior tracking.
 
-## Martin Tile Server
+## Martin tile server
 
 To deliver map tiles without burdening the core API, Wildside deploys the
 **Martin** tile server as a distinct service. Martin connects to the same
@@ -80,11 +80,14 @@ logic.
 
 Operational notes:
 
-- Use a read-only Postgres role and a separate connection string for Martin.
+- Use a read-only Postgres role (SELECT on required schemas/tables only) and a
+  separate connection string for Martin.
 - Set a distinct ingress route to forward `/tiles/*` to the Martin service,
   avoiding Actix handlers.
 - Configure `--base-path /tiles`, connection pool size, worker processes, and
   in-memory cache size; enable Brotli or gzip compression.
+- Ensure geometries are in EPSG:3857 (Web Mercator), or set Martin’s
+  `default_srid` accordingly to avoid empty tiles.
 - Enforce CORS for tile endpoints, and apply rate limits or CDN caching at the
   edge.
 

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -80,14 +80,14 @@ logic.
 
 Operational notes:
 
-- Use a read-only Postgres role (SELECT on required schemas/tables only) and a
-  separate connection string for Martin.
+- Use a read-only Postgres role limited to `SELECT` on the schemas and tables
+  Martin serves, and supply a separate connection string.
 - Set a distinct ingress route to forward `/tiles/*` to the Martin service,
-  avoiding Actix handlers.
+  bypassing Actix handlers.
 - Configure `--base-path /tiles`, connection pool size, worker processes, and
   in-memory cache size; enable Brotli or gzip compression.
-- Ensure geometries are in EPSG:3857 (Web Mercator), or set Martin’s
-  `default_srid` accordingly to avoid empty tiles.
+- Ensure geometries are stored in EPSG:3857 (Web Mercator) or set Martin’s
+  `default_srid` to match to avoid empty tiles.
 - Enforce CORS for tile endpoints, and apply rate limits or CDN caching at the
   edge.
 

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -84,7 +84,7 @@ Operational notes:
 - Set a distinct ingress route to forward `/tiles/*` to the Martin service,
   avoiding Actix handlers.
 - Configure `--base-path /tiles`, connection pool size, worker processes, and
-  in-memory cache size; enable Brotli or Gzip.
+  in-memory cache size; enable Brotli or gzip compression.
 - Enforce CORS for tile endpoints, and apply rate limits or CDN caching at the
   edge.
 


### PR DESCRIPTION
## Summary
- describe Martin tile server as separate service providing `/tiles` endpoints backed by main PostGIS database

## Testing
- `make fmt`
- `make lint` *(fails: interrupt)*
- `make test` *(fails: interrupt)*

------
https://chatgpt.com/codex/tasks/task_e_68bc8569af248322a339aebc38e35885

## Summary by Sourcery

Documentation:
- Add documentation for the Martin tile server as a separate service exposing `/tiles/{z}/{x}/{y}.pbf` endpoints backed by the main PostGIS database