### PR TITLE
Address code review feedback for domain ports PR

### DIFF
--- a/backend/src/doc.rs
+++ b/backend/src/doc.rs
@@ -68,94 +68,50 @@ pub struct ApiDoc;
 
 #[cfg(test)]
 mod tests {
-    //! Tests verifying OpenAPI schema wrappers are correctly registered and referenced.
+    //! Tests verifying OpenAPI schema field structure.
+    //!
+    //! Schema registration and endpoint reference tests are covered by the
+    //! BDD tests in `backend/tests/openapi_schemas_bdd.rs`.
 
     use super::*;
+    use utoipa::openapi::schema::Schema;
+    use utoipa::openapi::RefOr;
     use utoipa::OpenApi;
 
     // Note: utoipa replaces :: with . in schema names
     const ERROR_SCHEMA_NAME: &str = "crate.domain.Error";
-    const ERROR_CODE_SCHEMA_NAME: &str = "crate.domain.ErrorCode";
     const USER_SCHEMA_NAME: &str = "crate.domain.User";
 
-    #[test]
-    fn openapi_document_contains_schema_wrappers() {
-        let doc = ApiDoc::openapi();
-        let json = doc.to_json().expect("valid JSON");
-
-        // Verify schemas are registered under domain type names (via #[schema(as = ...)])
-        assert!(
-            json.contains(&format!("\"{ERROR_SCHEMA_NAME}\"")),
-            "Error schema should be registered"
-        );
-        assert!(
-            json.contains(&format!("\"{ERROR_CODE_SCHEMA_NAME}\"")),
-            "ErrorCode schema should be registered"
-        );
-        assert!(
-            json.contains(&format!("\"{USER_SCHEMA_NAME}\"")),
-            "User schema should be registered"
-        );
-    }
-
-    #[test]
-    fn openapi_document_references_schema_types_in_responses() {
-        let doc = ApiDoc::openapi();
-        let json = doc.to_json().expect("valid JSON");
-
-        // Verify responses reference the schema types
-        // The paths should reference Error and User in their response schemas
-        assert!(
-            json.contains(&format!("#/components/schemas/{ERROR_SCHEMA_NAME}")),
-            "Responses should reference Error schema"
-        );
-        assert!(
-            json.contains(&format!("#/components/schemas/{USER_SCHEMA_NAME}")),
-            "Responses should reference User schema"
-        );
+    /// Assert that an Object schema contains a field with the given name.
+    fn assert_object_schema_has_field(schema: &RefOr<Schema>, field: &str) {
+        match schema {
+            RefOr::T(Schema::Object(obj)) => {
+                assert!(
+                    obj.properties.contains_key(field),
+                    "schema should have field '{field}'"
+                );
+            }
+            _ => panic!("expected Object schema"),
+        }
     }
 
     #[test]
     fn openapi_error_schema_has_required_fields() {
         let doc = ApiDoc::openapi();
-        let components = doc.components.as_ref().expect("components present");
-        let schemas = &components.schemas;
+        let schemas = &doc.components.as_ref().expect("components").schemas;
+        let error_schema = schemas.get(ERROR_SCHEMA_NAME).expect("Error schema");
 
-        // Check that the Error schema exists and has the expected structure
-        let error_schema = schemas
-            .get(ERROR_SCHEMA_NAME)
-            .expect("Error schema registered");
-        let schema_str = serde_json::to_string(error_schema).expect("serialise");
-
-        assert!(
-            schema_str.contains("\"code\""),
-            "Error schema should have code field"
-        );
-        assert!(
-            schema_str.contains("\"message\""),
-            "Error schema should have message field"
-        );
+        assert_object_schema_has_field(error_schema, "code");
+        assert_object_schema_has_field(error_schema, "message");
     }
 
     #[test]
     fn openapi_user_schema_has_required_fields() {
         let doc = ApiDoc::openapi();
-        let components = doc.components.as_ref().expect("components present");
-        let schemas = &components.schemas;
+        let schemas = &doc.components.as_ref().expect("components").schemas;
+        let user_schema = schemas.get(USER_SCHEMA_NAME).expect("User schema");
 
-        // Check that the User schema exists and has the expected structure
-        let user_schema = schemas
-            .get(USER_SCHEMA_NAME)
-            .expect("User schema registered");
-        let schema_str = serde_json::to_string(user_schema).expect("serialise");
-
-        assert!(
-            schema_str.contains("\"id\""),
-            "User schema should have id field"
-        );
-        assert!(
-            schema_str.contains("\"display_name\""),
-            "User schema should have display_name field"
-        );
+        assert_object_schema_has_field(user_schema, "id");
+        assert_object_schema_has_field(user_schema, "display_name");
     }
 }

--- a/docs/execplans/phase-0-update-modules-to-use-domain-ports.md
+++ b/docs/execplans/phase-0-update-modules-to-use-domain-ports.md
@@ -10,8 +10,8 @@ Two categories of hexagonal architecture violations exist:
 
 1. **TraceId crosses middleware→domain boundary**: Domain code imports `TraceId`
    from `middleware/trace.rs`
-2. **OpenAPI/Utoipa framework types in domain**: Domain types derive `ToSchema`
-   from the `utoipa` crate
+2. **OpenAPI (Open API Specification) / Utoipa framework types in domain**: Domain
+   types derive `ToSchema` from the `utoipa` crate
 
 ## Design Decisions
 


### PR DESCRIPTION
- Add schema constraints to UserSchema matching domain invariants:
  - id: format=uuid
  - display_name: minLength=3, maxLength=32, pattern for allowed chars
- Add ErrorCode sync test verifying domain serialization matches schema
- Consolidate OpenAPI tests: remove duplicates from doc.rs covered by BDD
- Refactor remaining doc.rs tests to use structured Schema inspection
- Define OpenAPI acronym on first use in exec plan documentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Refine OpenAPI schema definitions and tests to better align with domain invariants and documentation.

New Features:
- Tighten UserSchema OpenAPI constraints to reflect domain UUID and display name invariants.
- Add a regression test ensuring ErrorCode domain serialization stays in sync with its OpenAPI schema representation.

Enhancements:
- Simplify OpenAPI documentation tests to focus on schema field structure using direct schema inspection instead of JSON string matching.
- Clarify execution plan documentation by expanding the OpenAPI acronym on first use.

Tests:
- Remove redundant OpenAPI registration/response tests now covered by BDD, and add targeted schema field tests for Error and User objects.