### PR TITLE
Document OSM seeding, enrichment, and caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Wildside is a mobile “serendipity engine” for urban exploration, generating
 bespoke, narrative-rich walking tours tailored to user interests, time, and
 location. Leveraging OpenStreetMap, Wikidata, and a custom orienteering-based
-algorithm, it optimises for “interestingness” over efficiency. The MVP will be
+algorithm, it optimizes for “interestingness” over efficiency. The MVP will be
 a PWA with a Rust/React stack, self-hosted map/routing services, and a strong
 data-validation pipeline. The strategy emphasises cost control, security-first
 AI integration, and clear differentiation from fitness, hiking, and static tour

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -277,7 +277,7 @@ performance. Postgres metrics collection is enabled (for example, running a
 **Postgres exporter** or using CloudNativePG’s built-in metrics if deployed in
 K8s([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))).
 Key metrics include `pg_stat_activity`-derived gauges (connections in use),
-`pg_stat_database_blks_hit/blk_read` (cache hit rate), and slow query counts.
+`pg_stat_database_blks_hit/blks_read` (cache hit rate), and slow query counts.
 From the application side, enable Diesel’s query logging and instrument
 timings for critical queries (for instance, wrap certain calls to measure their
 duration). The Prometheus operator will scrape database metrics (if using an
@@ -285,9 +285,10 @@ operator or a managed DB with metrics). In Grafana, dashboards will plot DB
 metrics like CPU, I/O, number of queries per second, etc., as recommended by
 the deployment guide. Example alert:
 - `pg_connections{db="app"} / pg_max_connections > 0.8` for 5m → page SRE.
+  Note: metric names are exporter‑dependent; adjust to your exporter.
 
 If any query regularly takes too long (impacting route generation latency),
-alert and optimize that part (adding indexes or caching results). On the
+alert and optimise that part (adding indexes or caching results). On the
 analytics side, database operations themselves aren’t directly in PostHog, but
 PostHog may track high-level outcomes (e.g. “UserSavedRoute” event when a user
 saves a generated route to the DB).

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -284,38 +284,8 @@ duration). The Prometheus operator will scrape database metrics (if using an
 operator or a managed DB with metrics). In Grafana, dashboards will plot DB
 metrics like CPU, I/O, number of queries per second, etc., as recommended by
 the deployment guide. Example alert:
-- `pg_connections{db=\"app\"} / pg_max_connections > 0.8` for 5m → page SRE.
-If any query regularly takes too long (impacting route generation latency),
-alert and optimise that part (adding indexes or caching results). On the
-analytics side, database operations themselves aren’t directly in PostHog, but
-PostHog may track high-level outcomes (e.g. “UserSavedRoute” event when a user
-saves a generated route to the DB).
-K8s([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))).
-Key metrics include query throughput, slow query counts, connections in use,
-and cache hit rates. From the application side, enable Diesel’s query
-logging to detect slow queries and instrument timings for critical queries (for
-instance, wrap certain calls to measure their duration). The Prometheus
-operator will scrape database metrics (if using an operator or a managed DB
-with
-metrics)([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513)).
- In Grafana, dashboards will plot DB metrics like CPU, I/O, number of queries
-per second, etc., as recommended by the deployment
-guide([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513)).
- If any query regularly takes too long (impacting route generation latency),
-alert and optimise that part (adding indexes or caching
-results). On the analytics side, database operations themselves aren’t directly
-in PostHog, but PostHog may track high-level outcomes (e.g.
-“UserSavedRoute” event when a user saves a generated route to the DB).
-K8s([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))).
-Key metrics include `pg_stat_activity`-derived gauges (connections in use),
-`pg_stat_database_blks_hit/blk_read` (cache hit rate), and slow query counts.
-From the application side, enable Diesel’s query logging and instrument
-timings for critical queries (for instance, wrap certain calls to measure their
-duration). The Prometheus operator will scrape database metrics (if using an
-operator or a managed DB with metrics). In Grafana, dashboards will plot DB
-metrics like CPU, I/O, number of queries per second, etc., as recommended by
-the deployment guide. Example alert:
 - `pg_connections{db="app"} / pg_max_connections > 0.8` for 5m → page SRE.
+
 If any query regularly takes too long (impacting route generation latency),
 alert and optimise that part (adding indexes or caching results). On the
 analytics side, database operations themselves aren’t directly in PostHog, but

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -287,7 +287,7 @@ the deployment guide. Example alert:
 - `pg_connections{db="app"} / pg_max_connections > 0.8` for 5m → page SRE.
 
 If any query regularly takes too long (impacting route generation latency),
