### PR TITLE
Update Makefile yamllint target tool checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -237,5 +237,6 @@ nixie:
 	nixie --no-sandbox
 
 yamllint:
-	command -v helm >/dev/null && command -v uv >/dev/null && command -v yq >/dev/null
+	$(call ensure_tool,helm)
+	$(call ensure_tool,uv)
 	set -o pipefail; helm template wildside ./deploy/charts/wildside --kube-version $(KUBE_VERSION) | uvx --from "yamllint==$(YAMLLINT_VERSION)" yamllint -f parsable -


### PR DESCRIPTION
## Summary
- Updates Makefile yamllint target to rely on ensure_tool tool checks
- Removes yq presence check from yamllint target

## Changes

### Makefile
- Use $(call ensure_tool,helm) to verify helm is installed
- Use $(call ensure_tool,uv) to verify uv is installed
- Remove direct command -v checks and yq check
- Preserve existing yamllint pipeline: helm template wildside ./deploy/charts/wildside --kube-version $(KUBE_VERSION) | uvx --from \"yamllint==$(YAMLLINT_VERSION)\" yamllint -f parsable -

### Rationale
- Centralizes tool verification via ensure_tool macro, reducing duplication and clearer error messages

## Test plan
- [x] Run make yamllint to ensure it validates manifests
- [x] Verify missing tools produce a helpful error message from ensure_tool
- [x] Confirm yamllint output remains unchanged aside from tool-check mechanism


◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/ddd2f1d6-8ebb-46c3-9781-4f8189a5ea17

## Summary by Sourcery

Centralize yamllint target tool checks in the Makefile using the shared ensure_tool macro and drop the unused yq prerequisite.

Enhancements:
- Replace inline command checks for helm and uv in the yamllint Makefile target with the shared ensure_tool macro.
- Remove the yq dependency check from the yamllint Makefile target while preserving the existing linting pipeline.