### PR TITLE
Document health endpoints

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -247,6 +247,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "actix-web-prom"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76743e67d4e7efa9fc2ac7123de0dd7b2ca592668e19334f1d81a3b077afc6ac"
+dependencies = [
+ "actix-web",
+ "futures-core",
+ "log",
+ "pin-project-lite",
+ "prometheus",
+ "regex",
+ "strfmt",
+]
+
+[[package]]
 name = "actix_derive"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -361,6 +376,7 @@ dependencies = [
  "actix-session",
  "actix-web",
  "actix-web-actors",
+ "actix-web-prom",
  "futures-util",
  "insta",
  "regex",
@@ -1282,7 +1298,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1db05f56d34358a8b1066f67cbb203ee3e7ed2ba674a6263a1d5ec6db2204323"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 2.0.16",
  "ucd-trie",
 ]
 
@@ -1380,6 +1396,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d61789d7719defeb74ea5fe81f2fdfdbd28a803847077cecce2ff14e1472f6f1"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "prometheus"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d33c28a30771f7f96db69893f78b857f7450d7e0237e9c8fc6427a81bae7ed1"
+dependencies = [
+ "cfg-if",
+ "fnv",
+ "lazy_static",
+ "memchr",
+ "parking_lot",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -1786,6 +1816,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "strfmt"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fdc163db75f7b5ffa3daf0c5a7136fb0d4b2f35523cd1769da05e034159feb"
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1815,11 +1851,31 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.16",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -24,6 +24,16 @@ tokio = { version = "1", features = ["macros"] }
 utoipa = { version = "5", features = ["macros", "uuid", "yaml", "actix_extras"] }
 utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 
+# Optional: Prometheus metrics via middleware + /metrics endpoint
+# Kept behind the `metrics` feature to allow local builds without
+# fetching new dependencies. Enable with `--features metrics`.
+actix-web-prom = { version = "0.8", optional = true }
+
+[features]
+default = []
+# Enable Prometheus metrics middleware and endpoint
+metrics = ["dep:actix-web-prom"]
+
 [dev-dependencies]
 actix-rt = "2"
 rstest = "0.18"

--- a/backend/src/api/health.rs
+++ b/backend/src/api/health.rs
@@ -1,16 +1,46 @@
-use actix_web::{get, HttpResponse};
+//! Health endpoints: liveness & readiness probes for orchestration and load balancers.
+//! Document endpoints in OpenAPI via Utoipa.
+use actix_web::{get, web, HttpResponse};
+use std::sync::atomic::{AtomicBool, Ordering};
 
-/// Readiness probe. Return 200 when dependencies are initialised and the server can handle traffic.
+#[derive(Default)]
+pub struct HealthState {
+    ready: AtomicBool,
+}
+
+impl HealthState {
+    /// Create a new health state starting as not ready.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Mark the service as ready.
+    pub fn mark_ready(&self) {
+        self.ready.store(true, Ordering::Relaxed);
+    }
+
+    /// Return readiness state.
+    pub fn is_ready(&self) -> bool {
+        self.ready.load(Ordering::Relaxed)
+    }
+}
+
+/// Readiness probe. Return 200 when dependencies are initialised and the server can handle traffic; return 503 otherwise.
 #[utoipa::path(
     get,
     path = "/health/ready",
     responses(
-        (status = 200, description = "Server is ready to handle traffic")
+        (status = 200, description = "Server is ready to handle traffic"),
+        (status = 503, description = "Server is not ready")
     )
 )]
 #[get("/health/ready")]
