### PR TITLE
Clarify background worker queue setup

### DIFF
--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -590,6 +590,7 @@ const MAX_BACKOFF_SECS: u64 = 160; // cap backoff at 160 seconds
 // Worker with bounded immediate retries
 let worker = WorkerBuilder::new("route_generation")
     .layer(RetryLayer::new(RetryPolicy::retries(MAX_ATTEMPTS)))
+    .data(dlq_storage.clone())
     .build(rg_storage.clone(), route_generation_handler);
 
 // Inside the handler, on failure, reschedule with backoff (persisting attempts):
@@ -668,9 +669,11 @@ struct GenerateRouteJob {
 }
 ```
 
-Validate GeoPoint with -90.0 ≤ lat ≤ 90.0 and -180.0 < lon ≤ 180.0 at
-enqueue time. Apply minimal guards when enqueuing to reject or normalise
-out-of-range coordinates.
+// Validate GeoPoint with -90.0 ≤ lat ≤ 90.0 and -180.0 < lon ≤ 180.0 at
+// enqueue time.
+
+Apply minimal guards when enqueuing to reject or normalise out-of-range
+coordinates.
 
 Scheduled jobs, such as refreshing OpenStreetMap data, run on
 `enrichment` under the same at‑least‑once, idempotent, retry‑with‑backoff,


### PR DESCRIPTION
## Summary
- tighten background worker description and remove first-person voice
- show Redis namespaces for Apalis queues and provide a compilable job schema snippet

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68be123551188322ae76d4506cedbe8e

## Summary by Sourcery

Revise background worker documentation to clarify queue setup, provide Rust code examples for Apalis-Redis configuration and job schema, and refine reliability and observability guidance.

Documentation:
- Simplify prose in the background worker section and remove first-person voice.
- Add a Rust code snippet illustrating Apalis-Redis queue configuration with separate namespaces.
- Provide a compilable job schema with GeoPoint, RoutePrefs, and GenerateRouteJob definitions.
- Refine reliability policy bullets for retry backoff, DLQ routing, and idempotency.
- Tighten observability guidance for metrics, logging, and Prometheus integration.