### PR TITLE
Bump basic-ftp to 5.2.2 to fix pnpm audit vulnerabilities

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
       "pino": "9.13.1",
       "qs": "6.14.2",
       "rollup": "4.59.0",
-      "basic-ftp": "5.2.1",
+      "basic-ftp": "5.2.2",
       "dompurify": "3.3.2",
       "tar-fs": "3.1.1",
       "validator": "13.15.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   pino: 9.13.1
   qs: 6.14.2
   rollup: 4.59.0
-  basic-ftp: 5.2.1
+  basic-ftp: 5.2.2
   dompurify: 3.3.2
   tar-fs: 3.1.1
   validator: 13.15.23
@@ -1212,8 +1212,8 @@ packages:
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
-  basic-ftp@5.2.1:
-    resolution: {integrity: sha512-0yaL8JdxTknKDILitVpfYfV2Ob6yb3udX/hK97M7I3jOeznBNxQPtVvTUtnhUkyHlxFWyr5Lvknmgzoc7jf+1Q==}
+  basic-ftp@5.2.2:
+    resolution: {integrity: sha512-1tDrzKsdCg70WGvbFss/ulVAxupNauGnOlgpyjKzeQxzyllBLS0CGLV7tjIXTK3ZQA9/FBEm9qyFFN1bciA6pw==}
     engines: {node: '>=10.0.0'}
 
   binary-extensions@2.3.0:
@@ -4367,7 +4367,7 @@ snapshots:
 
   base64-js@1.5.1: {}
 
-  basic-ftp@5.2.1: {}
+  basic-ftp@5.2.2: {}
 
   binary-extensions@2.3.0: {}
 
@@ -5038,7 +5038,7 @@ snapshots:
 
   get-uri@6.0.5:
     dependencies:
-      basic-ftp: 5.2.1
+      basic-ftp: 5.2.2
       data-uri-to-buffer: 6.0.2
       debug: 4.4.1
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- Bump basic-ftp from 5.2.1 to 5.2.2 to address vulnerabilities reported by pnpm audit
- No code changes; only dependency upgrade and lockfile refresh

## Changes
### Dependency Updates
- package.json: basic-ftp -> 5.2.2
- pnpm-lock.yaml: lockfile updated to reflect 5.2.2 with updated integrity

## Rationale
- Addresses security advisories detected by pnpm audit; 5.2.2 includes fixes for reported vulnerabilities

## Testing plan
- [x] Run pnpm install to refresh the lockfile
- [x] Run pnpm audit to verify vulnerabilities are resolved
- [x] Run existing FTP-related functionality to ensure there are no regressions
- [x] Execute full test suite (if applicable) to confirm stability

## Notes
- This is a patch upgrade with no API changes; compatibility should be preserved. Ensure CI passes after dependency refresh.

◳ Generated by [DevBoxer](https://www.devboxer.com) ◰

---

ℹ️ Tag @devboxerhub to ask questions and address PR feedback

📎 **Task**: https://www.devboxer.com/task/363ab4da-ae2b-4c20-91d2-63006bde49e3

## Summary by Sourcery

Build:
- Bump basic-ftp from 5.2.1 to 5.2.2 in package.json and regenerate pnpm-lock.yaml to reflect the new version.