### PR TITLE
Handle Prometheus metrics init errors gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -373,6 +373,7 @@ version = "0.1.0"
 dependencies = [
  "actix",
  "actix-rt",
+ "actix-service",
  "actix-session",
  "actix-web",
  "actix-web-actors",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -8,6 +8,8 @@ url = "2"
 actix-web = "4"
 actix = "0.13"
 actix-web-actors = "4"
+# Type-erased middleware requires actix-service utilities.
+actix-service = "2"
 # Use cookie-session to keep sessions stateless and avoid external stores like Redis.
 # Note: each session is stored in a single cookie (~4 KB max); larger sessions risk 500 errors.
 actix-session = { version = "0.11", features = ["cookie-session"] }

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -12,6 +12,7 @@ use actix_session::{
     storage::CookieSessionStore,
     SessionMiddleware,
 };
+#[cfg(feature = "metrics")]
 use actix_web::body::BoxBody;
 use actix_web::cookie::{Key, SameSite};
 use actix_web::dev::{Server, ServiceFactory, ServiceRequest, ServiceResponse};

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -249,17 +249,15 @@ fn create_server(
     prometheus: Option<actix_web_prom::PrometheusMetrics>,
 ) -> std::io::Result<Server> {
     let server_health_state = health_state.clone();
-    let metrics = prometheus;
-    let key_clone = key;
     let server = HttpServer::new(move || {
         let app = build_app(
             server_health_state.clone(),
-            key_clone.clone(),
+            key.clone(),
             cookie_secure,
             same_site,
         );
 
-        let middleware = MetricsLayer::from_option(metrics.clone());
+        let middleware = MetricsLayer::from_option(prometheus.clone());
 
         app.wrap(middleware)
     })
@@ -279,11 +277,10 @@ fn create_server(
     bind_address: (String, u16),
 ) -> std::io::Result<Server> {
     let server_health_state = health_state.clone();
-    let key_clone = key;
     let server = HttpServer::new(move || {
         build_app(
             server_health_state.clone(),
-            key_clone.clone(),
+            key.clone(),
             cookie_secure,
             same_site,
         )

--- a/backend/src/ws/display_name.rs
+++ b/backend/src/ws/display_name.rs
@@ -12,7 +12,7 @@ pub const DISPLAY_NAME_MAX: usize = 32;
 /// Only alphanumeric characters, underscores and spaces are allowed.
 ///
 /// ```
-/// use wildside::ws::display_name::is_valid_display_name;
+/// use backend::ws::display_name::is_valid_display_name;
 /// assert!(matches!(is_valid_display_name("Alice"), Ok(true)));
 /// assert!(matches!(is_valid_display_name("bad$char"), Ok(false)));
 /// ```


### PR DESCRIPTION
## Summary
- continue booting the backend when Prometheus metrics initialisation fails instead of panicking
- reuse the computed bind address and only wrap the Actix app in Prometheus middleware when construction succeeds
- fix the display name doctest to reference the backend crate so doctests pass
- closes #112

## Testing
- `make fmt`
- `make lint`
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_68e05cc256f08322a942e8d2d9c1ccd3

## Summary by Sourcery

Gracefully handle Prometheus metrics initialization errors by logging a warning and continuing startup without metrics, reuse the computed bind address across server builds, and correct the display_name doctest import path.

Bug Fixes:
- Prevent backend panic on Prometheus initialization failure by logging a warning and booting without metrics.

Enhancements:
- Compute the bind address once and reuse it for both metrics-enabled and metrics-disabled server instances.
- Only wrap the Actix application in Prometheus middleware when metrics construction succeeds.

Documentation:
- Update the display_name doctest to reference the correct backend crate path.