### PR TITLE
Add JavaScript tests to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,9 @@ jobs:
       - name: Type check
         run: make typecheck
 
+      - name: JavaScript tests
+        run: make js-test
+
       # Backend
       - uses: leynos/shared-actions/.github/actions/setup-rust@c2b856998a4438bfdaa71c90cde1b03044e5d260
       - name: Rust build

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ BIOME_VERSION ?= 2.2.4
 TSC_VERSION ?= 5.9.2
 
 # Place one consolidated PHONY declaration near the top of the file
-.PHONY: all clean be fe fe-build openapi gen docker-up docker-down fmt lint test typecheck deps lockfile \
+.PHONY: all clean be fe fe-build openapi gen docker-up docker-down fmt lint test js-test typecheck deps lockfile \
         check-fmt markdownlint markdownlint-docs mermaid-lint nixie yamllint audit \
         lint-asyncapi lint-openapi lint-makefile conftest tofu doks-test doks-policy \
         dev-cluster-test
@@ -109,6 +109,9 @@ lint-makefile:
 
 test: deps typecheck
 	RUSTFLAGS="-D warnings" cargo test --manifest-path backend/Cargo.toml --all-targets --all-features
+	$(MAKE) js-test
+
+js-test:
 	pnpm -r --if-present --silent run test
 
 TS_WORKSPACES := frontend-pwa packages/tokens packages/types


### PR DESCRIPTION
## Summary
- add a dedicated `js-test` Makefile target and reuse it from the main test recipe
- invoke `make js-test` during CI so TypeScript and JavaScript test scripts run

## Testing
- make js-test

------
https://chatgpt.com/codex/tasks/task_e_68ca10718a348322acbdb66ad18bddf8

## Summary by Sourcery

Add a js-test Makefile target for running JavaScript tests and integrate it into the main test flow and CI pipeline.

Enhancements:
- Add js-test recipe to Makefile for running pnpm-based JavaScript tests
- Include js-test in .PHONY declarations and call it from the main test target

CI:
- Add a JavaScript tests step in GitHub Actions CI to invoke make js-test