-alert and optimise that part (adding indexes or caching results). On the
+alert and optimize that part (adding indexes or caching results). On the
 analytics side, database operations themselves aren’t directly in PostHog, but
 PostHog may track high-level outcomes (e.g. “UserSavedRoute” event when a user
 saves a generated route to the DB).
@@ -352,8 +352,8 @@ Operational details:
   - Send a descriptive `User-Agent` and `Contact` header (email or URL);
     include a per-tenant token in the `User-Agent` for tracing abuse; expose
     both via config.
-  - Enforce rate limits (≤ 10 000 requests/day; transfer < 1 GB/day), default
-    timeout 180 s, and `maxsize` 512 MiB.
+  - Enforce rate limits (≤ 10 000 requests/day; transfer < 1 GB/day; as of
+    2025-09-08), default timeout 180 s, and `maxsize` 512 MiB.
   - Cap concurrent Overpass requests with a global semaphore or worker pool
     (default ≤ 2, configurable).
   - Retry HTTP 429 responses with jittered backoff.
@@ -370,13 +370,13 @@ Operational details:
     - Hash: lowercase hex SHA-256 of the canonical payload.
     - Key: `route:v1:<hash>` (optionally truncate to first 32 hex chars;
       document truncation).
-- **TTLs:** Set a default TTL (24 h) for anonymous route results; apply a
-  jitter of ±10% to avoid stampedes; skip TTL for saved routes. Invalidate on
-  schema/engine version bumps by rotating namespace suffix (e.g. `v2`).
-- **Eviction:** Configure `maxmemory` and `maxmemory-policy allkeys-lfu`; set
-  per-namespace memory budgets and alert on `evicted_keys` > 0.
-- **Attribution & provenance:** Store enrichment provenance (source URL,
-  timestamp, bbox) and enforce OSM attribution requirements in UI/docs.
+    - **TTLs:** Set a default TTL (24 h) for anonymous route results; apply a
+      jitter of ±10% to avoid stampedes; skip TTL for saved routes. Invalidate
+      on schema/engine version bumps by rotating namespace suffix (e.g. `v2`).
+    - **Eviction:** Configure `maxmemory` and `maxmemory-policy allkeys-lfu`;
+      set per-namespace memory budgets and alert on `evicted_keys` > 0.
+    - **Attribution & provenance:** Store enrichment provenance (source URL,
+      timestamp, bbox) and enforce OSM attribution requirements in UI/docs.
 
 ## Caching Layer (Redis/Memcached)
 
@@ -437,14 +437,7 @@ The cost analysis for MVP even budgets a small Redis Cloud instance for
 caching([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L2-L5)),
 underlining its role as both cache and queue.
 
-In a Kubernetes deployment, Redis can run as an in-cluster service or use a
-managed Redis. For a lightweight start, a single small Redis instance (or even
-an in-memory cache within the app process for non-critical data) suffices. The
-cost analysis for the MVP even budgets a small Redis Cloud instance for
-caching[^1], underlining its role. Memcached could alternatively be used for
-simple key-value caching if an even simpler, stateless cache layer is desired;
-however, Redis offers more features (persistence, pub/sub, etc.) that could be
-handy (for example, using Redis as the job queue backend in Apalis).
+ 
 
 *Observability:* The caching layer is monitored to ensure it’s effectively
 improving performance. **Cache hit rates and misses** for critical caches are
@@ -887,6 +880,7 @@ for urban explorers, but also is stable, scalable, and well-monitored in
 production.
 
 **Sources:** The design is informed by the Wildside project’s high-level design
+ 
 documents and repository guides, which emphasise a Rust Actix backend,
 Postgres/PostGIS data store, and monolithic MVP approach[^1][^2]. Observability
 and cloud deployment strategies follow the cloud-native architecture
@@ -903,3 +897,23 @@ growth.
 [^6]: <https://www.reddit.com/r/rust/comments/1jjebum/introducing_apalis_v07/#:~:text=,Many%20more%20features>
 [^7]: <https://docs.rs/underway#:~:text=Underway%20provides%20durable%20background%20jobs,scheduling%20and%20atomic%20task%20management>
 [^8]: <https://github.com/maxcountryman/underway#:~:text=maxcountryman%2Funderway%3A%20Durable%20step%20functions%20via,of%20the%20previous%20step>