-pub async fn ready() -> HttpResponse {
-    HttpResponse::Ok().finish()
+pub async fn ready(state: web::Data<HealthState>) -> HttpResponse {
+    if state.is_ready() {
+        HttpResponse::Ok().finish()
+    } else {
+        HttpResponse::ServiceUnavailable().finish()
+    }
 }
 
 /// Liveness probe. Return 200 when the process is alive.

--- a/backend/src/api/health.rs
+++ b/backend/src/api/health.rs
@@ -3,6 +3,7 @@
 use actix_web::{get, web, HttpResponse};
 use std::sync::atomic::{AtomicBool, Ordering};
 
+/// Shared readiness state for health checks.
 #[derive(Default)]
 pub struct HealthState {
     ready: AtomicBool,

--- a/backend/src/api/health.rs
+++ b/backend/src/api/health.rs
@@ -1,6 +1,6 @@
 //! Health endpoints: liveness & readiness probes for orchestration and load balancers.
 //! Document endpoints in OpenAPI via Utoipa.
-use actix_web::{get, web, HttpResponse};
+use actix_web::{get, http::header, web, HttpResponse};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Shared readiness state for health checks.
@@ -38,9 +38,13 @@ impl HealthState {
 #[get("/health/ready")]
 pub async fn ready(state: web::Data<HealthState>) -> HttpResponse {
     if state.is_ready() {
-        HttpResponse::Ok().finish()
+        HttpResponse::Ok()
+            .insert_header((header::CACHE_CONTROL, "no-store"))
+            .finish()
     } else {
-        HttpResponse::ServiceUnavailable().finish()
+        HttpResponse::ServiceUnavailable()
+            .insert_header((header::CACHE_CONTROL, "no-store"))
+            .finish()
     }
 }
 
@@ -54,5 +58,7 @@ pub async fn ready(state: web::Data<HealthState>) -> HttpResponse {
 )]
 #[get("/health/live")]
 pub async fn live() -> HttpResponse {
-    HttpResponse::Ok().finish()
+    HttpResponse::Ok()
+        .insert_header((header::CACHE_CONTROL, "no-store"))
+        .finish()
 }

--- a/backend/src/api/health.rs
+++ b/backend/src/api/health.rs
@@ -1,0 +1,27 @@
+use actix_web::{get, HttpResponse};
+
+/// Readiness probe. Return 200 when dependencies are initialised and the server can handle traffic.
+#[utoipa::path(
+    get,
+    path = "/health/ready",
+    responses(
+        (status = 200, description = "Server is ready to handle traffic")
+    )
+)]
+#[get("/health/ready")]
+pub async fn ready() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}
+
+/// Liveness probe. Return 200 when the process is alive.
+#[utoipa::path(
+    get,
+    path = "/health/live",
+    responses(
+        (status = 200, description = "Server is alive")
+    )
+)]
+#[get("/health/live")]
+pub async fn live() -> HttpResponse {
+    HttpResponse::Ok().finish()
+}

--- a/backend/src/api/health.rs
+++ b/backend/src/api/health.rs
@@ -4,6 +4,7 @@ use actix_web::{get, http::header, web, HttpResponse};
 use std::sync::atomic::{AtomicBool, Ordering};
 
 /// Shared readiness state for health checks.
