### PR TITLE
Add override parity tests and docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,7 +95,7 @@ jobs:
         run: make audit
 
       - name: Install Nixie
-        run: uv tool install --from git+https://github.com/leynos/nixie nixie
+        run: uv tool install nixie-cli
 
       - name: Nixie
         run: make nixie

--- a/Makefile
+++ b/Makefile
@@ -163,7 +163,8 @@ test-rust: workspace-sync prepare-pg-worker
 	PG_EMBEDDED_WORKER=$(PG_WORKER_PATH) NEXTEST_TEST_THREADS=$(NEXTEST_TEST_THREADS) $(RUST_FLAGS_ENV) cargo nextest run --workspace --all-targets --all-features --no-fail-fast
 
 test-frontend: deps typecheck
-	pnpm -r --if-present --silent run test
+	pnpm run test
+	pnpm run test:workspaces
 
 .PHONY: prepare-pg-worker
 .ONESHELL: prepare-pg-worker

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
         "puppeteer": "^23.11.1",
         "validator": "^13.15.23",
         "vite": "^7.3.2",
+        "vitest": "^3.2.4",
       },
     },
     "frontend-pwa": {

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -342,7 +342,7 @@ other tooling:
   `0` on success or `1` on any mismatch or missing block.
 - **`formatOverrideValue(value)`** — formats a single override value for
   human-readable diagnostics; returns `"<missing>"` for `undefined` and a
-  JSON-stringified string otherwise.
+  JSON-stringified value otherwise.
 
 Example import:
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -256,6 +256,37 @@ The hexagonal boundary is enforced via visibility:
 Domain code depends only on the `RouteCache` port trait. The Redis adapter
 implements this port without exposing `bb8-redis` types in the public API.
 
+## Root-level script tests
+
+Repository-level Node.js scripts under `scripts/` are tested with
+[Vitest](https://vitest.dev/). The root `vitest.config.mjs` configures test
+discovery:
+
+- **Environment:** `node`
+- **Test file pattern:** `scripts/**/*.test.mjs`
+
+Run these tests with:
+
+```sh
+pnpm run test
+```
+
+Workspace package tests (frontend, etc.) are run separately:
+
+```sh
+pnpm run test:workspaces
+```
+
+`make test` runs both in sequence.
+
+### Adding tests for a new script
+
+1. Create a test file alongside the script: `scripts/<name>.test.mjs`.
+2. Use `vi.mock` / `vi.resetModules` from Vitest to isolate each import.
+3. If the script has CLI side-effects, gate them behind a direct-invocation
+   guard (see "Programmatic API" under "Override parity check") so the module
+   can be imported cleanly in tests.
+
 ## Override parity check
 
 This repository pins certain security-sensitive dependencies in two separate
@@ -300,6 +331,36 @@ The check runs as a step in `.github/workflows/ci.yml`:
 
 It appears after `make lockfile` and before `make deps`. A failure here means
 the two override blocks have drifted; update `package.json` and recommit.
+
+### Programmatic API
+
+`scripts/check-overrides-parity.mjs` exports two functions for use in tests or
+other tooling:
+
+- **`checkOverridesParity(packageJson)`** — accepts a parsed `package.json`
+  object, writes diagnostics to `console.log` or `console.error`, and returns
+  `0` on success or `1` on any mismatch or missing block.
+- **`formatOverrideValue(value)`** — formats a single override value for
+  human-readable diagnostics; returns `"<missing>"` for `undefined` and a
+  JSON-stringified string otherwise.
+
+Example import:
+
+```js
+import {
+  checkOverridesParity,
+  formatOverrideValue,
+} from './scripts/check-overrides-parity.mjs';
+```
+
+The CLI entry point is protected by a direct-invocation guard so importing the
+module does not trigger any file I/O or process side-effects:
+
+```js
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  // only runs when invoked directly as `node ./scripts/check-overrides-parity.mjs`
+}
+```
 
 ## Operational references
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -267,7 +267,8 @@ used for installation:
 
 The script `scripts/check-overrides-parity.mjs` verifies that both blocks
 contain identical values for every pinned dependency. It is run automatically
-in CI after the lockfile step and before dependency installation.
+in Continuous Integration (CI) after the lockfile step and before dependency
+installation.
 
 ### Running locally
 

--- a/docs/developers-guide.md
+++ b/docs/developers-guide.md
@@ -256,6 +256,50 @@ The hexagonal boundary is enforced via visibility:
 Domain code depends only on the `RouteCache` port trait. The Redis adapter
 implements this port without exposing `bb8-redis` types in the public API.
 
+## Override parity check
+
+This repository pins certain security-sensitive dependencies in two separate
+override blocks so they resolve correctly regardless of whether Bun or pnpm is
+used for installation:
+
+- `overrides` — top-level; consumed by Bun.
+- `pnpm.overrides` — consumed by pnpm.
+
+The script `scripts/check-overrides-parity.mjs` verifies that both blocks
+contain identical values for every pinned dependency. It is run automatically
+in CI after the lockfile step and before dependency installation.
+
+### Running locally
+
+```sh
+node ./scripts/check-overrides-parity.mjs
+```
+
+A passing run prints:
+
+```text
+Override parity verified for basic-ftp, dompurify.
+```
+
+A failing run prints a per-dependency diff to stderr and exits with code `1`.
+
+### Resolving failures
+
+When the check fails, open `package.json` and ensure the version string in
+`overrides.<package>` exactly matches the version string in
+`pnpm.overrides.<package>`. Both entries must be present and identical.
+
+### CI integration
+
+The check runs as a step in `.github/workflows/ci.yml`:
+
+```yaml
+- run: node ./scripts/check-overrides-parity.mjs
+```
+
+It appears after `make lockfile` and before `make deps`. A failure here means
+the two override blocks have drifted; update `package.json` and recommit.
+
 ## Operational references
 
 - For local command quick reference and embedded PostgreSQL worker setup:

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "markdownlint-cli": "^0.45.0",
     "puppeteer": "^23.11.1",
     "validator": "^13.15.23",
-    "vite": "^7.3.2"
+    "vite": "^7.3.2",
+    "vitest": "^3.2.4"
   },
   "name": "myapp",
   "private": true,
@@ -23,7 +24,8 @@
     "fmt": "node ./scripts/run-workspace-script.mjs fmt",
     "lint": "node ./scripts/run-workspace-script.mjs lint",
     "typecheck": "node ./scripts/run-workspace-script.mjs typecheck",
-    "test": "node ./scripts/run-workspace-script.mjs test",
+    "test": "vitest run --config vitest.config.mjs",
+    "test:workspaces": "node ./scripts/run-workspace-script.mjs test",
     "audit": "node ./scripts/run-workspace-script.mjs audit",
     "audit:validate": "node security/validate-audit.js"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3)
