### PR TITLE
Update GitOps tree roadmap

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -1,5 +1,6 @@
 {
   "lockfileVersion": 1,
+  "configVersion": 0,
   "workspaces": {
     "": {
       "name": "myapp",

--- a/docs/ephemeral-previews-roadmap.md
+++ b/docs/ephemeral-previews-roadmap.md
@@ -86,11 +86,12 @@ repository and commits Flux-ready manifests into `wildside-infra`.
     zones, issuers, and credential handles between modules.
 
 - [ ] **Lay out the `wildside-infra` GitOps tree**: Ensure the repository hosts
-  `clusters/<cluster>/`, `modules/`, and a `platform` directory with
-  subdirectories for `sources`, `traefik`, `cert-manager`, `external-dns`,
-  `vault`, and shared data services (CloudNativePG, Redis). Each subdirectory
-  should contain the HelmReleases, Kustomizations, and supporting manifests the
-  action can render idempotently.
+  `clusters/<cluster>/`, a `modules/` directory synced from `infra/modules/`,
+  and a `platform` directory with subdirectories for `sources`, `traefik`,
+  `cert-manager`, `external-dns`, `vault`, `databases` (CloudNativePG), and
+  `redis` (Valkey). Each subdirectory should contain the HelmReleases,
+  Kustomizations, and supporting manifests rendered idempotently by the
+  workflow helper.
 
 - [ ] **Extend `wildside-infra-k8s` for fixtures**: Update the action so it
   applies the new modules, writes resulting manifests into the `platform/*`


### PR DESCRIPTION
Align roadmap entry with automated GitOps layout
and sync bun lockfile after tooling runs.

## Summary by Sourcery

Update the ephemeral previews roadmap to reflect the current automated GitOps tree layout and regenerate the Bun lockfile after tooling updates.

Documentation:
- Revise the GitOps tree roadmap entry to describe the synced modules directory and updated platform subdirectory structure (including databases and redis) and reference the workflow helper for rendering manifests.

Chores:
- Refresh the Bun lockfile to align with the latest tooling state.