+/// Gate /health/ready responses on this atomic flag.
 #[derive(Default)]
 pub struct HealthState {
     ready: AtomicBool,

--- a/backend/src/api/health.rs
+++ b/backend/src/api/health.rs
@@ -18,12 +18,12 @@ impl HealthState {
 
     /// Mark the service as ready.
     pub fn mark_ready(&self) {
-        self.ready.store(true, Ordering::Relaxed);
+        self.ready.store(true, Ordering::Release);
     }
 
     /// Return readiness state.
     pub fn is_ready(&self) -> bool {
-        self.ready.load(Ordering::Relaxed)
+        self.ready.load(Ordering::Acquire)
     }
 }
 
@@ -31,6 +31,7 @@ impl HealthState {
 #[utoipa::path(
     get,
     path = "/health/ready",
+    tags = ["health"],
     responses(
         (status = 200, description = "Server is ready to handle traffic"),
         (status = 503, description = "Server is not ready")
@@ -53,6 +54,7 @@ pub async fn ready(state: web::Data<HealthState>) -> HttpResponse {
 #[utoipa::path(
     get,
     path = "/health/live",
+    tags = ["health"],
     responses(
         (status = 200, description = "Server is alive")
     )

--- a/backend/src/api/mod.rs
+++ b/backend/src/api/mod.rs
@@ -1,3 +1,4 @@
 //! REST API modules.
 
+pub mod health;
 pub mod users;

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -7,7 +7,6 @@ use utoipa::OpenApi;
 /// Swagger UI is enabled in debug builds only and used by tooling.
 #[derive(OpenApi)]
 #[openapi(
-<<<<<<< HEAD
     paths(
         crate::api::users::list_users,
         crate::api::users::login,
@@ -15,18 +14,9 @@ use utoipa::OpenApi;
         crate::api::health::live,
     ),
     components(schemas(User, Error, ErrorCode)),
-    tags((name = "users", description = "Operations related to users"))
-||||||| parent of 526744b (Tag health endpoints in OpenAPI spec)
-    paths(crate::api::users::list_users, crate::api::health::ready, crate::api::health::live),
-    components(schemas(User)),
-    tags((name = "users", description = "Operations related to users"))
-=======
-    paths(crate::api::users::list_users, crate::api::health::ready, crate::api::health::live),
-    components(schemas(User)),
     tags(
         (name = "users", description = "Operations related to users"),
         (name = "health", description = "Endpoints for health checks")
     )
->>>>>>> 526744b (Tag health endpoints in OpenAPI spec)
 )]
 pub struct ApiDoc;

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -7,6 +7,7 @@ use utoipa::OpenApi;
 /// Swagger UI is enabled in debug builds only and used by tooling.
 #[derive(OpenApi)]
 #[openapi(
+<<<<<<< HEAD
     paths(
         crate::api::users::list_users,
         crate::api::users::login,
@@ -15,5 +16,17 @@ use utoipa::OpenApi;
     ),
     components(schemas(User, Error, ErrorCode)),
     tags((name = "users", description = "Operations related to users"))
+||||||| parent of 526744b (Tag health endpoints in OpenAPI spec)
+    paths(crate::api::users::list_users, crate::api::health::ready, crate::api::health::live),
+    components(schemas(User)),
+    tags((name = "users", description = "Operations related to users"))
+=======
+    paths(crate::api::users::list_users, crate::api::health::ready, crate::api::health::live),
+    components(schemas(User)),
+    tags(
+        (name = "users", description = "Operations related to users"),
+        (name = "health", description = "Endpoints for health checks")
+    )
+>>>>>>> 526744b (Tag health endpoints in OpenAPI spec)
 )]
 pub struct ApiDoc;

--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -10,6 +10,8 @@ use utoipa::OpenApi;
     paths(
         crate::api::users::list_users,
         crate::api::users::login,
+        crate::api::health::ready,
+        crate::api::health::live,
     ),
     components(schemas(User, Error, ErrorCode)),
     tags((name = "users", description = "Operations related to users"))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -83,10 +83,11 @@ async fn main() -> std::io::Result<()> {
 
             app
         }
-    });
+    })
+    .bind(("0.0.0.0", 8080))?;
 
     // Mark the application as ready after initialisation completes.
     health_state.mark_ready();
 