+      vitest:
+        specifier: ^3.2.4
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3)
 
   frontend-pwa:
     dependencies:
@@ -3242,7 +3245,7 @@ snapshots:
       '@babel/types': 7.28.4
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -3324,7 +3327,7 @@ snapshots:
       '@babel/parser': 7.28.4
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -3555,7 +3558,7 @@ snapshots:
       '@antfu/install-pkg': 1.1.0
       '@antfu/utils': 9.2.0
       '@iconify/types': 2.0.0
-      debug: 4.4.1
+      debug: 4.4.3
       globals: 15.15.0
       kolorist: 1.8.0
       local-pkg: 1.1.2
@@ -4202,6 +4205,14 @@ snapshots:
       magic-string: 0.30.19
     optionalDependencies:
       vite: 7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3)
+
+  '@vitest/mocker@3.2.4(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3))':
+    dependencies:
+      '@vitest/spy': 3.2.4
+      estree-walker: 3.0.3
+      magic-string: 0.30.19
+    optionalDependencies:
+      vite: 7.3.2(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4939,7 +4950,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.1
+      debug: 4.4.3
       get-stream: 5.2.0
       yauzl: 3.2.1
     optionalDependencies:
@@ -5039,7 +5050,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.3.0
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5102,14 +5113,14 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
@@ -5557,7 +5568,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.4.1
+      debug: 4.4.3
       decode-named-character-reference: 1.2.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -5695,7 +5706,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -5867,7 +5878,7 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -6109,7 +6120,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.1
+      debug: 4.4.3
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -6397,10 +6408,31 @@ snapshots:
   vite-node@3.2.4(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.1
+      debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vite-node@3.2.4(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.2(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -6454,7 +6486,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.3.3
-      debug: 4.4.1
+      debug: 4.4.3
       expect-type: 1.2.2
       magic-string: 0.30.19
       pathe: 2.0.3
@@ -6471,6 +6503,48 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 22.18.12
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
+  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.4
+      '@vitest/mocker': 3.2.4(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3))
+      '@vitest/pretty-format': 3.2.4
+      '@vitest/runner': 3.2.4
+      '@vitest/snapshot': 3.2.4
+      '@vitest/spy': 3.2.4
+      '@vitest/utils': 3.2.4
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.2.2
+      magic-string: 0.30.19
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.2(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3)
+      vite-node: 3.2.4(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 24.3.1
     transitivePeerDependencies:
       - jiti
       - less

--- a/scripts/check-overrides-parity.mjs
+++ b/scripts/check-overrides-parity.mjs
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const OVERRIDES_TO_CHECK = ['basic-ftp', 'dompurify'];
@@ -74,7 +75,7 @@ export function checkOverridesParity(packageJson) {
   return 1;
 }
 
-if (process.argv[1] === fileURLToPath(import.meta.url)) {
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
   const packageJson = await readPackageJson();
   process.exitCode = checkOverridesParity(packageJson);
 }

--- a/scripts/check-overrides-parity.mjs
+++ b/scripts/check-overrides-parity.mjs
@@ -6,6 +6,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
 
 const OVERRIDES_TO_CHECK = ['basic-ftp', 'dompurify'];
 const PACKAGE_JSON_PATH = new URL('../package.json', import.meta.url);
@@ -16,7 +17,7 @@ const PACKAGE_JSON_PATH = new URL('../package.json', import.meta.url);
  * @param {unknown} value - The override value to display.
  * @returns {string} A stable string representation for logs.
  */
-function formatOverrideValue(value) {
+export function formatOverrideValue(value) {
   return value === undefined ? '<missing>' : JSON.stringify(value);
 }
 
@@ -36,7 +37,7 @@ async function readPackageJson() {
  * @param {Record<string, unknown>} packageJson - The parsed package manifest.
  * @returns {number} `0` when overrides match, otherwise `1`.
  */
-function checkOverridesParity(packageJson) {
+export function checkOverridesParity(packageJson) {
   const rootOverrides = packageJson.overrides ?? {};
   const pnpmOverrides = packageJson.pnpm?.overrides ?? {};
 
@@ -73,5 +74,7 @@ function checkOverridesParity(packageJson) {
   return 1;
 }
 
-const packageJson = await readPackageJson();
-process.exitCode = checkOverridesParity(packageJson);
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+  const packageJson = await readPackageJson();
+  process.exitCode = checkOverridesParity(packageJson);
+}

--- a/scripts/check-overrides-parity.test.mjs
+++ b/scripts/check-overrides-parity.test.mjs
@@ -1,0 +1,216 @@
+/** @file Tests the override parity helper and guarded CLI entrypoint. */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fileURLToPath } from 'node:url';
+
+const readFileMock = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  readFile: readFileMock,
+}));
+
+const moduleUrl = new URL('./check-overrides-parity.mjs', import.meta.url);
+const modulePath = fileURLToPath(moduleUrl);
+
+/**
+ * Load a fresh copy of the module under test after resetting the module cache.
+ *
+ * @returns {Promise<typeof import('./check-overrides-parity.mjs')>} The imported module.
+ */
+async function loadModule() {
+  vi.resetModules();
+  return import('./check-overrides-parity.mjs');
+}
+
+describe('formatOverrideValue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns <missing> when the value is undefined', async () => {
+    const { formatOverrideValue } = await loadModule();
+
+    expect(formatOverrideValue(undefined)).toBe('<missing>');
+  });
+
+  it('stringifies string values for diagnostics', async () => {
+    const { formatOverrideValue } = await loadModule();
+
+    expect(formatOverrideValue('5.3.0')).toBe('"5.3.0"');
+  });
+});
+
+describe('checkOverridesParity', () => {
+  let consoleLogSpy;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('returns 0 and logs success when both override blocks match', async () => {
+    const { checkOverridesParity } = await loadModule();
+    const packageJson = {
+      overrides: {
+        'basic-ftp': '5.3.0',
+        dompurify: '3.4.0',
+      },
+      pnpm: {
+        overrides: {
+          'basic-ftp': '5.3.0',
+          dompurify: '3.4.0',
+        },
+      },
+    };
+
+    expect(checkOverridesParity(packageJson)).toBe(0);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      expect.stringContaining('basic-ftp, dompurify'),
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 and reports the mismatched dependency version', async () => {
+    const { checkOverridesParity } = await loadModule();
+    const packageJson = {
+      overrides: {
+        'basic-ftp': '5.3.0',
+        dompurify: '3.3.0',
+      },
+      pnpm: {
+        overrides: {
+          'basic-ftp': '5.3.0',
+          dompurify: '3.4.0',
+        },
+      },
+    };
+
+    expect(checkOverridesParity(packageJson)).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Override mismatch for "dompurify":'),
+    );
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 when the top-level overrides block is absent', async () => {
+    const { checkOverridesParity } = await loadModule();
+    const packageJson = {
+      pnpm: {
+        overrides: {
+          'basic-ftp': '5.3.0',
+          dompurify: '3.4.0',
+        },
+      },
+    };
+
+    expect(checkOverridesParity(packageJson)).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('overrides: <missing>'),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('pnpm.overrides: "5.3.0"'),
+    );
+  });
+
+  it('returns 1 when the pnpm overrides block is absent', async () => {
+    const { checkOverridesParity } = await loadModule();
+    const packageJson = {
+      overrides: {
+        'basic-ftp': '5.3.0',
+        dompurify: '3.4.0',
+      },
+    };
+
+    expect(checkOverridesParity(packageJson)).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+
+  it('returns 1 when an individual top-level entry is missing', async () => {
+    const { checkOverridesParity } = await loadModule();
+    const packageJson = {
+      overrides: {
+        dompurify: '3.4.0',
+      },
+      pnpm: {
+        overrides: {
+          'basic-ftp': '5.3.0',
+          dompurify: '3.4.0',
+        },
+      },
+    };
+
+    expect(checkOverridesParity(packageJson)).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Override mismatch for "basic-ftp":'),
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('overrides: <missing>'),
+    );
+  });
+
+  it('returns 1 when both override blocks are absent', async () => {
+    const { checkOverridesParity } = await loadModule();
+
+    expect(checkOverridesParity({})).toBe(1);
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    expect(consoleLogSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('direct execution guard', () => {
+  let originalArgv;
+  let originalExitCode;
+  let consoleLogSpy;
+  let consoleErrorSpy;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    originalArgv = [...process.argv];
+    originalExitCode = process.exitCode;
+    process.exitCode = undefined;
+    consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.exitCode = originalExitCode;
+    consoleLogSpy.mockRestore();
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('reads package.json and sets exitCode when invoked directly', async () => {
+    readFileMock.mockResolvedValueOnce(
+      JSON.stringify({
+        overrides: {
+          'basic-ftp': '5.3.0',
+          dompurify: '3.4.0',
+        },
+        pnpm: {
+          overrides: {
+            'basic-ftp': '5.3.0',
+            dompurify: '3.4.0',
+          },
+        },
+      }),
+    );
+    process.argv = [process.argv[0], modulePath];
+
+    await loadModule();
+
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+    expect(process.exitCode).toBe(0);
+    expect(consoleLogSpy).toHaveBeenCalledWith(
+      'Override parity verified for basic-ftp, dompurify.',
+    );
+    expect(consoleErrorSpy).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/check-overrides-parity.test.mjs
+++ b/scripts/check-overrides-parity.test.mjs
@@ -11,10 +11,6 @@ vi.mock('node:fs/promises', () => ({
 
 const moduleUrl = new URL('./check-overrides-parity.mjs', import.meta.url);
 const modulePath = fileURLToPath(moduleUrl);
-const SYNCED = {
-  'basic-ftp': '5.3.0',
-  dompurify: '3.4.0',
-};
 
 /**
  * Load a fresh copy of the module under test after resetting the module cache.
@@ -24,6 +20,20 @@ const SYNCED = {
 async function loadModule() {
   vi.resetModules();
   return import('./check-overrides-parity.mjs');
+}
+
+/** Convenience fixture data shared across parity tests. */
+const SYNCED = { 'basic-ftp': '5.3.0', dompurify: '3.4.0' };
+
+/**
+ * Load a fresh module and immediately invoke checkOverridesParity.
+ *
+ * @param {object} packageJson - The package.json fixture to check.
+ * @returns {Promise<number>} The exit-code returned by checkOverridesParity.
+ */
+async function runParityCheck(packageJson) {
+  const { checkOverridesParity } = await loadModule();
+  return checkOverridesParity(packageJson);
 }
 
 describe('formatOverrideValue', () => {
@@ -47,17 +57,6 @@ describe('formatOverrideValue', () => {
 describe('checkOverridesParity', () => {
   let consoleLogSpy;
   let consoleErrorSpy;
-
-  /**
-   * Run the parity check against a provided manifest object.
-   *
-   * @param {Record<string, unknown>} packageJson - The manifest to validate.
-   * @returns {Promise<number>} The parity check exit code.
-   */
-  async function runParityCheck(packageJson) {
-    const { checkOverridesParity } = await loadModule();
-    return checkOverridesParity(packageJson);
-  }
 
   beforeEach(() => {
     vi.clearAllMocks();

--- a/scripts/check-overrides-parity.test.mjs
+++ b/scripts/check-overrides-parity.test.mjs
@@ -11,6 +11,10 @@ vi.mock('node:fs/promises', () => ({
 
 const moduleUrl = new URL('./check-overrides-parity.mjs', import.meta.url);
 const modulePath = fileURLToPath(moduleUrl);
+const SYNCED = {
+  'basic-ftp': '5.3.0',
+  dompurify: '3.4.0',
+};
 
 /**
  * Load a fresh copy of the module under test after resetting the module cache.
@@ -44,6 +48,17 @@ describe('checkOverridesParity', () => {
   let consoleLogSpy;
   let consoleErrorSpy;
 
+  /**
+   * Run the parity check against a provided manifest object.
+   *
+   * @param {Record<string, unknown>} packageJson - The manifest to validate.
+   * @returns {Promise<number>} The parity check exit code.
+   */
+  async function runParityCheck(packageJson) {
+    const { checkOverridesParity } = await loadModule();
+    return checkOverridesParity(packageJson);
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
     consoleLogSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -56,21 +71,12 @@ describe('checkOverridesParity', () => {
   });
 
   it('returns 0 and logs success when both override blocks match', async () => {
-    const { checkOverridesParity } = await loadModule();
-    const packageJson = {
-      overrides: {
-        'basic-ftp': '5.3.0',
-        dompurify: '3.4.0',
-      },
-      pnpm: {
-        overrides: {
-          'basic-ftp': '5.3.0',
-          dompurify: '3.4.0',
-        },
-      },
-    };
+    const result = await runParityCheck({
+      overrides: SYNCED,
+      pnpm: { overrides: SYNCED },
+    });
 
-    expect(checkOverridesParity(packageJson)).toBe(0);
+    expect(result).toBe(0);
     expect(consoleLogSpy).toHaveBeenCalledWith(
       expect.stringContaining('basic-ftp, dompurify'),
     );
@@ -78,21 +84,15 @@ describe('checkOverridesParity', () => {
   });
 
   it('returns 1 and reports the mismatched dependency version', async () => {
-    const { checkOverridesParity } = await loadModule();
-    const packageJson = {
+    const result = await runParityCheck({
       overrides: {
         'basic-ftp': '5.3.0',
         dompurify: '3.3.0',
       },
-      pnpm: {
-        overrides: {
-          'basic-ftp': '5.3.0',
-          dompurify: '3.4.0',
-        },
-      },
-    };
+      pnpm: { overrides: SYNCED },
+    });
 
-    expect(checkOverridesParity(packageJson)).toBe(1);
+    expect(result).toBe(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Override mismatch for "dompurify":'),
     );
@@ -100,17 +100,9 @@ describe('checkOverridesParity', () => {
   });
 
   it('returns 1 when the top-level overrides block is absent', async () => {
-    const { checkOverridesParity } = await loadModule();
-    const packageJson = {
-      pnpm: {
-        overrides: {
-          'basic-ftp': '5.3.0',
-          dompurify: '3.4.0',
-        },
-      },
-    };
+    const result = await runParityCheck({ pnpm: { overrides: SYNCED } });
 
-    expect(checkOverridesParity(packageJson)).toBe(1);
+    expect(result).toBe(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('overrides: <missing>'),
     );
@@ -120,34 +112,22 @@ describe('checkOverridesParity', () => {
   });
 
   it('returns 1 when the pnpm overrides block is absent', async () => {
-    const { checkOverridesParity } = await loadModule();
-    const packageJson = {
-      overrides: {
-        'basic-ftp': '5.3.0',
-        dompurify: '3.4.0',
-      },
-    };
+    const result = await runParityCheck({ overrides: SYNCED });
 
-    expect(checkOverridesParity(packageJson)).toBe(1);
+    expect(result).toBe(1);
     expect(consoleErrorSpy).toHaveBeenCalled();
     expect(consoleLogSpy).not.toHaveBeenCalled();
   });
 
   it('returns 1 when an individual top-level entry is missing', async () => {
-    const { checkOverridesParity } = await loadModule();
-    const packageJson = {
+    const result = await runParityCheck({
       overrides: {
         dompurify: '3.4.0',
       },
-      pnpm: {
-        overrides: {
-          'basic-ftp': '5.3.0',
-          dompurify: '3.4.0',
-        },
-      },
-    };
+      pnpm: { overrides: SYNCED },
+    });
 
-    expect(checkOverridesParity(packageJson)).toBe(1);
+    expect(result).toBe(1);
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       expect.stringContaining('Override mismatch for "basic-ftp":'),
     );
@@ -157,9 +137,9 @@ describe('checkOverridesParity', () => {
   });
 
   it('returns 1 when both override blocks are absent', async () => {
-    const { checkOverridesParity } = await loadModule();
+    const result = await runParityCheck({});
 
-    expect(checkOverridesParity({})).toBe(1);
+    expect(result).toBe(1);
     expect(consoleErrorSpy).toHaveBeenCalled();
     expect(consoleLogSpy).not.toHaveBeenCalled();
   });

--- a/vitest.config.mjs
+++ b/vitest.config.mjs
@@ -1,0 +1,10 @@
+/** @file Root Vitest configuration for repository script tests. */
+
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['scripts/**/*.test.mjs'],
+  },
+});


### PR DESCRIPTION
Refactor the override parity script so its pure helpers can be imported without triggering CLI side effects.

Add root-scoped Vitest coverage for the parity helper and guarded entrypoint, wire those tests into the existing frontend test gate, and document how the parity check works in the developer guide.

## Summary by Sourcery

Refine the override parity script into a reusable module, add root-level tests for its behavior and guarded CLI entrypoint, and document how the override parity check works and is integrated into CI.

New Features:
- Introduce a root Vitest test configuration for running repository script tests.
- Add Vitest-based coverage for the override parity helper and its direct-execution guard.

Enhancements:
- Export the override parity helpers so they can be imported without triggering CLI side effects and gate CLI execution behind a direct-invocation check.
- Adjust frontend test execution to run both the new root-level tests and existing workspace tests via separate npm scripts.

Build:
- Add Vitest as a dev dependency and wire the root test script to use the new Vitest config.

Documentation:
- Document the override parity check, its local usage, failure modes, and CI integration in the developer guide.