### PR TITLE
Fix comma placement in repository structure docs

### DIFF
--- a/docs/repository-structure.md
+++ b/docs/repository-structure.md
@@ -195,7 +195,7 @@ ______________________________________________________________________
 - `bunx orval` writes `src/api/generated/client.ts`; `src/api/client.ts` wraps
   the generated code with query helpers and runtime validation.
 - A small `src/api/fetcher.ts` centralizes base URL, auth, and error handling.
-- `orval.config.cjs` pins the mutator to the named `customFetch` export so the
+- `orval.config.cjs` pins the mutator to the named `customFetch` export, so the
   generator does not try to import a default export.
 - TanStack Query hooks (handwritten or template‑generated) wrap the client for
   caching and retries.


### PR DESCRIPTION
## Summary
- insert a comma in the orval configuration sentence to separate the two clauses

## Testing
- not run (documentation change only)

------
https://chatgpt.com/codex/tasks/task_e_68efa49d826483229dbfcb897d01f098

## Summary by Sourcery

Documentation:
- Add missing comma in the orval.config.cjs description to separate clauses