### PR TITLE
Remove redundant mut from app builder

### DIFF
--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -67,6 +67,8 @@ fn build_app(
 
     #[cfg(debug_assertions)]
     let app = app.service(SwaggerUi::new("/docs").url("/api-docs/openapi.json", ApiDoc::openapi()));
+    #[cfg(not(debug_assertions))]
+    let app = app;
 
     app
 }


### PR DESCRIPTION
## Summary
- drop unnecessary mutable binding when constructing Actix app

## Testing
- `make fmt`
- `make lint` *(fails: Validation failed with 5 errors and 3 warnings)*
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68c701c0c4288322b35a0a0ab77cfe5d

## Summary by Sourcery

Streamline Actix application construction by removing redundant mutable `app` binding and simplifying service registration

Enhancements:
- Remove unnecessary `mut` declaration when building the Actix app
- Condense conditional `SwaggerUi` service registration into a single binding