### PR TITLE
ci: enforce pnpm lockfile consistency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,8 @@ jobs:
             **/pyproject.toml
             **/uv.lock
 
-      - name: Ensure pnpm lockfile
-        if: ${{ hashFiles('**/pnpm-lock.yaml') == '' }}
-        run: pnpm install --lockfile-only
+      - name: Check lockfile consistency
+        run: make lockfile
       - name: Install dependencies (frozen)
         run: pnpm install --frozen-lockfile
 

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ endef
 ASYNCAPI_CLI_VERSION ?= 3.4.2
 REDOCLY_CLI_VERSION ?= 2.1.0
 
-.PHONY: all clean be fe fe-build openapi gen docker-up docker-down fmt lint test typecheck deps \
+.PHONY: all clean be fe fe-build openapi gen docker-up docker-down fmt lint test typecheck deps lockfile \
         check-fmt markdownlint markdownlint-docs mermaid-lint nixie yamllint audit \
         lint-asyncapi lint-openapi lint-makefile
 
@@ -107,6 +107,10 @@ audit: deps
 	pnpm -r install
 	pnpm -r --if-present run audit
 	pnpm audit
+
+lockfile:
+	pnpm install --lockfile-only
+	git diff --exit-code pnpm-lock.yaml
 
 check-fmt:
 	cargo fmt --manifest-path backend/Cargo.toml --all -- --check

--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -554,13 +554,16 @@ sequenceDiagram
 
   CI->>NodeSetup: Install Node (corepack: true)
   NodeSetup->>PNPM: Provide pnpm via Corepack
-  CI->>PNPM: If missing -> `pnpm install --lockfile-only`
+  CI->>PNPM: Validate lockfile (`pnpm install --lockfile-only`)
   CI->>PNPM: `pnpm install --frozen-lockfile`
   PNPM->>Repo: Resolve workspace (pnpm-workspace.yaml)
   CI->>PNPM: Run lifecycle scripts (`pnpm -r run build`, `pnpm -r --if-present test`, `pnpm -r --if-present run audit`)
   PNPM-->>CI: Return results/status
   note right of PNPM: Cache and frozen lockfile enforce reproducible CI installs
 ```
+
+`make lockfile` runs `pnpm install --lockfile-only` and fails if
+`pnpm-lock.yaml` changes, guarding against stale dependencies.
 
 ### Docker Compose startup sequence
 


### PR DESCRIPTION
## Summary
- add `make lockfile` target and CI step to check `pnpm-lock.yaml`
- document lockfile validation in repo structure guide

## Testing
- `make fmt`
- `make lint` *(fails: interrupted)*
- `make test` *(fails: interrupted)*
- `make check-fmt`


------
https://chatgpt.com/codex/tasks/task_e_68c3798bb0a4832283f7ca9f050f3bd9

## Summary by Sourcery

Enforce pnpm lockfile consistency by adding a Makefile target, integrating it into CI, and updating documentation

Enhancements:
- Introduce make lockfile target to validate pnpm-lock.yaml consistency
- Integrate make lockfile check into GitHub Actions workflow

CI:
- Replace manual pnpm lockfile step with make lockfile invocation in CI

Documentation:
- Document lockfile validation step in repository structure guide