### PR TITLE
Chore: Bump basic-ftp to fix FTP command injection vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "pino": "9.13.1",
       "qs": "6.14.2",
       "rollup": "4.59.0",
-      "basic-ftp": "5.2.0",
+      "basic-ftp": "5.2.1",
       "dompurify": "3.3.2",
       "tar-fs": "3.1.1",
       "validator": "13.15.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   pino: 9.13.1
   qs: 6.14.2
   rollup: 4.59.0
-  basic-ftp: 5.2.0
+  basic-ftp: 5.2.1
   dompurify: 3.3.2
   tar-fs: 3.1.1
   validator: 13.15.23
@@ -1212,8 +1212,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.2.0:
-    resolution: {integrity: sha512-VoMINM2rqJwJgfdHq6RiUudKt2BV+FY5ZFezP/ypmwayk68+NzzAQy4XXLlqsGD4MCzq3DrmNFD/uUmBJuGoXw==}
+  basic-ftp@5.2.1:
+    resolution: {integrity: sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==}
     engines: {node: '>=10.0.0'}
 
   binary-extensions@2.3.0:
@@ -4367,7 +4367,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.2.0: {}
+  basic-ftp@5.2.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -5038,7 +5038,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.0
+      basic-ftp: 5.2.1
       data-uri-to-buffer: 6.0.2
       debug: 4.4.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Upgrades basic-ftp from 5.2.0 to 5.2.1 to address a known FTP command injection vulnerability.
- No functional changes; this is a dependency security patch.

## Changes
### Dependencies
- package.json: basic-ftp bumped from 5.2.0 to 5.2.1
- pnpm-lock.yaml: lockfile updated to reflect 5.2.1, including new integrity hash

## Test plan
- [x] Run pnpm install to refresh dependencies
- [x] Run unit/integration tests
- [ ] Manually verify FTP-related workflows (connect/list/upload) in a safe environment
- [x] Confirm package.json reflects basic-ftp@5.2.1

## Notes
- This patch contains only dependency updates; no application logic changes.
- Ensure CI passes after dependency resolution.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/e6a76794-766b-434a-8571-172ceda93476

## Summary by Sourcery

Build:
- Bump basic-ftp dependency from 5.2.0 to 5.2.1 and update lockfile for the new version.