### PR TITLE
Strengthen Vault appliance validation

### DIFF
--- a/infra/modules/vault_appliance/tests/vault_appliance_test.go
+++ b/infra/modules/vault_appliance/tests/vault_appliance_test.go
@@ -167,7 +167,7 @@ func mutateResourceRules(t *testing.T, doc map[string]interface{}, resourceType 
 
 	mutateResourceChanges(t, doc, resourceType, func(delta map[string]interface{}) {
 		for _, selector := range selectors {
-			mutateRulesInSection(delta, selector, mutate)
+			mutateRulesInSection(t, delta, selector, mutate)
 		}
 	})
 }
@@ -206,7 +206,7 @@ func isResourceType(change map[string]interface{}, expected string) bool {
 	return ok && typ == expected
 }
 
-func mutateRulesInSection(delta map[string]interface{}, selector ruleSelector, mutate func(map[string]interface{})) {
+func mutateRulesInSection(t *testing.T, delta map[string]interface{}, selector ruleSelector, mutate func(map[string]interface{})) {
 	container, _ := delta[selector.section].(map[string]interface{})
 	if container == nil {
 		return
@@ -214,6 +214,11 @@ func mutateRulesInSection(delta map[string]interface{}, selector ruleSelector, m
 
 	raw, exists := container[selector.list]
 	if !exists {
+		return
+	}
+
+	if unresolved, ok := raw.(bool); ok && unresolved {
+		require.Fail(t, "plan JSON must materialise inbound rules for this test to run")
 		return
 	}
 

--- a/infra/modules/vault_appliance/tests/vault_appliance_test.go
+++ b/infra/modules/vault_appliance/tests/vault_appliance_test.go
@@ -104,6 +104,7 @@ func runConftestPolicyTest(t *testing.T, vars map[string]interface{}) ([]byte, e
 func runConftestWithPlan(t *testing.T, planJSON string) ([]byte, error) {
 	t.Helper()
 
+	requireBinary(t, "conftest", "conftest not installed; skipping policy test")
 	policyDir := policyPath(t)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)

--- a/infra/modules/vault_appliance/variables.tf
+++ b/infra/modules/vault_appliance/variables.tf
@@ -201,25 +201,8 @@ variable "certificate_ip_sans" {
     condition = alltrue([
       for raw in var.certificate_ip_sans :
       trimspace(raw) != "" && (
-        (
-          length(split(".", trimspace(raw))) == 4 &&
-          alltrue([
-            for octet in split(".", trimspace(raw)) :
-            can(regex("^\\d+$", octet)) &&
-            can(tonumber(octet)) &&
-            tonumber(octet) >= 0 &&
-            tonumber(octet) <= 255
-          ])
-        ) ||
-        can(regex(
-          join("", [
-            "(?i)^(?:([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|",
-            "([0-9a-f]{1,4}:){1,7}:|",
-            ":(:[0-9a-f]{1,4}){1,7}|",
-            "([0-9a-f]{1,4}:){1,4}:(?:((25[0-5]|2[0-4]\\d|1?\\d?\\d)\\.){3}(25[0-5]|2[0-4]\\d|1?\\d?\\d)))$",
-          ]),
-          trimspace(raw)
-        ))
+        can(cidrhost(format("%s/32", trimspace(raw)), 0)) ||
+        can(cidrhost(format("%s/128", trimspace(raw)), 0))
       )
     ])
     error_message = "certificate_ip_sans must contain valid IPv4 or IPv6 addresses."

--- a/infra/modules/vault_appliance/variables.tf
+++ b/infra/modules/vault_appliance/variables.tf
@@ -199,17 +199,27 @@ variable "certificate_ip_sans" {
 
   validation {
     condition = alltrue([
-      for ip in var.certificate_ip_sans :
-      trimspace(ip) != "" &&
-      can(
-        cidrhost(
-          format(
-            "%s/%d",
-            trimspace(ip),
-            contains(trimspace(ip), ":") ? 128 : 32,
-          ),
-          0
-        )
+      for raw in var.certificate_ip_sans :
+      trimspace(raw) != "" && (
+        (
+          length(split(".", trimspace(raw))) == 4 &&
+          alltrue([
+            for octet in split(".", trimspace(raw)) :
+            can(regex("^\\d+$", octet)) &&
+            can(tonumber(octet)) &&
+            tonumber(octet) >= 0 &&
+            tonumber(octet) <= 255
+          ])
+        ) ||
+        can(regex(
+          join("", [
+            "(?i)^(?:([0-9a-f]{1,4}:){7}[0-9a-f]{1,4}|",
+            "([0-9a-f]{1,4}:){1,7}:|",
+            ":(:[0-9a-f]{1,4}){1,7}|",
+            "([0-9a-f]{1,4}:){1,4}:(?:((25[0-5]|2[0-4]\\d|1?\\d?\\d)\\.){3}(25[0-5]|2[0-4]\\d|1?\\d?\\d)))$",
+          ]),
+          trimspace(raw)
+        ))
       )
     ])
     error_message = "certificate_ip_sans must contain valid IPv4 or IPv6 addresses."


### PR DESCRIPTION
## Summary
- validate Vault certificate IP SANs with direct IPv4/IPv6 checks
- exercise terraform validation failures for missing and invalid module variables
- extend Conftest coverage with plan mutations for HTTPS, redirect, and firewall rules

## Testing
- ⚠️ `(cd infra/modules/vault_appliance/tests && go test ./... -run TestVaultAppliancePolicyEnforcesHTTPS -count=1)` *(fails: command blocked waiting for external tooling, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68d80065d55483229191091c415b1162

## Summary by Sourcery

Strengthen Vault appliance validation by adding direct IPv4/IPv6 checks for certificate SANs, introducing Terraform validation tests for required and optional variables, and extending Conftest policy test coverage for HTTPS enforcement, HTTP-to-HTTPS redirection, and firewall rules.

New Features:
- Validate certificate_ip_sans with explicit IPv4 octet checks and regex-based IPv6 validation
- Add Terraform InitAndValidate tests for missing required and invalid optional module variables
- Add Conftest policy tests to enforce HTTPS termination, HTTP-to-HTTPS redirection, and load balancer firewall rules

Enhancements:
- Introduce helper functions to mutate Terraform plan JSON and invoke Conftest with plan data (mutatePlanJSON, mutateLoadBalancerForwardingRules, mutateFirewallInboundRules, runConftestWithPlan)