+documents and repository guides, which emphasize a Rust Actix backend,
+Postgres/PostGIS data store, and monolithic MVP
+approach([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L637-L645))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L655-L663))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L671-L680))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L682-L690)).
+ Observability and cloud deployment strategies are aligned with the provided
+cloud-native architecture
+recommendations([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))([2](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/repository-structure.md#L2-L5))
+ and caching and optimisation considerations from the technical risk
+analysis([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L8-L16))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L14-L17)).
+ All these pieces coalesce into the architecture detailed above, setting the
+stage for Wildside’s successful implementation and growth.
+documents and repository guides, which emphasize a Rust Actix backend,
+Postgres/PostGIS data store, and monolithic MVP
+approach([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L637-L645))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L655-L663))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L671-L680))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L682-L690)).
+ Observability and cloud deployment strategies are aligned with the provided
+cloud-native architecture
+recommendations([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))([2](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/repository-structure.md#L2-L5))
+and caching and optimization considerations from the technical risk
+analysis([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L8-L16))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L14-L17)).
+ All these pieces coalesce into the architecture detailed above, setting the
+stage for Wildside’s successful implementation and growth.

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -272,13 +272,34 @@ transactionally updates user-specific info. Heavy geospatial reads can be
 isolated by using read replicas or a separate schema, but the MVP can start
 with a single database instance for everything.
 
