### PR TITLE
Ensure nixie installs Puppeteer browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -161,6 +161,7 @@ markdownlint:
 	     xargs -0 -- markdownlint
 
 nixie:
+	node scripts/install-mermaid-browser.mjs
 	# CI currently requires --no-sandbox; remove once nixie supports
 	# environment variable control for this option
 	nixie --no-sandbox

--- a/scripts/install-mermaid-browser.mjs
+++ b/scripts/install-mermaid-browser.mjs
@@ -22,7 +22,6 @@ function hasLocalBrowser() {
   } catch (error) {
     if (
       error instanceof Error &&
-      typeof error.message === 'string' &&
       error.message.includes(MISSING_BROWSER_MESSAGE_FRAGMENT)
     ) {
       return false;

--- a/scripts/install-mermaid-browser.mjs
+++ b/scripts/install-mermaid-browser.mjs
@@ -10,6 +10,7 @@
  */
 
 import { existsSync } from 'node:fs';
+import { pathToFileURL } from 'node:url';
 import { executablePath } from 'puppeteer';
 import { downloadBrowsers } from 'puppeteer/lib/esm/puppeteer/node/install.js';
 
@@ -45,4 +46,18 @@ async function ensureBrowsersInstalled() {
   }
 }
 
-await ensureBrowsersInstalled();
+export async function main() {
+  await ensureBrowsersInstalled();
+}
+
+const executedScriptUrl =
+  process.argv[1] === undefined ? undefined : pathToFileURL(process.argv[1]).href;
+
+if (executedScriptUrl === import.meta.url) {
+  // Preserve the original side effect for the `make nixie` workflow while
+  // allowing other modules to import `main` without triggering a download.
+  main().catch((error) => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/install-mermaid-browser.mjs
+++ b/scripts/install-mermaid-browser.mjs
@@ -1,0 +1,49 @@
+/**
+ * @file Ensures the Chrome binaries required by Puppeteer are available before
+ * Mermaid diagrams are rendered in CI.
+ *
+ * Nixie shells out to `mmdc`, which depends on Puppeteer finding the
+ * `chrome-headless-shell` executable. The GitHub runners used in CI start with
+ * an empty Puppeteer cache, so we proactively download the browser artefacts
+ * that match the version bundled with our dependencies. This keeps the `make
+ * nixie` target reproducible without relying on a manual pre-install step.
+ */
+
+import { existsSync } from 'node:fs';
+import { executablePath } from 'puppeteer';
+import { downloadBrowsers } from 'puppeteer/lib/esm/puppeteer/node/install.js';
+
+const MISSING_BROWSER_MESSAGE_FRAGMENT = 'Could not find Chrome';
+
+function hasLocalBrowser() {
+  try {
+    const browserPath = executablePath();
+    return Boolean(browserPath) && existsSync(browserPath);
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      typeof error.message === 'string' &&
+      error.message.includes(MISSING_BROWSER_MESSAGE_FRAGMENT)
+    ) {
+      return false;
+    }
+
+    throw error;
+  }
+}
+
+async function ensureBrowsersInstalled() {
+  if (hasLocalBrowser()) {
+    return;
+  }
+
+  await downloadBrowsers();
+
+  if (!hasLocalBrowser()) {
+    throw new Error(
+      'Puppeteer still cannot locate Chrome after downloading browser artefacts.'
+    );
+  }
+}
+
+await ensureBrowsersInstalled();


### PR DESCRIPTION
## Summary
- add a helper script that downloads the Puppeteer-managed Chrome build when the cache is empty
- call the helper from `make nixie` so Mermaid diagrams render reliably in CI

## Testing
- make nixie

------
https://chatgpt.com/codex/tasks/task_e_68e360f5aa1883229740e1196e2579af

## Summary by Sourcery

Ensure Puppeteer-managed Chromium is installed before running the nixie target to reliably render Mermaid diagrams in CI.

Enhancements:
- Add a Node.js helper script that checks for and downloads Puppeteer’s Chrome binaries when the local cache is empty
- Invoke the install-mermaid-browser script in the Makefile nixie target to automate browser setup