### PR TITLE
Refactor server setup into build_app helper

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -2396,20 +2396,6 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-dependencies = [
- "zeroize_derive",
-]
-
-[[package]]
-name = "zeroize_derive"
-version = "1.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
 
 [[package]]
 name = "zerotrie"

--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -389,6 +389,7 @@ dependencies = [
  "utoipa",
  "utoipa-swagger-ui",
  "uuid",
+ "zeroize",
 ]
 
 [[package]]
@@ -2388,6 +2389,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -29,6 +29,8 @@ utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 # fetching new dependencies. Enable with `--features metrics`.
 actix-web-prom = { version = "0.10", optional = true }
 
+zeroize = { version = "1.7", default-features = false, features = ["zeroize_derive"] }
+
 [features]
 default = []
 # Enable Prometheus metrics middleware and endpoint

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -29,7 +29,7 @@ utoipa-swagger-ui = { version = "9", features = ["actix-web"] }
 # fetching new dependencies. Enable with `--features metrics`.
 actix-web-prom = { version = "0.10", optional = true }
 
-zeroize = { version = "1.7", default-features = false, features = ["zeroize_derive"] }
+zeroize = "1.7"
 
 [features]
 default = []

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -116,7 +116,7 @@ async fn main() -> std::io::Result<()> {
         env::var("PORT")
             .ok()
             .and_then(|p| p.parse().ok())
-            .unwrap_or(8080u16),
+            .unwrap_or(8080_u16),
     ))?;
 
     let server = server.run();

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -57,7 +57,7 @@ fn build_app(
         .service(login)
         .service(list_users);
 
-    let mut app = App::new()
+    let app = App::new()
         .app_data(health_state)
         .wrap(Trace)
         .service(api)
@@ -66,9 +66,9 @@ fn build_app(
         .service(live);
 
     #[cfg(debug_assertions)]
-    {
-        app = app.service(SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi()));
-    }
+    let app = app.service(SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi()));
+    #[cfg(not(debug_assertions))]
+    let app = app;
 
     app
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1,6 +1,6 @@
 //! Backend entry-point: wires REST endpoints, WebSocket entry, and OpenAPI docs.
 
-use actix_session::{storage::CookieSessionStore, SessionMiddleware};
+use actix_session::{config::PersistentSession, storage::CookieSessionStore, SessionMiddleware};
 use actix_web::cookie::{Key, SameSite};
 use actix_web::dev::{ServiceFactory, ServiceRequest, ServiceResponse};
 use actix_web::{web, App, HttpServer};