+<<<<<<< HEAD
 *Observability:* The database and ORM layer are monitored to ensure healthy
 performance. Postgres metrics collection is enabled (for example, running a
+||||||| parent of 824436e (Use en-GB spelling in DB monitoring section)
+*Observability:* The database and ORM layer will be monitored to ensure healthy
+performance. We will enable Postgres metrics collection (for example, running a
+=======
+*Observability:* The database and ORM layer will be monitored to ensure healthy
+performance. Enable Postgres metrics collection (for example, running a
+>>>>>>> 824436e (Use en-GB spelling in DB monitoring section)
 **Postgres exporter** or using CloudNativePG’s built-in metrics if deployed in
+<<<<<<< HEAD
 K8s[^4]). Key metrics include query throughput, slow query counts, connections
 in use, and cache hit rates. From the application side, Diesel’s query
 logging detects slow queries and instruments timings for critical ones (for
+||||||| parent of 824436e (Use en-GB spelling in DB monitoring section)
+K8s([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))).
+Key metrics include query throughput, slow query counts, connections in use,
+and cache hit rates. From the application side, we can use Diesel’s query
+logging to detect slow queries and instrument timings for critical queries (for
+=======
+K8s([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))).
+Key metrics include query throughput, slow query counts, connections in use,
+and cache hit rates. From the application side, enable Diesel’s query
+logging to detect slow queries and instrument timings for critical queries (for
+>>>>>>> 824436e (Use en-GB spelling in DB monitoring section)
 instance, wrap certain calls to measure their duration). The Prometheus
+<<<<<<< HEAD
 operator scrapes database metrics (if using an operator or a managed DB with
 metrics)[^4]. In Grafana, dashboards plot DB metrics like CPU, I/O, and number
 of queries per second, as recommended by the deployment guide[^4]. If any query
@@ -287,6 +308,31 @@ highlight the slow part for optimisation (adding indexes or caching results).
 On the analytics side, database operations themselves aren’t directly in
 PostHog, but PostHog can track high-level outcomes (e.g. “UserSavedRoute”
 event when a user saves a generated route to the DB).
+||||||| parent of 824436e (Use en-GB spelling in DB monitoring section)
+operator will scrape database metrics (if using an operator or a managed DB
+with
+metrics)([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513)).
+ In Grafana, dashboards will plot DB metrics like CPU, I/O, number of queries
+per second, etc., as recommended by the deployment
+guide([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513)).
+ If any query regularly takes too long (impacting route generation latency),
+we’ll get alerted and can optimize that part (adding indexes or caching
+results). On the analytics side, database operations themselves aren’t directly
+in PostHog, but we might use PostHog to track high-level outcomes (e.g.
+“UserSavedRoute” event when a user saves a generated route to the DB).
+=======
+operator will scrape database metrics (if using an operator or a managed DB
+with
+metrics)([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513)).
+ In Grafana, dashboards will plot DB metrics like CPU, I/O, number of queries
+per second, etc., as recommended by the deployment
+guide([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513)).
+ If any query regularly takes too long (impacting route generation latency),
+alert and optimise that part (adding indexes or caching
+results). On the analytics side, database operations themselves aren’t directly
+in PostHog, but PostHog may track high-level outcomes (e.g.
+“UserSavedRoute” event when a user saves a generated route to the DB).
+>>>>>>> 824436e (Use en-GB spelling in DB monitoring section)
 
 ## Data Seeding, Enrichment, and Route Caching
 
@@ -362,6 +408,7 @@ The cost analysis for MVP even budgets a small Redis Cloud instance for
 caching([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L2-L5)),
 underlining its role as both cache and queue.
 
+<<<<<<< HEAD
 In a Kubernetes deployment, Redis can run as an in-cluster service or use a
 managed Redis. For a lightweight start, a single small Redis instance (or even
 an in-memory cache within the app process for non-critical data) suffices. The
@@ -370,6 +417,33 @@ caching[^1], underlining its role. Memcached could alternatively be used for
 simple key-value caching if an even simpler, stateless cache layer is desired;
 however, Redis offers more features (persistence, pub/sub, etc.) that could be
 handy (for example, using Redis as the job queue backend in Apalis).
+||||||| parent of 824436e (Use en-GB spelling in DB monitoring section)
+*Observability:* The caching layer will be monitored to ensure it’s effectively
+improving performance. We’ll track **cache hit rates and misses** for critical
+caches. For instance, a Prometheus metric `cache_route_lookup_hits_total` vs
+`cache_route_lookup_misses_total` can be recorded to measure how often a route
+result was served from cache versus had to be recomputed. Redis itself provides
+stats like memory usage, eviction counts, connections, which can be exposed via
+a Redis exporter and scraped by Prometheus. In Grafana, we’d include panels for
+cache performance (high miss rates might indicate we can optimize caching
+strategy). From an analytics perspective, caching is transparent to users, so
+not directly relevant to PostHog events, but a successful cache hit does
+indirectly improve user experience (faster response) which could reflect in
+user retention metrics over time.
+=======
+*Observability:* The caching layer will be monitored to ensure it’s effectively
+improving performance. We’ll track **cache hit rates and misses** for critical
+caches. For instance, a Prometheus metric `cache_route_lookup_hits_total` vs
+`cache_route_lookup_misses_total` can be recorded to measure how often a route
+result was served from cache versus had to be recomputed. Redis itself provides
+stats like memory usage, eviction counts, connections, which can be exposed via
+a Redis exporter and scraped by Prometheus. In Grafana, we’d include panels for
+cache performance (high miss rates might indicate we can optimise caching
+strategy). From an analytics perspective, caching is transparent to users, so
+not directly relevant to PostHog events, but a successful cache hit does
+indirectly improve user experience (faster response) which could reflect in
+user retention metrics over time.
+>>>>>>> 824436e (Use en-GB spelling in DB monitoring section)
 
 *Observability:* The caching layer is monitored to ensure it’s effectively
 improving performance. **Cache hit rates and misses** for critical caches are
@@ -812,6 +886,7 @@ for urban explorers, but also is stable, scalable, and well-monitored in
 production.
 
 **Sources:** The design is informed by the Wildside project’s high-level design
+<<<<<<< HEAD
 documents and repository guides, which emphasise a Rust Actix backend,
 Postgres/PostGIS data store, and monolithic MVP approach[^1][^2]. Observability
 and cloud deployment strategies follow the cloud-native architecture
@@ -828,3 +903,26 @@ growth.
 [^6]: <https://www.reddit.com/r/rust/comments/1jjebum/introducing_apalis_v07/#:~:text=,Many%20more%20features>
 [^7]: <https://docs.rs/underway#:~:text=Underway%20provides%20durable%20background%20jobs,scheduling%20and%20atomic%20task%20management>
 [^8]: <https://github.com/maxcountryman/underway#:~:text=maxcountryman%2Funderway%3A%20Durable%20step%20functions%20via,of%20the%20previous%20step>
+||||||| parent of 824436e (Use en-GB spelling in DB monitoring section)
+documents and repository guides, which emphasize a Rust Actix backend,
+Postgres/PostGIS data store, and monolithic MVP
+approach([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L637-L645))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L655-L663))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L671-L680))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L682-L690)).
+ Observability and cloud deployment strategies are aligned with the provided
+cloud-native architecture
+recommendations([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))([2](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/repository-structure.md#L2-L5))
+ and caching and optimization considerations from the technical risk
+analysis([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L8-L16))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L14-L17)).
+ All these pieces coalesce into the architecture detailed above, setting the
+stage for Wildside’s successful implementation and growth.
+=======
+documents and repository guides, which emphasize a Rust Actix backend,
+Postgres/PostGIS data store, and monolithic MVP
+approach([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L637-L645))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L655-L663))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L671-L680))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L682-L690)).
+ Observability and cloud deployment strategies are aligned with the provided
+cloud-native architecture
+recommendations([4](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/cloud-native-ephemeral-previews.md#L1505-L1513))([2](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/repository-structure.md#L2-L5))
+ and caching and optimisation considerations from the technical risk
+analysis([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L8-L16))([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L14-L17)).
+ All these pieces coalesce into the architecture detailed above, setting the
+stage for Wildside’s successful implementation and growth.
+>>>>>>> 824436e (Use en-GB spelling in DB monitoring section)

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -288,7 +288,7 @@ side, database operations themselves aren’t directly in PostHog, but PostHog
 can track high-level outcomes (e.g. “UserSavedRoute” event when a user saves a
 generated route to the DB).
 
-## Data Seeding, Enrichment, and Route Caching
+## Data seeding, enrichment, and route caching
 
  
 - Initial OSM seeding: A Rust ingestion tool uses the `osmpbf` crate to parse
@@ -314,12 +314,12 @@ Operational details:
   requests/day; transfer < 1 GB/day), default timeout 180 s and maxsize
   512 MiB; handle HTTP 429 with jittered retries and backoff; prefer
   mirrored or self-hosted endpoints at scale.
-  ([dev.overpass-api.de](https://dev.overpass-api.de/overpass-doc/en/preface/commons.html?utm_source=openai),
-  [osm-queries.ldodds.com](https://osm-queries.ldodds.com/tutorial/26-timeouts-and-endpoints.osm.html?utm_source=openai))
+  ([dev.overpass-api.de](https://dev.overpass-api.de/overpass-doc/en/preface/commons.html),
+  [osm-queries.ldodds.com](https://osm-queries.ldodds.com/tutorial/26-timeouts-and-endpoints.osm.html))
 - **Cache keys:** Canonicalise request parameters before hashing (stable
   JSON encoding, sorted keys, normalised floats with fixed precision for
   coordinates, normalised theme ordering). Use namespaced key format
-  `route:v1:`.
+  `route:v1:<hash>` where `<hash>` is a digest of the canonical payload.
 - **TTLs:** Set a default TTL (24 h) for anonymous route results; apply a
   small jitter (±5 min) to avoid stampedes; skip TTL for saved routes.
   Invalidate on schema/engine version bumps by rotating namespace suffix

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -272,6 +272,7 @@ transactionally updates user-specific info. Heavy geospatial reads can be
 isolated by using read replicas or a separate schema, but the MVP can start
 with a single database instance for everything.
 
+ 
 *Observability:* The database and ORM layer are monitored to ensure healthy
 performance. Postgres metrics collection is enabled (for example, running a
 **Postgres exporter** or using CloudNativePG’s built-in metrics if deployed in
@@ -286,6 +287,8 @@ metrics like CPU, I/O, number of queries per second, etc., as recommended by
 the deployment guide. Example alert:
 - `pg_connections{db="app"} / pg_max_connections > 0.8` for 5m → page SRE.
   Note: metric names are exporter‑dependent; adjust to your exporter.
+ 
+ 
 
 If any query regularly takes too long (impacting route generation latency),
 alert and optimise that part (adding indexes or caching results). On the
@@ -369,7 +372,7 @@ Operational details:
     - Stable JSON (UTF-8, sorted keys, no whitespace).
     - Coordinates rounded to 5 decimal places (~1.1 m); themes sorted.
     - Hash: lowercase hex SHA-256 of the canonical payload.
-    - Key: `route:v1:<hash>` (optionally truncate to first 32 hex chars;
+    - Key: `route:v1:<sha256>` (optionally truncate to first 32 hex chars;
       document truncation).
     - **TTLs:** Set a default TTL (24 h) for anonymous route results; apply a
       jitter of ±10% to avoid stampedes; skip TTL for saved routes. Invalidate

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -291,7 +291,7 @@ the deployment guide. Example alert:
  
 
 If any query regularly takes too long (impacting route generation latency),
-alert and optimise that part (adding indexes or caching results). On the
+alert and optimize that part (adding indexes or caching results). On the
 analytics side, database operations themselves aren’t directly in PostHog, but
 PostHog may track high-level outcomes (e.g. “UserSavedRoute” event when a user
 saves a generated route to the DB).

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -316,10 +316,11 @@ Operational details:
   mirrored or self-hosted endpoints at scale.
   ([dev.overpass-api.de](https://dev.overpass-api.de/overpass-doc/en/preface/commons.html),
   [osm-queries.ldodds.com](https://osm-queries.ldodds.com/tutorial/26-timeouts-and-endpoints.osm.html))
-- **Cache keys:** Canonicalise request parameters before hashing (stable
-  JSON encoding, sorted keys, normalised floats with fixed precision for
-  coordinates, normalised theme ordering). Use namespaced key format
-  `route:v1:<hash>` where `<hash>` is a digest of the canonical payload.
+  - **Cache keys:** Canonicalise request parameters before hashing (stable
+    JSON encoding, sorted keys, normalised floats with fixed precision for
+    coordinates, normalised theme ordering). Use namespaced key format such
+    as `route:v1:9f1ae8cc` where the suffix is a SHA-256 digest of the
+    canonical payload.
 - **TTLs:** Set a default TTL (24 h) for anonymous route results; apply a
   small jitter (±5 min) to avoid stampedes; skip TTL for saved routes.
   Invalidate on schema/engine version bumps by rotating namespace suffix

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -272,7 +272,6 @@ transactionally updates user-specific info. Heavy geospatial reads can be
 isolated by using read replicas or a separate schema, but the MVP can start
 with a single database instance for everything.
 
- 
 *Observability:* The database and ORM layer are monitored to ensure healthy
 performance. Postgres metrics collection is enabled (for example, running a
 **Postgres exporter** or using CloudNativePG’s built-in metrics if deployed in
@@ -285,10 +284,10 @@ duration). The Prometheus operator will scrape database metrics (if using an
 operator or a managed DB with metrics). In Grafana, dashboards will plot DB
 metrics like CPU, I/O, number of queries per second, etc., as recommended by
 the deployment guide. Example alert:
+
 - `pg_connections{db="app"} / pg_max_connections > 0.8` for 5m → page SRE.
+
   Note: metric names are exporter‑dependent; adjust to your exporter.
- 
- 
 
 If any query regularly takes too long (impacting route generation latency),
 alert and optimize that part (adding indexes or caching results). On the
@@ -317,7 +316,7 @@ saves a generated route to the DB).
   hash of the request parameters as the cache key. If a later request hashes to
   the same value, the cached route is returned immediately, reducing
   computation and latency.
- 
+
 Figure: Route response caching and on-demand enrichment sequence.
 
 ```mermaid
@@ -349,7 +348,6 @@ sequenceDiagram
   end
 ```
 
- 
 Operational details:
 
 - **Overpass quotas:**
@@ -440,8 +438,6 @@ metrics:
 The cost analysis for MVP even budgets a small Redis Cloud instance for
 caching([1](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/wildside-high-level-design.md#L2-L5)),
 underlining its role as both cache and queue.
-
- 
 
 *Observability:* The caching layer is monitored to ensure it’s effectively
 improving performance. **Cache hit rates and misses** for critical caches are
@@ -884,7 +880,7 @@ for urban explorers, but also is stable, scalable, and well-monitored in
 production.
 
 **Sources:** The design is informed by the Wildside project’s high-level design
- 
+
 documents and repository guides, which emphasise a Rust Actix backend,
 Postgres/PostGIS data store, and monolithic MVP approach[^1][^2]. Observability
 and cloud deployment strategies follow the cloud-native architecture

--- a/docs/complexity-antipatterns-and-refactoring-strategies.md
+++ b/docs/complexity-antipatterns-and-refactoring-strategies.md
@@ -418,7 +418,7 @@ CQRS is an architectural pattern that segregates operations that modify state
 and should represent specific business intentions (e.g.,
 
 `BookHotelRoomCommand` rather than `SetReservationStatusCommand`).18 Queries
-never alter data and return Data Transfer Objects (DTOs) optimised for display
+never alter data and return Data Transfer Objects (DTOs) optimized for display
 needs.18
 
 While CQRS operates at a higher architectural level than a single Bumpy Road

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -565,7 +565,7 @@ flowchart TD
       --bbox <minLon,minLat,maxLon,maxLat> \
       --tags amenity,historic,tourism,leisure,natural \
       --batch-size 10000 \
-      --threads 4
+      --threads 4   # number of decode/ingest worker threads (document scope)
     ```
 
   - Performance: Stream with bounded memory; parallel decode when CPU > 1.

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -542,9 +542,9 @@ flowchart TD
 
 #### 3.3.4. Implementation Tasks
 
-- [ ] **Initial Data Seeding:** Create a standalone data ingestion script
-  (e.g., using Python with `osmium`) that performs the one-time pre-seeding of
-  the database for a defined geographic area (Edinburgh).
+- [ ] **Initial Data Seeding:** Build a Rust-based ingestion tool using the
+  `osmpbf` crate, as outlined in the backend design, to perform the one-time
+  pre-seeding of the database for a defined geographic area (Edinburgh).
 
 - [ ] **Implement On-Demand Enrichment Logic:** In the `GenerateRouteJob`
   handler, add logic to detect when the local POI query returns a sparse result

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -543,8 +543,18 @@ flowchart TD
 #### 3.3.4. Implementation Tasks
 
 - [ ] **Initial Data Seeding:** Build a Rust-based ingestion tool using the
-  `osmpbf` crate, as outlined in the backend design, to perform the one-time
-  pre-seeding of the database for a defined geographic area (Edinburgh).
+  `osmpbf` crate to perform the one-time pre-seeding of the database for a
+  defined geographic area (Edinburgh).
+   - Input: `.osm.pbf` extract (e.g., Geofabrik); filter to launch polygon.
+   - Mapping: Nodes → POIs; Ways/Relations → POIs via centroid; persist `id`
+     (OSM element id), `location` (GEOGRAPHY Point 4326), `osm_tags` (JSONB).
+   - Write path: UPSERT by `id` in batches with transactions; ensure GIST on
+     `location` and GIN on `osm_tags` exist before bulk load.
+   - Determinism: Canonicalise tag keys/values; record import provenance
+     (source URL, timestamp, bbox) for audit.
+   - CLI: `ingest-osm --pbf edinburgh.osm.pbf --bbox  --tags
+     amenity,historic,tourism,leisure,natural`.
+   - Performance: Stream with bounded memory; parallel decode when CPU>1.
 
 - [ ] **Implement On-Demand Enrichment Logic:** In the `GenerateRouteJob`
   handler, add logic to detect when the local POI query returns a sparse result

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -548,13 +548,18 @@ flowchart TD
    - Input: `.osm.pbf` extract (e.g., Geofabrik); filter to launch polygon.
    - Mapping: Nodes → POIs; Ways/Relations → POIs via centroid; persist `id`
      (OSM element id), `location` (GEOGRAPHY Point 4326), `osm_tags` (JSONB).
-   - Write path: UPSERT by `id` in batches with transactions; ensure GIST on
-     `location` and GIN on `osm_tags` exist before bulk load.
+   - Write path: UPSERT by `id` in batches with transactions; ensure GiST on
+     `location` and GIN on `osm_tags` exist before bulk load; ensure a UNIQUE
+     constraint on `id` backs the upsert.
    - Determinism: Canonicalise tag keys/values; record import provenance
      (source URL, timestamp, bbox) for audit.
-   - CLI: `ingest-osm --pbf edinburgh.osm.pbf --bbox  --tags
-     amenity,historic,tourism,leisure,natural`.
-   - Performance: Stream with bounded memory; parallel decode when CPU>1.
+   - CLI:
+     ```bash
+     ingest-osm --pbf edinburgh.osm.pbf \
+       --bbox <minLon,minLat,maxLon,maxLat> \
+       --tags amenity,historic,tourism,leisure,natural
+     ```
+   - Performance: Stream with bounded memory; parallel decode when CPU > 1.
 
 - [ ] **Implement On-Demand Enrichment Logic:** In the `GenerateRouteJob`
   handler, add logic to detect when the local POI query returns a sparse result

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -449,8 +449,7 @@ Null (NN), and Generalized Search Tree (GiST).
 | ---------- | -------- | ------------------------------------------------- | ------------------------------------------- |
 | `poi_element_type` | `TEXT` | `PRIMARY KEY`, `FOREIGN KEY (pois.element_type)` | POI element type. |
 | `poi_id` | `BIGINT` | `PRIMARY KEY`, `FOREIGN KEY (pois.id)` | POI element ID. |
-| `theme_id` | `UUID` | `PRIMARY KEY`, `FOREIGN KEY (interest_themes.id)` | Foreign key to the `interest_themes` table. |
-|  |  | PK: `(poi_element_type, poi_id, theme_id)`; FK: `(poi_element_type, poi_id)` → `pois(element_type, id)` |  |
+| `theme_id` | `UUID` | `PRIMARY KEY`, `FOREIGN KEY (interest_themes.id)`; PK `(poi_element_type, poi_id, theme_id)`; FK `(poi_element_type, poi_id)` → `pois(element_type, id)` | Foreign key to the `interest_themes` table. |
 
 **`routes`**: Stores generated walks.
 
@@ -562,7 +561,7 @@ flowchart TD
     ensure a UNIQUE constraint on `(element_type, id)` backs the upsert. Create
     GiST on `location` and GIN on `osm_tags` after the initial bulk load to
     maximize ingest throughput.
-  - Determinism: Canonicalise tag keys/values; record import provenance
+  - Determinism: Canonicalize tag keys/values; record import provenance
     (source URL, timestamp, bbox) for audit.
   - CLI:
 

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -434,7 +434,7 @@ Null (NN), and Generalized Search Tree (GiST).
 | Column | Type | Notes |
 | ------------------ | ------------------------ | ------------------------------------------- |
 | `id` | `BIGINT` | PK; OSM element ID |
-| `location` | `GEOGRAPHY(Point, 4326)` | NN; GIST index |
+| `location` | `GEOGRAPHY(Point, 4326)` | NN; GiST index |
 | `osm_tags` | `JSONB` | OSM tags; GIN index |
 | `narrative` | `TEXT` | Optional engaging description |
 | `popularity_score` | `REAL` | Default 0.5; 0.0 hidden gem – 1.0 hotspot |
@@ -452,7 +452,7 @@ Null (NN), and Generalized Search Tree (GiST).
 | ------------------- | ---------------------------- | ------------------------------------- |
 | `id` | `UUID` | PK; default `gen_random_uuid()` |
 | `user_id` | `UUID` | FK `users.id`; nullable |
-| `path` | `GEOMETRY(LineString, 4326)` | Full path; GIST index |
+| `path` | `GEOMETRY(LineString, 4326)` | Full path; GiST index |
 | `generation_params` | `JSONB` | Parameters used to generate the route |
 | `created_at` | `TIMESTAMPTZ` | NN; default `NOW()` |
 

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -548,9 +548,9 @@ flowchart TD
    - Input: `.osm.pbf` extract (e.g., Geofabrik); filter to launch polygon.
    - Mapping: Nodes → POIs; Ways/Relations → POIs via centroid; persist `id`
      (OSM element id), `location` (GEOGRAPHY Point 4326), `osm_tags` (JSONB).
-   - Write path: UPSERT by `id` in batches with transactions; ensure GiST on
-     `location` and GIN on `osm_tags` exist before bulk load; ensure a UNIQUE
-     constraint on `id` backs the upsert.
+   - Write path: UPSERT by `id` in batches with transactions; ensure a UNIQUE
+     constraint on `id` backs the upsert. Create GiST on `location` and GIN on
+     `osm_tags` after the initial bulk load to maximise ingest throughput.
    - Determinism: Canonicalise tag keys/values; record import provenance
      (source URL, timestamp, bbox) for audit.
    - CLI:
@@ -560,6 +560,11 @@ flowchart TD
        --tags amenity,historic,tourism,leisure,natural
      ```
    - Performance: Stream with bounded memory; parallel decode when CPU > 1.
+   - Acceptance criteria:
+     - CLI runs against an Edinburgh extract and completes within a bounded time.
+     - Idempotent re-runs do not duplicate POIs (UPSERT-by-id verified).
+     - UNIQUE(id), GiST(location), and GIN(osm_tags) exist post-load.
+     - Import provenance (source URL, timestamp, bbox) recorded.
 
 - [ ] **Implement On-Demand Enrichment Logic:** In the `GenerateRouteJob`
   handler, add logic to detect when the local POI query returns a sparse result


### PR DESCRIPTION
## Summary
- expand backend design with section on Rust `osmpbf` data seeding
- note `EnrichmentJob` Overpass queries when POIs are sparse
- describe Redis route caching keyed by hashed request parameters

## Testing
- `make check-fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bc86092584832288138553fca4d792

## Summary by Sourcery

Document the backend’s OSM data workflow by adding a new section on initial seeding, on-demand enrichment, and route caching in Redis, and update implementation tasks to specify the Rust ingestion tool.

Documentation:
- Add a Data Seeding, Enrichment, and Route Caching section to the backend design doc describing Rust-based OSM seeding, Overpass enrichment jobs, and Redis-backed route caching
- Update implementation checklist to replace the Python/osmium seeder with a Rust `osmpbf` ingestion tool