### PR TITLE
Add infrastructure test dependency check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ OPENAPI_SPEC ?= spec/openapi.json
 
 # Place one consolidated PHONY declaration near the top of the file
 .PHONY: all clean be fe fe-build openapi gen docker-up docker-down fmt lint test typecheck deps lockfile \
-        check-fmt markdownlint markdownlint-docs mermaid-lint nixie yamllint audit \
+        check-fmt check-test-deps markdownlint markdownlint-docs mermaid-lint nixie yamllint audit \
         lint-asyncapi lint-openapi lint-makefile lint-infra conftest tofu doks-test doks-policy fluxcd-test fluxcd-policy \
         vault-appliance-test vault-appliance-policy dev-cluster-test workspace-sync
 
@@ -153,6 +153,9 @@ check-fmt:
 	cargo fmt --manifest-path backend/Cargo.toml --all -- --check
 	$(call exec_or_bunx,biome,format,@biomejs/biome@$(BIOME_VERSION))
 
+check-test-deps:
+	./scripts/check_test_dependencies.py
+
 markdownlint:
 	find . \
 	  \( -path './backend/target' -o -path './target' -o \
@@ -177,7 +180,7 @@ conftest:
 tofu:
 	$(call ensure_tool,tofu)
 
-doks-test:
+doks-test: check-test-deps
 	tofu fmt -check infra/modules/doks
 	tofu -chdir=infra/modules/doks/examples/basic init
 	tofu -chdir=infra/modules/doks/examples/basic validate
@@ -194,7 +197,7 @@ doks-test:
 	|| test $$? -eq 2
 	$(MAKE) doks-policy
 
-doks-policy: conftest tofu
+doks-policy: check-test-deps conftest tofu
 	tofu -chdir=infra/modules/doks/examples/basic plan -out=tfplan.binary -detailed-exitcode \
 	-var cluster_name=test \
 	-var region=nyc1 \
@@ -204,10 +207,10 @@ doks-policy: conftest tofu
 	tofu -chdir=infra/modules/doks/examples/basic show -json tfplan.binary > infra/modules/doks/examples/basic/plan.json
 	conftest test infra/modules/doks/examples/basic/plan.json --policy infra/modules/doks/policy
 
-dev-cluster-test: conftest tofu
+dev-cluster-test: check-test-deps conftest tofu
 	DOKS_KUBERNETES_VERSION=$(DOKS_KUBERNETES_VERSION) ./scripts/dev-cluster-test.sh
 
-fluxcd-test:
+fluxcd-test: check-test-deps
 	tofu fmt -check infra/modules/fluxcd
 	tofu -chdir=infra/modules/fluxcd/examples/basic init
 	if [ -n "$(FLUX_KUBECONFIG_PATH)" ]; then \
@@ -234,7 +237,7 @@ fluxcd-test:
 
 # Delegate the Terraform plan and Conftest execution to a script so the target
 # stays readable while still supporting temporary files and clean shutdown.
-fluxcd-policy: conftest tofu
+fluxcd-policy: check-test-deps conftest tofu
 	if [ -z "$(FLUX_KUBECONFIG_PATH)" ]; then \
 	echo "Skipping fluxcd-policy; set FLUX_KUBECONFIG_PATH to run"; \
 	else \
@@ -248,7 +251,7 @@ fluxcd-policy: conftest tofu
 	./scripts/fluxcd-policy.sh; \
 	fi
 
-vault-appliance-test:
+vault-appliance-test: check-test-deps
 	tofu fmt -check infra/modules/vault_appliance
 	tofu -chdir=infra/modules/vault_appliance/examples/basic init
 	tofu -chdir=infra/modules/vault_appliance/examples/basic validate
@@ -267,7 +270,7 @@ vault-appliance-test:
 	|| test $$? -eq 2
 	$(MAKE) vault-appliance-policy
 
-vault-appliance-policy: conftest tofu
+vault-appliance-policy: check-test-deps conftest tofu
 	DIGITALOCEAN_TOKEN=dummy tofu -chdir=infra/modules/vault_appliance/examples/basic plan -out=tfplan.binary -detailed-exitcode \
 	-var name=vault-ci \
 	-var region=nyc1 \

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -55,6 +55,9 @@
   HCL syntax and workflows. *Audience: infrastructure developers.*
 - [Unit testing OpenTofu modules and scripts][opentofu-testing] – strategies
   for testing IaC modules. *Audience: infrastructure developers.*
+- [Infrastructure test dependency checklist](infrastructure-test-dependencies.md)
+  – validates CLI prerequisites before running Terraform policy suites.
+  *Audience: infrastructure developers and CI engineers.*
 - [DOKS OpenTofu module design](doks-module-design.md) – design decisions for
   the DigitalOcean Kubernetes module. *Audience: infrastructure developers.*
 - [FluxCD OpenTofu module design](fluxcd-module-design.md) – design decisions for

--- a/docs/infrastructure-test-dependencies.md
+++ b/docs/infrastructure-test-dependencies.md
@@ -1,0 +1,27 @@
+# Infrastructure test dependency checklist
+
+The Go-based infrastructure test suites rely on external command-line tools.
+When those binaries are absent the tests previously skipped silently, which
+made it difficult to spot coverage gaps in CI. To address this we ship a small
+pre-flight validator:
+
+```bash
+make check-test-deps
+```
+
+The target executes `scripts/check_test_dependencies.py` and fails early if the
+required tools are missing. Run it locally before `make doks-test`,
+`make fluxcd-test`, `make vault-appliance-test`, or `make dev-cluster-test` so
+you know whether the environment is ready. CI pipelines should add the same
+step before invoking the infrastructure test matrix.
+
+## Required binaries
+
+| Tool       | Purpose                                                         |
+| ---------- | --------------------------------------------------------------- |
+| `tofu`     | Executes plans for the Terraform modules exercised in tests.    |
+| `conftest` | Evaluates Open Policy Agent assertions against generated plans. |
+
+If the script reports a missing dependency, install it via your system package
+manager or follow the instructions in the tool's official documentation. Once
+installed, rerun `make check-test-deps` to confirm the environment is healthy.

--- a/scripts/check_test_dependencies.py
+++ b/scripts/check_test_dependencies.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Pre-flight validation for infrastructure test dependencies.
+
+This script verifies that required command-line tools for Terraform and policy
+integration tests are available before test execution. Run it as a CI step or
+locally prior to invoking the infrastructure-oriented Go test suites to avoid
+silent skips caused by missing binaries.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from dataclasses import dataclass
+from typing import Iterable, List
+
+
+@dataclass(frozen=True)
+class Dependency:
+    """Represents a required binary for the infrastructure test suites."""
+
+    name: str
+    description: str
+
+
+REQUIRED_DEPENDENCIES: tuple[Dependency, ...] = (
+    Dependency("tofu", "OpenTofu CLI for Terraform plan execution"),
+    Dependency("conftest", "Policy testing via Open Policy Agent"),
+)
+
+
+def collect_missing(dependencies: Iterable[Dependency]) -> List[Dependency]:
+    """Return the subset of *dependencies* that are not discoverable on PATH."""
+
+    missing: List[Dependency] = []
+    for dependency in dependencies:
+        if shutil.which(dependency.name) is None:
+            missing.append(dependency)
+    return missing
+
+
+def format_missing_message(missing: Iterable[Dependency]) -> str:
+    """Create a human-readable report for *missing* dependencies."""
+
+    lines = [
+        "Required test dependencies were not found on PATH.",
+        "Install the following tools before running the infrastructure tests:",
+        "",
+    ]
+    for dependency in missing:
+        lines.append(f"  - {dependency.name}: {dependency.description}")
+    return "\n".join(lines)
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] in {"-h", "--help"}:
+        sys.stdout.write(
+            "Run this script before executing the Go-based infrastructure tests "
+            "to verify that the supporting command-line tools are installed.\n"
+        )
+        sys.stdout.write(
+            "Install missing tools via your package manager or refer to "
+            "docs/infrastructure-test-dependencies.md for guidance.\n"
+        )
+        return 0
+
+    missing = collect_missing(REQUIRED_DEPENDENCIES)
+    if missing:
+        sys.stderr.write(format_missing_message(missing) + "\n")
+        return 1
+
+    sys.stdout.write("All required test dependencies are present.\n")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- add a reusable dependency validation script for Terraform and policy tests
- gate infrastructure Makefile targets on the new check and document the workflow
- document the dependency checklist for developers and CI consumers
- closes #131

## Testing
- python3 scripts/check_test_dependencies.py --help

------
https://chatgpt.com/codex/tasks/task_e_68e056ada22883229929129c022242ce