@@ -144,6 +144,9 @@ fn build_app(
         .cookie_secure(cookie_secure)
         .cookie_http_only(true)
         .cookie_same_site(same_site)
+        .session_lifecycle(
+            PersistentSession::default().session_ttl(actix_web::cookie::time::Duration::hours(2)),
+        )
         .build();
 
     let api = web::scope("/api/v1")

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -22,116 +22,6 @@ use backend::doc::ApiDoc;
 use backend::ws;
 use backend::Trace;
 
-/// Application bootstrap.
-#[actix_web::main]
-async fn main() -> std::io::Result<()> {
-    if let Err(e) = fmt()
-        .with_env_filter(EnvFilter::from_default_env())
-        .json()
-        .try_init()
-    {
-        warn!(error = %e, "tracing init failed");
-    }
-
-    let key_path =
-        env::var("SESSION_KEY_FILE").unwrap_or_else(|_| "/var/run/secrets/session_key".into());
-    let key = match std::fs::read(&key_path) {
-        Ok(mut bytes) => {
-            if !cfg!(debug_assertions) && bytes.len() < 32 {
-                return Err(std::io::Error::other(format!(
-                    "session key at {key_path} too short: need >=32 bytes, got {}",
-                    bytes.len()
-                )));
-            }
-            let key = Key::derive_from(&bytes);
-            bytes.zeroize();
-            key
-        }
-        Err(e) => {
-            let allow_dev = env::var("SESSION_ALLOW_EPHEMERAL").ok().as_deref() == Some("1");
-            if cfg!(debug_assertions) || allow_dev {
-                warn!(path = %key_path, error = %e, "using temporary session key (dev only)");
-                Key::generate()
-            } else {
-                return Err(std::io::Error::other(format!(
-                    "failed to read session key at {key_path}: {e}"
-                )));
-            }
-        }
-    };
-
-    let cookie_secure = match env::var("SESSION_COOKIE_SECURE") {
-        Ok(v) => match v.to_ascii_lowercase().as_str() {
-            "1" | "true" | "yes" | "y" => true,
-            "0" | "false" | "no" | "n" => false,
-            other => {
-                warn!(value = %other, "invalid SESSION_COOKIE_SECURE; defaulting to secure");
-                true
-            }
-        },
-        Err(_) => true,
-    };
-    let default_same_site = if cfg!(debug_assertions) {
-        SameSite::Lax
-    } else {
-        SameSite::Strict
-    };
-    let same_site = match env::var("SESSION_SAMESITE") {
-        Ok(v) => match v.to_ascii_lowercase().as_str() {
-            "lax" => SameSite::Lax,
-            "strict" => SameSite::Strict,
-            "none" => {
-                if !cookie_secure && !cfg!(debug_assertions) {
-                    return Err(std::io::Error::other(
-                        "SESSION_SAMESITE=None requires SESSION_COOKIE_SECURE=1",
-                    ));
-                }
-                SameSite::None
-            }
-            other => {
-                if cfg!(debug_assertions) {
-                    warn!(value = %other, "invalid SESSION_SAMESITE, using default");
-                    default_same_site
-                } else {
-                    return Err(std::io::Error::other(format!(
-                        "invalid SESSION_SAMESITE: {other}"
-                    )));
-                }
-            }
-        },
-        Err(_) => default_same_site,
-    };
-
-    let health_state = web::Data::new(HealthState::new());
-    // Clone for server factory so readiness probe remains accessible.
-    let server_health_state = health_state.clone();
-    let server = HttpServer::new(move || {
-        let app = build_app(
-            server_health_state.clone(),
-            key.clone(),
-            cookie_secure,
-            same_site,
-        );
-        #[cfg(feature = "metrics")]
-        let app = {
-            let prometheus = make_metrics();
-            app.wrap(prometheus)
-        };
-        app
-    })
-    .bind((
-        env::var("HOST").unwrap_or_else(|_| "0.0.0.0".into()),
-        env::var("PORT")
-            .ok()
-            .and_then(|p| p.parse().ok())
-            .unwrap_or(8080u16),
-    ))?;
-
-    let server = server.run();
-    health_state.mark_ready();
-    server.await
-}
-
 fn build_app(
     health_state: web::Data<HealthState>,
     key: Key,
@@ -179,9 +69,143 @@ fn build_app(
 }
 
 #[cfg(feature = "metrics")]
-fn make_metrics() -> actix_web_prom::PrometheusMetrics {
+fn make_metrics(
+) -> Result<actix_web_prom::PrometheusMetrics, Box<dyn std::error::Error + Send + Sync>> {
     PrometheusMetricsBuilder::new("wildside")
         .endpoint("/metrics")
         .build()
-        .expect("configure Prometheus metrics")
+}
+
+fn load_session_key() -> std::io::Result<Key> {
+    let key_path =
+        env::var("SESSION_KEY_FILE").unwrap_or_else(|_| "/var/run/secrets/session_key".into());
+    match std::fs::read(&key_path) {
+        Ok(mut bytes) => {
+            if !cfg!(debug_assertions) && bytes.len() < 32 {
+                return Err(std::io::Error::other(format!(
+                    "session key at {key_path} too short: need >=32 bytes, got {}",
+                    bytes.len()
+                )));
+            }
+            let key = Key::derive_from(&bytes);
+            bytes.zeroize();
+            Ok(key)
+        }
+        Err(e) => {
+            let allow_dev = env::var("SESSION_ALLOW_EPHEMERAL").ok().as_deref() == Some("1");
+            if cfg!(debug_assertions) || allow_dev {
+                warn!(path = %key_path, error = %e, "using temporary session key (dev only)");
+                Ok(Key::generate())
+            } else {
+                Err(std::io::Error::other(format!(
+                    "failed to read session key at {key_path}: {e}"
+                )))
+            }
+        }
+    }
+}
+
+fn cookie_secure_from_env() -> bool {
+    match env::var("SESSION_COOKIE_SECURE") {
+        Ok(v) => match v.to_ascii_lowercase().as_str() {
+            "1" | "true" | "yes" | "y" => true,
+            "0" | "false" | "no" | "n" => false,
+            other => {
+                warn!(value = %other, "invalid SESSION_COOKIE_SECURE; defaulting to secure");
+                true
+            }
+        },
+        Err(_) => true,
+    }
+}
+
+fn same_site_from_env(cookie_secure: bool) -> std::io::Result<SameSite> {
+    let default_same_site = if cfg!(debug_assertions) {
+        SameSite::Lax
+    } else {
+        SameSite::Strict
+    };
+    Ok(match env::var("SESSION_SAMESITE") {
+        Ok(v) => match v.to_ascii_lowercase().as_str() {
+            "lax" => SameSite::Lax,
+            "strict" => SameSite::Strict,
+            "none" => {
+                if !cookie_secure && !cfg!(debug_assertions) {
+                    return Err(std::io::Error::other(
+                        "SESSION_SAMESITE=None requires SESSION_COOKIE_SECURE=1",
+                    ));
+                }
+                SameSite::None
+            }
+            other => {
+                if cfg!(debug_assertions) {
+                    warn!(value = %other, "invalid SESSION_SAMESITE, using default");
+                    default_same_site
+                } else {
+                    return Err(std::io::Error::other(format!(
+                        "invalid SESSION_SAMESITE: {other}"
+                    )));
+                }
+            }
+        },
+        Err(_) => default_same_site,
+    })
+}
+
+fn bind_address() -> (String, u16) {
+    (
+        env::var("HOST").unwrap_or_else(|_| "0.0.0.0".into()),
+        match env::var("PORT") {
+            Ok(p) => match p.parse::<u16>() {
+                Ok(n) => n,
+                Err(_) => {
+                    warn!(value = %p, "invalid PORT; falling back to 8080");
+                    8080u16
+                }
+            },
+            Err(_) => 8080u16,
+        },
+    )
+}
+
+/// Application bootstrap.
+#[actix_web::main]
+async fn main() -> std::io::Result<()> {
+    if let Err(e) = fmt()
+        .with_env_filter(EnvFilter::from_default_env())
+        .json()
+        .try_init()
+    {
+        warn!(error = %e, "tracing init failed");
+    }
+
+    let key = load_session_key()?;
+    let cookie_secure = cookie_secure_from_env();
+    let same_site = same_site_from_env(cookie_secure)?;
+    #[cfg(feature = "metrics")]
+    let prometheus = match make_metrics() {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(error = %e, "failed to initialise Prometheus metrics");
+            return Err(std::io::Error::other(e));
+        }
+    };
+    let health_state = web::Data::new(HealthState::new());
+    let server_health_state = health_state.clone();
+    let server = HttpServer::new(move || {
+        let app = build_app(
+            server_health_state.clone(),
+            key.clone(),
+            cookie_secure,
+            same_site,
+        );
+        #[cfg(feature = "metrics")]
+        let app = app.wrap(prometheus.clone());
+        app
+    })
+    .bind(bind_address())?;
+
+    let server = server.run();
+    health_state.mark_ready();
+    server.await
 }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -119,6 +119,11 @@ fn cookie_secure_from_env() -> bool {
     }
 }
 
+/// Determine the session SameSite policy, allowing an environment override.
+///
+/// Defaults to `Lax` in debug builds and `Strict` otherwise. `SESSION_SAMESITE`
+/// can set `Strict`, `Lax`, or `None`; choosing `None` requires a secure cookie
+/// and some browsers may block such third-party cookies entirely.
 fn same_site_from_env(cookie_secure: bool) -> std::io::Result<SameSite> {
     let default_same_site = if cfg!(debug_assertions) {
         SameSite::Lax

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -724,20 +724,25 @@ let key_bytes = {
 };
 let key = Key::from(&key_bytes);
 
+let same_site = if cfg!(debug_assertions) {
+    SameSite::Lax
+} else {
+    SameSite::Strict
+};
 let middleware = SessionMiddleware::builder(CookieSessionStore::default(), key)
     .cookie_name("session")
     .cookie_content_security(CookieContentSecurity::Private) // encrypt + sign
     .cookie_secure(true)
     .cookie_http_only(true)
-    .cookie_same_site(SameSite::Lax)
+    .cookie_same_site(same_site)
     .build();
 ```
 
 On login, the server sets a cookie named `session`, such as `session=<payload>`,
 and `actix-session` handles serialization and integrity checks automatically.
-Cookies are marked `HttpOnly`, `Secure`, and use `SameSite=Lax` unless a
-cross-site flow is required. To rotate the key, generate a new value, replace
-the secret file, and restart the pods; the framework cannot validate cookies
+Cookies are marked `HttpOnly`, `Secure`, and use `SameSite=Lax` during development
+but `SameSite=Strict` otherwise unless a cross-site flow is required. To rotate the key,
+generate a new value, replace the secret file, and restart the pods; the framework cannot validate cookies
 issued with a previous key, so all existing sessions are dropped. This keeps the
 session layer self-contained without any server-side cache or database lookup.
 

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -741,7 +741,8 @@ let middleware = SessionMiddleware::builder(CookieSessionStore::default(), key)
 On login, the server sets a cookie named `session`, such as `session=<payload>`,
 and `actix-session` handles serialization and integrity checks automatically.
 Cookies are marked `HttpOnly`, `Secure`, and use `SameSite=Lax` during development
-but `SameSite=Strict` otherwise unless a cross-site flow is required. To rotate the key,
+and `SameSite=Strict` otherwise. For cross-site flows, set `SESSION_SAMESITE`
+to `Lax` or `None` explicitly (note that `None` requires `Secure=true`). To rotate the key,
 generate a new value, replace the secret file, and restart the pods; the framework cannot validate cookies
 issued with a previous key, so all existing sessions are dropped. This keeps the
 session layer self-contained without any server-side cache or database lookup.

--- a/docs/backend-design.md
+++ b/docs/backend-design.md
@@ -741,11 +741,19 @@ let middleware = SessionMiddleware::builder(CookieSessionStore::default(), key)
 On login, the server sets a cookie named `session`, such as `session=<payload>`,
 and `actix-session` handles serialization and integrity checks automatically.
 Cookies are marked `HttpOnly`, `Secure`, and use `SameSite=Lax` during development
-and `SameSite=Strict` otherwise. For cross-site flows, set `SESSION_SAMESITE`
-to `Lax` or `None` explicitly (note that `None` requires `Secure=true`). To rotate the key,
-generate a new value, replace the secret file, and restart the pods; the framework cannot validate cookies
-issued with a previous key, so all existing sessions are dropped. This keeps the
-session layer self-contained without any server-side cache or database lookup.
+and `SameSite=Strict` otherwise.
+
+Override `SameSite` when cross-site flows are required:
+
+- Environment: `SESSION_SAMESITE=Strict|Lax|None` (optional; overrides build
+  mode).
+- If `SESSION_SAMESITE=None`, cookies must be `Secure=true` and some browsers
+  may block third-party cookies by policy.
+
+To rotate the key, generate a new value, replace the secret file, and restart
+the pods; the framework cannot validate cookies issued with a previous key, so
+all existing sessions are dropped. This keeps the session layer self-contained
+without any server-side cache or database lookup.
 
 **Security considerations:** Browser cookies are limited to 4 KiB, so the
 serialized session payload must stay within that bound. For non‑persistent

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -249,45 +249,44 @@ identity-provider redirects. It accepts `Strict`, `Lax`, or `None`; any other
 value aborts startup outside debug builds. `None` also requires
 `SESSION_COOKIE_SECURE=1` and may still be blocked by some browsers' policies.
 
-    Deployment manifests in `deploy/k8s/` should mount the secret read-only and
-    expose its path to the service (for instance, via a `SESSION_KEY_FILE`
-    environment variable). Use high-entropy (≥64-byte) keys and rotate them by
-    deploying new secrets and reloading the service, so the fresh key takes
-    effect while the previous key remains available for validating existing
-    sessions during the rollout. For seamless rotation, run at least two
-    replicas and perform a rolling update, so pods with the prior key continue
-    to validate existing cookies until expiry. Scope the middleware to routes
-    that require authentication. Developers can opt into an ephemeral session
-    key by setting `SESSION_ALLOW_EPHEMERAL=1`; production should leave this
-    unset so startup fails if the key file is unreadable.
+Deployment manifests in `deploy/k8s/` should mount the secret read-only and
+expose its path to the service (for instance, via a `SESSION_KEY_FILE`
+environment variable). Use high-entropy (≥64-byte) keys and rotate them by
+deploying new secrets and reloading the service, so the fresh key takes
+effect while the previous key remains available for validating existing
+sessions during the rollout. For seamless rotation, run at least two
+replicas and perform a rolling update, so pods with the prior key continue
+to validate existing cookies until expiry. Scope the middleware to routes
+that require authentication. Developers can opt into an ephemeral session
+key by setting `SESSION_ALLOW_EPHEMERAL=1`; production should leave this
+unset so startup fails if the key file is unreadable.
 
-  - [x] **Login endpoint:** Add `POST /api/v1/login` to validate credentials
-        and initialise sessions.
+- [x] **Login endpoint:** Add `POST /api/v1/login` to validate credentials
+  and initialise sessions.
 
-  - [ ] **Observability:**
+- [ ] **Observability:**
 
-    - Integrate the `actix-web-prom` crate as middleware to expose default
-      Prometheus metrics on a `/metrics` endpoint.
-      Status: wired behind a `metrics` cargo feature. Build with
-      `--features metrics` to enable middleware and the `/metrics` route
-      without impacting environments that cannot fetch new crates.
+  - Integrate the `actix-web-prom` crate as middleware to expose default
+    Prometheus metrics on a `/metrics` endpoint. Status: wired behind a
+    `metrics` cargo feature. Build with `--features metrics` to enable
+    middleware and the `/metrics` route without impacting environments that
+    cannot fetch new crates.
 
-    - Implement `/health/ready` and `/health/live` endpoints.
-      `/health/ready` returns `200 OK` once dependencies are
-      initialised and `503` otherwise.
+  - Implement `/health/ready` and `/health/live` endpoints. `/health/ready`
+    returns `200 OK` once dependencies are initialised and `503` otherwise.
 
-    - Ensure all request handlers have `tracing` spans with a unique
-      `request_id`, propagating it via a `Trace-Id` response header for
-      client correlation.
+  - Ensure all request handlers have `tracing` spans with a unique
+    `request_id`, propagating it via a `Trace-Id` response header for client
+    correlation.
 
-  - [ ] **API Endpoints:**
+- [ ] **API Endpoints:**
 
-    - Implement the full suite of user management endpoints (create, read,
-      update) under `/api/v1/users`.
+  - Implement the full suite of user management endpoints (create, read,
+    update) under `/api/v1/users`.
 
-    - Create a `/api/v1/routes` endpoint to accept route generation requests.
-      This endpoint should validate the input and enqueue a `GenerateRouteJob`
-      (see § 3.4).
+  - Create a `/api/v1/routes` endpoint to accept route generation requests.
+    This endpoint should validate the input and enqueue a `GenerateRouteJob`
+    (see § 3.4).
 
 The flow for request handling and trace propagation is shown below:
 

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -153,7 +153,7 @@ API and WebSocket traffic.
     `SESSION_ALLOW_EPHEMERAL=1`.
 
     ```rust
-    use actix_session::{storage::CookieSessionStore, SessionMiddleware};
+    use actix_session::{config::PersistentSession, storage::CookieSessionStore, SessionMiddleware};
     use actix_web::cookie::{time::Duration, Key, SameSite};
     use actix_web::web;
     use std::env;
@@ -207,7 +207,7 @@ API and WebSocket traffic.
     .cookie_same_site(same_site)
     // Set at deploy time if required:
     //.cookie_domain(Some("example.com".into()))
-    .cookie_max_age(Duration::hours(2))
+    .session_lifecycle(PersistentSession::default().session_ttl(Duration::hours(2)))
     .build();
 
     let api = web::scope("/api/v1")

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -122,6 +122,8 @@ API and WebSocket traffic.
 - **Current Status:** A foundational Actix Web server exists in
   `backend/src/main.rs`. It is configured with basic logging (`tracing`),
   OpenAPI documentation (`utoipa`), and a working WebSocket endpoint (`/ws`).
+  The server binds to a host and port taken from the `HOST` and `PORT`
+  environment variables, defaulting to `0.0.0.0:8080` for development.
 
 - **Key Responsibilities:**
 

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -215,14 +215,15 @@ API and WebSocket traffic.
         .service(list_users);
     ```
 
-    The key must be at least 32 bytes; release builds refuse to start if the key is shorter, and the raw bytes are zeroised after derivation. Session cookies use `SameSite=Lax` in debug builds and `SameSite=Strict` otherwise, expiring after two hours.
+    The key must be at least 32 bytes; release builds refuse to start if the key is shorter, and the raw bytes are zeroised after derivation. Session cookies use `SameSite=Lax` in debug builds and `SameSite=Strict` otherwise, expiring after two hours. Override the policy with `SESSION_SAMESITE=Strict|Lax|None`; setting `None` also requires `SESSION_COOKIE_SECURE=1`.
 
 `CookieSessionStore` keeps session state entirely in the cookie, avoiding an
     external store such as Redis. Browsers cap individual cookies at roughly 4
     KB, so session payloads must remain well under this limit.
 
     Set `SESSION_COOKIE_SECURE=0` during local development to allow cookies over
-    plain HTTP; production deployments should leave this unset to enforce HTTPS.
+      plain HTTP; production deployments should leave this unset to enforce HTTPS.
+      Use `SESSION_SAMESITE` to override the default for cross-site flows such as identity-provider redirects. It accepts `Strict`, `Lax`, or `None`; any other value aborts startup outside debug builds, and `None` also requires `SESSION_COOKIE_SECURE=1`.
 
     Deployment manifests in `deploy/k8s/` should mount the secret read-only and
     expose its path to the service (for instance, via a `SESSION_KEY_FILE`

--- a/docs/wildside-backend-design.md
+++ b/docs/wildside-backend-design.md
@@ -146,8 +146,10 @@ API and WebSocket traffic.
     key from a secret store (for example, a Kubernetes Secret or Vault) and
     mount or inject it for the service at runtime. Name the cookie `session`
     and configure it with `Secure=true`, `HttpOnly=true`, and `SameSite=Lax`
-    during development but `SameSite=Strict` for releases. Startup must abort
-    in production if the key file cannot be
+    during development but `SameSite=Strict` for releases. Override with
+    `SESSION_SAMESITE=Strict|Lax|None` when cross-site flows are required;
+    `None` mandates `Secure=true` and may still be blocked by some browsers.
+    Startup must abort in production if the key file cannot be
     read; a temporary key is permitted only in development when
     `SESSION_ALLOW_EPHEMERAL=1`.
 
@@ -220,8 +222,10 @@ API and WebSocket traffic.
     - Session cookies use `SameSite=Lax` in debug builds and `SameSite=Strict`
       otherwise, and expire after two hours.
 
-    - Override with `SESSION_SAMESITE=Strict|Lax|None`. When `None` is chosen,
-      also set `SESSION_COOKIE_SECURE=1`.
+    - Override with `SESSION_SAMESITE=Strict|Lax|None` (takes precedence over
+      the build mode). If `SESSION_SAMESITE=None`, also set
+      `SESSION_COOKIE_SECURE=1`; some browsers may block third-party cookies
+      regardless.
 
 `CookieSessionStore` keeps session state entirely in the cookie, avoiding an
     external store such as Redis. Browsers cap individual cookies at roughly 4
@@ -232,7 +236,7 @@ plain HTTP; production deployments should leave this unset to enforce HTTPS.
 Use `SESSION_SAMESITE` to override the default for cross-site flows such as
 identity-provider redirects. It accepts `Strict`, `Lax`, or `None`; any other
 value aborts startup outside debug builds. `None` also requires
-`SESSION_COOKIE_SECURE=1`.
+`SESSION_COOKIE_SECURE=1` and may still be blocked by some browsers' policies.
 
     Deployment manifests in `deploy/k8s/` should mount the secret read-only and
     expose its path to the service (for instance, via a `SESSION_KEY_FILE`


### PR DESCRIPTION
## Summary
- flatten main by moving server construction into `build_app`
- isolate Prometheus metrics in `make_metrics`
- clone health state before server startup so readiness probe remains accessible
- read bind host and port from `HOST`/`PORT` environment variables
- enforce `SameSite::Strict` cookies outside debug builds

## Testing
- `make fmt`
- `make check-fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c07f3b8354832284079f9dfc911c90

## Summary by Sourcery

Refactor the Actix Web server setup by extracting application construction into a build_app helper, isolating metrics setup, and improving configuration and readiness handling.

Enhancements:
- Extract app assembly logic into a build_app function and metrics setup into make_metrics
- Clone the health state for the server factory to keep the readiness probe accessible
- Bind the server to host and port from HOST and PORT environment variables with default values
- Enforce SameSite::Strict cookies outside of debug builds

Documentation:
- Update backend design documentation to describe binding host and port via environment variables