### PR TITLE
Simplify Style Dictionary build outputs

### DIFF
--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -85,7 +85,7 @@ myapp/
 │  │  ├─ src/tokens.json
 │  │  ├─ src/themes/light.json
 │  │  ├─ src/themes/dark.json
-│  │  └─ build/style-dictionary.js    # emits CSS vars + TW preset + daisy theme
+│  │  └─ build/style-dictionary.js    # emits CSS vars + TW preset + daisy theme (sorted deterministically)
 │  ├─ types/                          # optional: shared TS helpers
 │  │  └─ src/index.ts
 │  └─ utils/                          # shared JS/TS utilities

--- a/packages/tokens/build/style-dictionary.js
+++ b/packages/tokens/build/style-dictionary.js
@@ -16,20 +16,10 @@ const sd = new StyleDictionary({
       buildPath: 'dist/css/',
       files: [{ destination: 'variables.css', format: 'css/variables' }],
     },
-    tailwind: {
-      transformGroup: 'js',
-      buildPath: 'dist/tw/',
-      files: [{ destination: 'preset.js', format: 'javascript/module' }],
-    },
-    daisy: {
-      transformGroup: 'js',
-      buildPath: 'dist/daisy/',
-      files: [{ destination: 'theme.js', format: 'javascript/module' }],
-    },
   },
 });
 
-sd.buildAllPlatforms();
+sd.buildPlatform('css');
 
 // Map tokens into Tailwind and DaisyUI presets
 /**
@@ -92,7 +82,10 @@ fs.writeFileSync(
 
 const themesUrl = new URL('../src/themes/', import.meta.url);
 // Convert the URL to a file-system path via `fileURLToPath` for cross-platform compatibility.
-const themeFiles = fs.readdirSync(fileURLToPath(themesUrl)).filter((f) => f.endsWith('.json'));
+const themeFiles = fs
+  .readdirSync(fileURLToPath(themesUrl))
+  .filter((fileName) => fileName.endsWith('.json'))
+  .sort((a, b) => a.localeCompare(b));
 const daisyThemes = themeFiles.map((file) => {
   const json = readJson(new URL(file, themesUrl));
   const semantic = unwrap(json.semantic ?? {});

--- a/packages/tokens/build/validate-contrast.js
+++ b/packages/tokens/build/validate-contrast.js
@@ -299,6 +299,7 @@ const themesUrl = new URL('../src/themes/', import.meta.url);
 const themeFiles = fs
   .readdirSync(fileURLToPath(themesUrl))
   .filter((f) => f.endsWith('.json'))
+  .sort((a, b) => a.localeCompare(b))
   .map((f) => new URL(f, themesUrl));
 
 let allErrors = [];


### PR DESCRIPTION
## Summary
- drop the duplicate Style Dictionary Tailwind and Daisy platforms so the build only emits CSS directly while keeping custom framework outputs
- sort theme JSON files before composing DaisyUI themes to guarantee deterministic bundles
- note the deterministic token build in the repository structure guide
- closes #168

## Testing
- make lint

------
https://chatgpt.com/codex/tasks/task_e_68dea24dfd0083229caa5614b995b000

## Summary by Sourcery

Simplify the Style Dictionary build to only emit CSS and enforce deterministic theme ordering

Enhancements:
- Restrict the Style Dictionary build to only the CSS platform
- Sort theme JSON files alphabetically before composing DaisyUI themes to guarantee deterministic bundles

Documentation:
- Update repository structure guide to note deterministic sorting in the style-dictionary build