-    server.bind(("0.0.0.0", 8080))?.run().await
+    server.run().await
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -90,11 +90,15 @@ async fn main() -> std::io::Result<()> {
             // `--features metrics` to expose `/metrics` and add request metrics.
             #[cfg(feature = "metrics")]
             let app = {
+                // Prometheus middleware automatically serves the metrics at the configured
+                // endpoint (by short‑circuiting matching requests). We should therefore only
+                // wrap the app; registering it as a service is incorrect because the
+                // PrometheusMetrics type is not an HttpServiceFactory.
                 let prometheus = PrometheusMetricsBuilder::new("wildside")
                     .endpoint("/metrics")
                     .build()
                     .expect("configure Prometheus metrics");
-                app.wrap(prometheus.clone()).service(prometheus)
+                app.wrap(prometheus)
             };
 
             app

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -2,7 +2,7 @@
 
 use actix_session::{storage::CookieSessionStore, SessionMiddleware};
 use actix_web::cookie::{Key, SameSite};
-use actix_web::{get, web, App, HttpResponse, HttpServer};
+use actix_web::{web, App, HttpServer};
 use std::env;
 use tracing::warn;
 use tracing_subscriber::{fmt, EnvFilter};
@@ -11,23 +11,12 @@ use utoipa::OpenApi;
 #[cfg(debug_assertions)]
 use utoipa_swagger_ui::SwaggerUi;
 
+use backend::api::health::{live, ready};
 use backend::api::users::{list_users, login};
 #[cfg(debug_assertions)]
 use backend::doc::ApiDoc;
 use backend::ws;
 use backend::Trace;
-
-/// Readiness probe. Return 200 when dependencies are initialised and the server can handle traffic.
-#[get("/health/ready")]
-async fn ready() -> HttpResponse {
-    HttpResponse::Ok().finish()
-}
-
-/// Liveness probe. Return 200 when the process is alive.
-#[get("/health/live")]
-async fn live() -> HttpResponse {
-    HttpResponse::Ok().finish()
-}
 
 /// Application bootstrap.
 #[actix_web::main]

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -710,11 +710,12 @@ configured with TLS (Let’s Encrypt via cert-manager). The static frontend (PWA
 can be served via a CDN or object storage, as indicated by the design (the
 sequence diagram shows the browser fetching assets from CDN and API calls
 hitting
-backend)[^2].
- The backend containers mount config (like database DSN, secrets for cookie
-signing, API keys) via K8s Secrets and ConfigMaps. Readiness/liveness probes for
-the Actix Web app (e.g. an endpoint `/healthz`) allow Kubernetes to detect if a
-pod is unresponsive and restart it.
+backend)([2](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/repository-structure.md#L26-L34)).
+ The backend containers will mount config (like database DSN, secrets for
+cookie signing, API keys) via K8s Secrets and ConfigMaps. Include readiness and
+liveness probes for the Actix Web app (endpoints `/health/ready` and
+`/health/live`) so Kubernetes can detect if a pod is unresponsive and restart
+it.
 
 Database options include a managed Postgres (e.g. DigitalOcean Managed DB) or
 running a cluster via an operator like **CloudNativePG**. The design documents

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -712,10 +712,21 @@ sequence diagram shows the browser fetching assets from CDN and API calls
 hitting
 backend)([2](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/repository-structure.md#L26-L34)).
  The backend containers will mount config (like database DSN, secrets for
+<<<<<<< HEAD
 cookie signing, API keys) via K8s Secrets and ConfigMaps. Include readiness and
 liveness probes for the Actix Web app (endpoints `/health/ready` and
 `/health/live`) so Kubernetes can detect if a pod is unresponsive and restart
 it.
+||||||| parent of a3395ac (Document HealthState and wrap health docs)
+cookie signing, API keys) via K8s Secrets and ConfigMaps. We’ll also include
+readiness and liveness probes for the Actix Web app (e.g. endpoints `/health/ready` and `/health/live`)
+so Kubernetes can detect if a pod is unresponsive and restart it.
+=======
+cookie signing, API keys) via K8s Secrets and ConfigMaps. We’ll also include
+readiness and liveness probes for the Actix Web app (e.g. endpoints
+`/health/ready` and `/health/live`) so Kubernetes can detect if a pod
+is unresponsive and restart it.
+>>>>>>> a3395ac (Document HealthState and wrap health docs)
 
 Database options include a managed Postgres (e.g. DigitalOcean Managed DB) or
 running a cluster via an operator like **CloudNativePG**. The design documents

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -706,27 +706,14 @@ availability and a couple of worker pods for throughput, adjusting as needed.
 
 Kubernetes best practices are used, such as a **Traefik Ingress** (as per the
 repo’s manifests) to route external traffic to the Actix Web service[^2],
-configured with TLS (Let’s Encrypt via cert-manager). The static frontend (PWA)
-can be served via a CDN or object storage, as indicated by the design (the
-sequence diagram shows the browser fetching assets from CDN and API calls
-hitting
-backend)([2](https://github.com/leynos/wildside/blob/663a1cb6ca7dd0af1b43276b65de6a2ae68f8da6/docs/repository-structure.md#L26-L34)).
- The backend containers will mount config (like database DSN, secrets for
-<<<<<<< HEAD
-cookie signing, API keys) via K8s Secrets and ConfigMaps. Include readiness and
-liveness probes for the Actix Web app (endpoints `/health/ready` and
-`/health/live`) so Kubernetes can detect if a pod is unresponsive and restart
-it.
-||||||| parent of a3395ac (Document HealthState and wrap health docs)
-cookie signing, API keys) via K8s Secrets and ConfigMaps. We’ll also include
-readiness and liveness probes for the Actix Web app (e.g. endpoints `/health/ready` and `/health/live`)
-so Kubernetes can detect if a pod is unresponsive and restart it.
-=======
-cookie signing, API keys) via K8s Secrets and ConfigMaps. We’ll also include
-readiness and liveness probes for the Actix Web app (e.g. endpoints
-`/health/ready` and `/health/live`) so Kubernetes can detect if a pod
-is unresponsive and restart it.
->>>>>>> a3395ac (Document HealthState and wrap health docs)
+configured with TLS (Let’s Encrypt via cert-manager). The static frontend
+(PWA) can be served via a CDN or object storage, as indicated by the design
+(the sequence diagram shows the browser fetching assets from CDN and API calls
+hitting the backend)[^2]. The backend containers will mount config (like
+database DSN and secrets for cookie signing and API keys) via K8s Secrets and
+ConfigMaps. We’ll also include readiness and liveness probes for the Actix Web
+app (e.g. endpoints `/health/ready` and `/health/live`) so Kubernetes can
+detect if a pod is unresponsive and restart it.
 
 Database options include a managed Postgres (e.g. DigitalOcean Managed DB) or
 running a cluster via an operator like **CloudNativePG**. The design documents

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -134,7 +134,7 @@ API and WebSocket traffic.
 
   - Enqueue jobs for the background workers to process.
 
-  - Serve a `/metrics` endpoint for Prometheus and a `/healthz` endpoint for
+  - Serve a `/metrics` endpoint for Prometheus and `/health/ready` and `/health/live` endpoints for
     Kubernetes probes.
 
 - **Implementation Tasks:**
@@ -222,7 +222,7 @@ API and WebSocket traffic.
     - Integrate the `actix-web-prom` crate as middleware to expose default
       Prometheus metrics on a `/metrics` endpoint.
 
-    - Implement a `/healthz` endpoint that returns a `200 OK` response.
+    - Implement `/health/ready` and `/health/live` endpoints. `/health/ready` returns `200 OK` once dependencies are initialised and `503` otherwise.
 
     - Ensure all request handlers have `tracing` spans with a unique
       `request_id`, propagating it via a `Trace-Id` response header for

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -222,6 +222,9 @@ API and WebSocket traffic.
 
     - Integrate the `actix-web-prom` crate as middleware to expose default
       Prometheus metrics on a `/metrics` endpoint.
+      Status: wired behind a `metrics` cargo feature. Build with
+      `--features metrics` to enable middleware and the `/metrics` route
+      without impacting environments that cannot fetch new crates.
 
     - Implement `/health/ready` and `/health/live` endpoints.
       `/health/ready` returns `200 OK` once dependencies are

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -134,8 +134,9 @@ API and WebSocket traffic.
 
   - Enqueue jobs for the background workers to process.
 
-  - Serve a `/metrics` endpoint for Prometheus and `/health/ready` and `/health/live` endpoints for
-    Kubernetes probes.
+  - Serve a `/metrics` endpoint for Prometheus and
+    `/health/ready` and `/health/live` endpoints for Kubernetes
+    probes.
 
 - **Implementation Tasks:**
 
@@ -222,7 +223,9 @@ API and WebSocket traffic.
     - Integrate the `actix-web-prom` crate as middleware to expose default
       Prometheus metrics on a `/metrics` endpoint.
 
-    - Implement `/health/ready` and `/health/live` endpoints. `/health/ready` returns `200 OK` once dependencies are initialised and `503` otherwise.
+    - Implement `/health/ready` and `/health/live` endpoints.
+      `/health/ready` returns `200 OK` once dependencies are
+      initialised and `503` otherwise.
 
     - Ensure all request handlers have `tracing` spans with a unique
       `request_id`, propagating it via a `Trace-Id` response header for


### PR DESCRIPTION
## Summary
- annotate readiness and liveness handlers for OpenAPI
- expose health endpoints in generated API docs

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68bb2e977eac832286b8e05d0d8bcd41

## Summary by Sourcery

Introduce dedicated health-check endpoints with OpenAPI documentation, integrate shared readiness state into the server, and update docs with new health paths and optional Prometheus metrics support.

New Features:
- Add a HealthState struct and `/health/ready` and `/health/live` handlers in a new health module
- Annotate readiness and liveness endpoints for OpenAPI and register them in Swagger UI

Enhancements:
- Inject shared readiness state into the Actix App and mark the service as ready after startup
- Refactor main server setup to include health routes and wrap the app with optional Prometheus middleware under a `metrics` feature

Build:
- Add `actix-web-prom` as an optional dependency and define a `metrics` cargo feature for Prometheus integration

Documentation:
- Update design documents and API docs to reference `/health/ready` and `/health/live` endpoints and conditional `/metrics` route