### PR TITLE
Add CodeScene rule for string-heavy arguments

### DIFF
--- a/.codescene/code-health-rules.json
+++ b/.codescene/code-health-rules.json
@@ -1,0 +1,9 @@
+{
+  "rules": {
+    "string-heavy-function-arguments": {
+      "threshold-by-pattern": {
+        "**/domain/*.rs": 100
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- add a CodeScene rule configuring the string-heavy function arguments threshold for domain Rust modules

## Testing
- not run (configuration change only)


------
https://chatgpt.com/codex/tasks/task_e_6907b1d97bcc83228734456c0731fb58

## Summary by Sourcery

Enhancements:
- Introduce a new CodeScene rule to flag functions with excessive string arguments in domain Rust modules.