### PR TITLE
Stabilize PWA design token build integration

### DIFF
--- a/frontend-pwa/package.json
+++ b/frontend-pwa/package.json
@@ -3,8 +3,11 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "predev": "pnpm --filter @app/tokens build",
     "dev": "vite",
+    "prebuild": "pnpm --filter @app/tokens build",
     "build": "vite build",
+    "prepreview": "pnpm --filter @app/tokens build",
     "preview": "vite preview",
     "gen:api": "bunx orval --config orval.config.yaml",
     "audit": "pnpm audit",

--- a/frontend-pwa/src/Main.tsx
+++ b/frontend-pwa/src/Main.tsx
@@ -4,7 +4,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import React from 'react';
 import { createRoot } from 'react-dom/client';
-import '@app/tokens/css/variables.css';
 import './index.css';
 import { App } from './app/App';
 

--- a/frontend-pwa/src/index.css
+++ b/frontend-pwa/src/index.css
@@ -1,3 +1,4 @@
+@import '@app/tokens/css/variables.css';
 @tailwind base;
 @tailwind components;
 @tailwind utilities;

--- a/frontend-pwa/vite.config.ts
+++ b/frontend-pwa/vite.config.ts
@@ -1,16 +1,25 @@
 /**
  * @file Vite configuration with tokens alias for the PWA.
  */
+import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import react from '@vitejs/plugin-react';
 import { defineConfig, loadEnv } from 'vite';
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
+  const projectRoot = fileURLToPath(new URL('.', import.meta.url));
+  const tokensDistPath = resolve(projectRoot, '../packages/tokens/dist');
+  if (!existsSync(tokensDistPath)) {
+    console.warn(
+      'Design tokens build output not found. Run `pnpm --filter @app/tokens build` to generate it.',
+    );
+  }
   return {
     resolve: {
       alias: {
-        '@app/tokens': resolve(__dirname, '../packages/tokens/dist'),
+        '@app/tokens': tokensDistPath,
       },
     },
     plugins: [react()],


### PR DESCRIPTION
## Summary
- ensure the PWA runs the token build before dev, build, and preview commands so the dist bundle always exists
- update the Vite config to resolve the tokens alias via import.meta.url and surface a helpful warning when the build output is missing
- centralise the design token CSS import in index.css for a consistent loading strategy

## Testing
- pnpm --filter frontend-pwa build

------
https://chatgpt.com/codex/tasks/task_e_68e0af40066883229fa25302d4cd3f63