### PR TITLE
Handle invalid trace header encoding gracefully

### DIFF
--- a/backend/src/middleware/trace.rs
+++ b/backend/src/middleware/trace.rs
@@ -9,6 +9,7 @@ use actix_web::dev::{Service, ServiceRequest, ServiceResponse, Transform};
 use actix_web::http::header::{HeaderName, HeaderValue};
 use actix_web::{Error, HttpMessage};
 use futures_util::future::{ready, LocalBoxFuture, Ready};
+use tracing::error;
 use uuid::Uuid;
 
 /// Per-request trace identifier stored in request extensions.
@@ -95,14 +96,13 @@ where
         let fut = self.service.call(req);
         Box::pin(async move {
             let mut res = fut.await?;
-            res.response_mut().headers_mut().insert(
-                HeaderName::from_static("trace-id"),
-                #[expect(
-                    clippy::expect_used,
-                    reason = "Trace IDs are UUIDs and valid header values"
-                )]
-                HeaderValue::from_str(&trace_id).expect("UUIDs produce valid header values"),
-            );
+            if let Err(error) = HeaderValue::from_str(&trace_id).map(|value| {
+                res.response_mut()
+                    .headers_mut()
+                    .insert(HeaderName::from_static("trace-id"), value);
+            }) {
+                error!(%error, trace_id = %trace_id, "failed to encode trace identifier header");
+            }
             Ok(res)
         })
     }


### PR DESCRIPTION
## Summary
- log and gracefully handle failures to encode the Trace-Id header instead of panicking
- closes #134

## Testing
- make fmt
- make lint
- make test

------
https://chatgpt.com/codex/tasks/task_e_68de668e1f64832284d68fba293250cb