### PR TITLE
Front-load hexagonal constraints

### DIFF
--- a/docs/backend-roadmap.md
+++ b/docs/backend-roadmap.md
@@ -90,7 +90,7 @@ adapter; direct stateful logic belongs behind the ports established above.
 
 ## Phase 2 – Data platform foundation
 
-Ensure schema and ingestion work expose their operations through domain ports
+Ensure schema and ingestion work expose their operations through domain ports,
 so persistence details stay confined to outbound adapters.
 
 ### Step: Schema baseline


### PR DESCRIPTION
Restructure the backend roadmap around a gating Phase 0 that establishes domain, port, and adapter seams before any feature work. Reinforce subsequent phases with guidance to route delivery through the hexagonal architecture and cross-link the pagination phase to the detailed design.

## Summary by Sourcery

Restructure the backend roadmap to front-load hexagonal architecture constraints by introducing a new Phase 0 for domain, port, and adapter seams, remove the redundant consolidation phase, and update all subsequent phases to adhere to these boundaries.

Enhancements:
- Add Phase 0 steps in the roadmap to establish domain models, explicit port traits, and inbound/outbound adapter boundaries before any feature work
- Introduce architectural guardrails with dependency lints, module diagrams, and integration tests to enforce hexagonal seams
- Shift consolidation tasks from the removed Phase 7 into Phase 0 and remove the redundant consolidation phase
- Reinforce guidance in all phases to route delivery through the defined hexagonal ports and adapters
- Cross-link the pagination phase to the detailed keyset-pagination design

Documentation:
- Revise backend-roadmap.md with the new Phase 0 structure, updated phase descriptions, and references to architecture and pagination design documents