### PR TITLE
Update assistant documentation guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,579 +1,224 @@
-# Assistant Instructions
+# Assistant instructions
 
-## Code Style and Structure
+## Code style and structure
 
-- **Code is for humans.** Write your code with clarity and empathy—assume a
+- **Code is for humans.** Write code with clarity and empathy—assume a
   tired teammate will need to debug it at 3 a.m.
-- **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs, or
-  complexity. Don't echo the obvious.
+- **Comment *why*, not *what*.** Explain assumptions, edge cases, trade-offs,
+  or complexity. Don't echo the obvious.
 - **Clarity over cleverness.** Be concise, but favour explicit over terse or
   obscure idioms. Prefer code that's easy to follow.
 - **Use functions and composition.** Avoid repetition by extracting reusable
   logic. Prefer generators or comprehensions, and declarative code to
   imperative repetition when readable.
-- **Small, meaningful functions.** Functions must be small, clear in purpose,
-  single responsibility, and obey command/query segregation.
+- **Small, meaningful functions.** Functions should have a clear purpose, single
+  responsibility, and obey command/query segregation.
 - **Clear commit messages.** Commit messages should be descriptive, explaining
   what was changed and why.
-- **Name things precisely.** Use clear, descriptive variable and function names.
-  For booleans, prefer names with `is`, `has`, or `should`.
-- **Structure logically.** Each file should encapsulate a coherent module. Group
-  related code (e.g., models + utilities + fixtures) close together.
-- **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers
-  related to a domain concept rather than splitting by type.
 - **Use consistent spelling and grammar.** Comments must use en-GB-oxendict
   ("-ize" / "-yse" / "-our") spelling and grammar, with the exception of
   references to external APIs.
 - **Illustrate with clear examples.** Function documentation must include clear
-  examples demonstrating the usage and outcome of the function. Test
-  documentation should omit examples where the example serves only to reiterate
-  the test logic.
-- **Keep file size manageable.** No single code file may be longer than 400
-  lines. Long switch statements or dispatch tables should be broken up by
-  feature and constituents colocated with targets. Large blocks of test data
-  should be moved to external data files.
+  examples demonstrating usage and outcome. Test documentation should omit
+  examples that only restate the test logic.
+- **Keep file size manageable.** No single code file should be longer than 400
+  lines. Long switch statements or dispatch tables should be broken up by feature
+  and constituents colocated with targets. Large blocks of test data should be
+  moved to external data files.
+- **Name things precisely.** Use clear, descriptive variable and function names.
+  For booleans, prefer names with `is`, `has`, or `should`.
+- **Structure logically.** Each file should encapsulate a coherent module. Group
+  related code (for example, models + utilities + fixtures) close together.
+- **Group by feature, not layer.** Colocate views, logic, fixtures, and helpers
+  related to a domain concept rather than splitting by type.
+- **Use clear file boundaries.** Each module, component, and package should have
+  an obvious responsibility and avoid accidental coupling.
 
-## Documentation Maintenance
+## Documentation maintenance
 
 - **Reference:** Use the markdown files within the `docs/` directory as a
   knowledge base and source of truth for project requirements, dependency
-  choices, and architectural decisions.
+  choices, and architectural decisions. Start with
+  [documentation contents](docs/contents.md) and
+  [repository layout](docs/repository-layout.md) when orienting within the
+  project.
 - **Update:** When new decisions are made, requirements change, libraries are
   added/removed, or architectural patterns evolve, **proactively update** the
   relevant file(s) in the `docs/` directory to reflect the latest state.
-  **Ensure the documentation remains accurate and current.**
-- Documentation must use en-GB-oxendict ("-ize" / "-yse" / "-our") spelling
-  and grammar. (EXCEPTION: the naming of the "LICENSE" file, which is to be
-  left unchanged for community consistency.)
-- A documentation style guide is provided at
-  `docs/documentation-style-guide.md`.
+- **Design decisions:** Record substantive decisions in the relevant design
+  document. For major decisions, capture an architectural decision record (ADR)
+  and reference it from the design document.
+- **User-facing behaviour:** Update [users' guide](docs/users-guide.md) for
+  behaviour or user-interface changes that users should know about.
+- **Internal interfaces:** Document internally facing interfaces in the relevant
+  component architecture document. Record internally facing conventions and
+  practices in [developers' guide](docs/developers-guide.md).
+- **Style:** All documentation must adhere to the
+  [documentation style guide](docs/documentation-style-guide.md).
 
-## Change Quality & Committing
+## Change quality and committing
 
 - **Atomicity:** Aim for small, focused, atomic changes. Each change (and
   subsequent commit) should represent a single logical unit of work.
-- **Quality Gates:** Before considering a change complete or proposing a commit,
-  ensure it meets the following criteria:
-
-  - New functionality or changes in behaviour are fully validated by relevant
-    unittests and behavioural tests.
-  - Where a bug is being fixed, a unittest has been provided demonstrating the
-    behaviour being corrected both to validate the fix and to guard against
-    regression.
-  - Passes all relevant unit and behavioural tests according to the guidelines
-    above. (Use `make test` to verify).
-  - Passes lint checks. (Use `make lint` to verify).
-  - Adheres to formatting standards tested using a formatting validator. (Use
-    `make check-fmt` to verify).
-
+- **Quality gates:** Before considering a change complete or proposing a
+  commit, ensure all of the following are met:
+  - New functionality or behaviour changes are fully validated by relevant unit
+    and behavioural tests.
+  - Bug fixes include a failing test before the fix and a passing test afterward.
+  - Code passes lint checks.
+  - Formatting is correct and validated.
+- **For Python files:**
+  - **Testing:** Passes all relevant unit and behavioural tests (`make test`).
+  - **Linting:** Passes lint checks (`make lint`).
+  - **Formatting:** Adheres to formatting standards (`make check-fmt`; use
+    `make fmt` to apply fixes).
+  - **Typechecking:** Passes type checking (`make typecheck`).
+- **Markdown files (`.md` only):**
+  - **Linting:** Passes markdown lint checks (`make markdownlint`).
+  - **Mermaid diagrams:** Passes validation using nixie (`make nixie`).
 - **Committing:**
+  - Only changes that meet all quality gates should be committed.
+  - Write clear, descriptive commit messages that summarise the change, following:
+    - **Imperative mood** in the subject line (for example, "Fix bug", "Add feature").
+    - **Subject line length:** around 50 characters or fewer.
+    - **Body:** Separate subject from body with a blank line. Explain *what* and
+      *why* in wrapped lines (approximately 72 columns).
+    - **Formatting:** Use Markdown for formatted text inside the message body.
+  - Do not commit changes that fail any quality gate.
 
-  - Only changes that meet all the quality gates above should be committed.
-  - Write clear, descriptive commit messages summarizing the change, following
-    these formatting guidelines:
+## Refactoring heuristics and workflow
 
-    - **Imperative Mood:** Use the imperative mood in the subject line (e.g.,
-      "Fix bug", "Add feature" instead of "Fixed bug", "Added feature").
-    - **Subject Line:** The first line should be a concise summary of the change
-      (ideally 50 characters or fewer).
-    - **Body:** Separate the subject from the body with a blank line. Subsequent
-      lines should explain the *what* and *why* of the change in more detail,
-      including rationale, goals, and scope. Wrap the body at 72 characters.
-    - **Formatting:** Use Markdown for any formatted text (like bullet points or
-      code snippets) within the commit message body.
-
-- Do not commit changes that fail any of the quality gates.
-
-## Refactoring Heuristics & Workflow
-
-- **Recognizing Refactoring Needs:** Regularly assess the codebase for potential
+- **Recognizing refactoring needs:** regularly assess the codebase for potential
   refactoring opportunities. Consider refactoring when you observe:
-- **Long Methods/Functions:** Functions or methods that are excessively long
-    or try to do too many things.
-- **Duplicated Code:** Identical or very similar code blocks appearing in
+  - **Long methods/functions:** functions that are excessively long or try to do
+    too many things.
+  - **Duplicated code:** identical or very similar code blocks appearing in
     multiple places.
-- **Complex Conditionals:** Deeply nested or overly complex `if`/`else` or
-    `switch` statements (high cyclomatic complexity).
-- **Large Code Blocks for Single Values:** Significant chunks of logic
-    dedicated solely to calculating or deriving a single value.
-- **Primitive Obsession / Data Clumps:** Groups of simple variables (strings,
-    numbers, booleans) that are frequently passed around together, often
-    indicating a missing class or object structure.
-- **Excessive Parameters:** Functions or methods requiring a very long list of
-    parameters.
-- **Feature Envy:** Methods that seem more interested in the data of another
-    class/object than their own.
-- **Shotgun Surgery:** A single change requiring small modifications in many
-    different classes or functions.
-- **Post-Commit Review:** After committing a functional change or bug fix (that
-  meets all quality gates), review the changed code and surrounding areas using
-  the heuristics above.
-- **Separate Atomic Refactors:** If refactoring is deemed necessary:
-- Perform the refactoring as a **separate, atomic commit** *after* the
-    functional change commit.
-- Ensure the refactoring adheres to the testing guidelines (behavioural tests
-    pass before and after, unit tests added for new units).
-- Ensure the refactoring commit itself passes all quality gates.
+  - **Complex conditionals:** deeply nested or overly complex `if`/`else` or
+    `switch` statements.
+  - **Large code blocks for single values:** significant logic blocks dedicated
+    to calculating or deriving one value.
+  - **Primitive obsession / data clumps:** groups of simple variables that are
+    frequently passed together, which may indicate a missing abstraction.
+  - **Excessive parameters:** functions or methods requiring too many parameters.
+  - **Feature envy:** methods that focus more on other data than their own.
+  - **Shotgun surgery:** one change that forces many files to be edited.
+- **Abstraction / port / helper policy:** before adding a new abstraction, port,
+  or helper:
+  - Sweep the repository to confirm there is no existing equivalent helper,
+    port, or abstraction.
+  - Document the new abstraction's intended scope and re-use policy.
+  - Record the decision in architecture, design, or developers-guide docs using
+    `docs/contents.md` as the index.
+- **Post-commit review:** after functional changes or bug fixes that meet quality
+  gates, review changed code and adjacent areas using these heuristics.
+- **Separate atomic refactors:** if refactoring is required, implement it in a
+  separate atomic commit after the functional change and ensure it passes all
+  relevant gates.
 
-## Rust Specific Guidance
+## Python verification and testing
 
-This repository is written in Rust and uses Cargo for building and dependency
-management. Contributors should follow these best practices when working on the
-project:
+- For Python work, use `pytest` for unit tests and `pytest-bdd` for behavioural
+  tests. Cover happy paths, unhappy paths, and relevant edge cases.
+- Snapshot tests (using `syrupy`) should be provided where multivariant output
+  format consistency is relevant to the requirements.
+- Add end-to-end tests where a change affects externally observable workflows,
+  integration contracts, persistence, command-line behaviour, network boundaries,
+  user interface flows, or other system-level behaviour.
+- Use property tests with `hypothesis` or `CrossHair` when a change introduces an
+  invariant over a range of inputs, states, orderings, or transitions.
+- Run relevant unit, behavioural, property, and end-to-end suites before and after
+  each change.
 
-- Run `make fmt`, `make lint`, and `make test` before committing. These targets
-  wrap `cargo fmt`, `cargo clippy`, and `cargo test` with the appropriate flags.
-- Clippy warnings MUST be disallowed.
-- Fix any warnings emitted during tests in the code itself rather than
-  silencing them.
-- Where a function is too long, extract meaningfully named helper functions
-  adhering to separation of concerns and CQRS.
-- Where a function has too many parameters, group related parameters in
-  meaningfully named structs.
-- Where a function is returning a large error consider using `Arc` to reduce the
-  amount of data returned.
-- Every module **must** begin with a module level (`//!`) comment explaining the
-  module's purpose and utility.
-- Document public APIs using Rustdoc comments (`///`) so documentation can be
-  generated with cargo doc.
-- Prefer immutable data and avoid unnecessary `mut` bindings.
-- Handle errors with the `Result` type instead of panicking where feasible.
-- Use explicit version ranges in `Cargo.toml` and keep dependencies up-to-date.
-- Avoid `unsafe` code unless absolutely necessary and document any usage
-  clearly.
-- Place function attributes **after** doc comments.
-- Do not use `return` in single-line functions.
-- Use predicate functions for conditional criteria with more than two branches.
-- Lints must not be silenced except as a **last resort**.
-- Lint rule suppressions must be tightly scoped and include a clear reason.
-- Prefer `expect` over `allow`.
-- Where a function is unused with specific features selected, use conditional
-  compilation with `#[cfg]` or `#[cfg_attr]`.
-- Prefer `.expect()` over `.unwrap()`.
-- Use `concat!()` to combine long string literals rather than escaping newlines
-  with a backslash.
-- Prefer single line versions of functions where appropriate. I.e.,
-
-  ```rust
-  pub fn new(id: u64) -> Self { Self(id) }
-  ```
-
-  Instead of:
-
-  ```rust
-  pub fn new(id: u64) -> Self {
-      Self(id)
-  }
-  ```
-
-### Testing
-
-- Write unit and behavioural tests for new functionality. Run both before and
-  after making any change.
-- Use `rstest` fixtures for shared setup.
-- Replace duplicated tests with `#[rstest(...)]` parameterised cases.
-- Prefer `mockall` for mocks/stubs.
-- Mock non-deterministic dependencies (e.g., environment variables and the
-  system clock) using dependency injection with the `mockable` crate (traits
-  like `Env` and `Clock`) where appropriate. See
-  `docs/reliable-testing-in-rust-via-dependency-injection.md` for guidance.
-
-### Dependency Management (Rust)
-
-- **Mandate caret requirements for all dependencies.** All crate versions
-  specified in `Cargo.toml` must use SemVer-compatible caret requirements
-  (e.g., `some-crate = "1.2.3"`). This is Cargo's default and allows for safe,
-  non-breaking updates to minor and patch versions while preventing breaking
-  changes from new major versions. This approach is critical for ensuring build
-  stability and reproducibility.
-- **Prohibit unstable version specifiers.** The use of wildcard (`*`) or
-  open-ended inequality (`>=`) version requirements is strictly forbidden, as
-  they introduce unacceptable risk and unpredictability. Tilde requirements
-  (`~`) should only be used where a dependency must be locked to patch-level
-  updates for a specific, documented reason.
-
-### Error Handling (Rust)
-
-- **Prefer semantic error enums**. Derive `std::error::Error` (via the
-  `thiserror` crate) for any condition the caller might inspect, retry, or map
-  to an HTTP status.
-- **Use an *opaque* error only at the app boundary**. Use `eyre::Report` for
-  human-readable logs; these should not be exposed in public APIs.
-- **Never export the opaque type from a library**. Convert to domain enums at
-  API boundaries, and to `eyre` only in the main `main()` entrypoint or
-  top-level async task.
-
-## Markdown Guidance
+## Markdown guidance
 
 - Validate Markdown files using `make markdownlint`.
-- Run `make fmt` after any documentation changes to format all Markdown
-  files and fix table markup.
-- Validate Mermaid diagrams in Markdown files by running `make nixie`.
-- Markdown paragraphs and bullet points must be wrapped at 80 columns.
-- Code blocks must be wrapped at 120 columns.
-- Tables and headings must not be wrapped.
+- Run `make fmt` after documentation changes to format Markdown and fix table
+  markup.
+- Validate Mermaid diagrams in Markdown by running `make nixie`.
+- Markdown paragraphs and bullet points should be wrapped at 80 columns.
+- Code blocks should be wrapped at 120 columns.
+- Tables and headings should not be wrapped.
 - Use dashes (`-`) for list bullets.
-- Use GitHub-flavoured Markdown footnotes (`[^1]`) for references and
-  footnotes.
+- Use GitHub-flavoured Markdown footnotes (`[^1]`) for references and footnotes.
 
-## TypeScript Frontend Guidance (Client‑Side Only)
+## Project documentation
 
-**Stack**: Bun · Biome · Vite (esbuild under the hood for dev) · React ·
-Tailwind CSS v4 · daisyUI v5 · TanStack (Query/Router/Table).
+Record design decisions in the design document. Where a decision is substantive,
+record it in an ADR document following the documentation style guide, then
+reference that ADR from the design document.
 
-This document mirrors the intent of the Rust guidance—strictness, clarity, and
-predictable builds—translated into idiomatic, modern TypeScript and a
-browser‑only runtime.
+Update `docs/users-guide.md` for any change to application behaviour or user
+interface that users should know about. Document internally facing interfaces
+or practices in the relevant component architecture document. Document internally
+facing conventions or practices in `docs/developers-guide.md`.
 
-### Toolchain & Project Shape
+## Python development guidelines
 
-- **ESM‑only**: Source and build outputs are ES Modules. No CommonJS. Configure
-  Vite accordingly; package publishes only ESM (for libraries) or static assets
-  (for apps).
-- **Runtime targets**: Target modern evergreen browsers. Use `browserslist` to
-  define the support matrix; drop legacy where feasible. Prefer native Web APIs
-  (Fetch, URL, AbortController, Streams).
-- **Bun as runner**: Use Bun for scripts and dev server invocations. Prefer
-  `bun run` for scripts and `bunx` for one‑off CLIs.
-- **Workspaces (optional)**: If a monorepo, use `pnpm` or Bun workspaces with
-  clear package boundaries and TS project references.
-- **Vite**: Default bundler for dev/build. Enable code‑splitting, prefetch
-  hints, and asset hashing. Esbuild handles TS/JS transforms in dev; production
-  uses Rollup via Vite.
-- **Project scripts (Bun)**:
-- `fmt`: `biome format --write .`
-- `lint`: `biome ci . && tsc -p tsconfig.json --noEmit`
-- `typecheck`: `tsc -p tsconfig.json --noEmit`
-- `dev`: `vite`
-- `build`: `vite build`
-- `preview`: `vite preview`
-- `test`: `vitest run --coverage`
-- `audit`: `bun x pnpm@latest audit`
-- `audit:snyk`: `bun x snyk test`
-- Note: `audit` requires a committed `bun.lock`; `audit:snyk` requires
-      installed dependencies—run `bun install` before invoking it.
+For Python development, refer to the detailed guidelines in the `.rules/`
+directory:
 
-  In this repository, Biome is orchestrated via the Makefile along with Rust
-  tooling. Prefer these entry points locally and in CI:
+- [Python code style guidelines](.rules/python-00.md) - Core Python 3.13 style
+  conventions.
+- [Python context managers](.rules/python-context-managers.md) - Best practices
+  for context managers.
+- [Python exceptions and logging][python-exceptions] -
+  Raising and handling exceptions and logging.
+- [Python generators](.rules/python-generators.md) - Generator and iterator
+  patterns.
+- [Python project configuration](.rules/python-pyproject.md) -
+  `pyproject.toml` and packaging.
+- [Python return patterns](.rules/python-return.md) - Function return
+  conventions.
+- [Python typing](.rules/python-typing.md) - Type annotation best practices.
 
-  ```bash
-  # Format all code (Rust + JS/TS via Biome)
-  make fmt
+[python-exceptions]: .rules/python-exception-design-raising-handling-and-logging.md
 
-  # Lint all code (Clippy + Biome CI)
-  make lint
+Additional docs:
 
-  # Check formatting only (no writes)
-  make check-fmt
-  ```
-
-  You can also call Biome directly through Bun when needed:
-
-  ```bash
-  bun x biome format --write
-  bun x biome ci frontend-pwa packages/tokens/src packages/tokens/build packages/types/src
-  ```
-
-### Compiler Configuration (Make It Sharp)
-
-Use a strict `tsconfig.json` suitable for browser builds:
-
-- `strict: true`
-- `noUncheckedIndexedAccess: true`
-- `exactOptionalPropertyTypes: true`
-- `noImplicitOverride: true`
-- `useUnknownInCatchVariables: true`
-- `noPropertyAccessFromIndexSignature: true`
-- `verbatimModuleSyntax: true` (and use `import type` / `export type`)
-- `moduleResolution: "bundler"` (lets Vite resolve modern packages)
-- `lib`: include only what you need (e.g., `dom`, `dom.iterable`, `es2022`)
-- Do not emit from `tsc` in app packages (`noEmit: true`); Vite handles
-  emission.
-
-**Order**: Place JSDoc comments above declarations and above any decorators.
-Keep docs close to code.
-
-### Code Style & Structure
-
-- **Immutability first**: Prefer `const`, `readonly`, and `Readonly<T>`; avoid
-  mutating props or inputs.
-- **Functions**: Extract meaningfully named helpers when a function grows long.
-  Keep trivial functions on one line when readability allows:
-
-  ```ts
-  export const mkId = (n: number): Id => new Id(n);
-  ```
-
-- **Parameters**: Group related parameters into typed objects or builders;
-  avoid long positional lists.
-- **Predicates**: When `if/else` grows beyond two branches, extract a predicate
-  function or use a lookup table. Ensure exhaustive `switch` with a `never`
-  guard helper.
-- **Docs**: Every module begins with a `/** @file … */` block describing
-  purpose, responsibilities, and usage.
-- **Public APIs (for libs)**: Export explicit entry points via `package.json`
-  `exports`/`types`. Avoid wildcard re‑exports that mask breaking changes.
-
-### Runtime Validation & Types
-
-- **Runtime schemas**: Validate I/O boundaries (network responses, localStorage
-  payloads, URL params) with `zod`/`valibot`. Generate TS types from schemas or
-  derive schemas from types, but add a CI check to keep them in sync.
-- **Nominal branding**: Use branded types for IDs/tokens to avoid accidental
-    mixing:
-
-    ```ts
-    type UserId = string & { readonly brand: "UserId" };
-    ```
-
-- **Cancellation**: Accept `AbortSignal` for any async that can hang (fetches,
-  long UI work). Wire signals through TanStack Query via `signal` in fetchers.
-- **Time & RNG**: Centralize `now()` and `rng()` adapters; never call
-  `Date.now()` or `Math.random()` directly in business logic.
-
-### Error Handling (Frontend)
-
-- **Semantic errors**: Use discriminated unions for recoverable conditions
-  callers might branch on (e.g.,
-  `{ type: "rate_limited"; retryAfterMs: number }`).
-- **Exceptions**: Reserve `Error` subclasses for exceptional paths
-  (framework/edge). Always attach a `cause` where available.
-- **App boundary**: Map domain errors to user‑facing messages in UI components
-  only. Never leak raw stack traces to the DOM or logs shipped to analytics.
-
-### Testing (Unit, Behavioural, and UI)
-
-- **Runner**: Vitest with `jsdom` (or `happy-dom`) for component tests. Keep
-  tests parallel‑safe and deterministic.
-- **Fixtures**: Use factories/builders for component props and server
-  responses. Avoid ad hoc object literals in tests.
-- **Parameterised tests**: Prefer table‑driven cases via `test.each` /
-  `it.each`.
-- **Mocking**: Use `vi.mock` for module boundaries. Inject adapters for
-  env/time/storage/fetch; do not monkey‑patch globals in product code.
-- **Fake timers**: `vi.useFakeTimers()` for time‑based logic; restore after
-  each test.
-- **Snapshots**: Keep deterministic by sorting keys and fixing seeds. Limit
-  snapshot scope to stable UI fragments.
-- **E2E (optional)**: Playwright for flows critical to revenue or safety; keep
-  the set minimal and fast.
-
-### Dependency Management (Frontend)
-
-- **Version policy**: Use caret requirements (`^x.y.z`) for all direct
-  dependencies. Avoid `*`, `>=` or tag aliases like `latest`. Use tilde
-  (`~x.y.z`) only with a documented justification.
-- **Lockfile**: Commit `bun.lock`. Recreate on major tool upgrades; keep
-  `bun.lockb` ignored.
-- **Audit**: Run `bun run audit` locally and in automation. Track exceptions
-  with explicit expiry dates.
-- **Culling**: Prefer small, actively maintained packages. Remove unmaintained
-  or risky dependencies swiftly.
-
-### Linting & Formatting
-
-- **Biome**: One tool for format + lint. Configure with strict rules: disallow
-  `any`, no non‑null `!`, forbid `@ts-ignore` in favour of `@ts-expect-error`
-  (with a reason).
-  - In this repo: use `make fmt`, `make lint`, and `make check-fmt`.
-  - Biome respects `.biomeignore` and VCS ignore files; large build trees like
-    any `target/` directory are excluded.
-- **Type‑checking**: `tsc --noEmit` as part of `lint` to catch type errors
-  early.
-- **Import hygiene**: Enforce sorted, grouped imports; no unused or extraneous
-  dependencies.
-
-### Performance & Correctness
-
-- **Code‑splitting**: Use Vite’s dynamic `import()` to split routes and heavy
-  feature bundles.
-- **TanStack Query**: Use stale‑time, cache‑time, and prefetch strategically.
-  Avoid `refetchOnWindowFocus` unless the data truly needs it.
-- **Async**: Avoid `await` inside loops; batch with `Promise.allSettled`. Use
-  `async` iterables/streams for large data.
-- **Rendering**: Enable React StrictMode in dev; memoise expensive components;
-  prefer derived data via selectors.
-- **Stability**: Keep JSON stable (deterministic key order) for snapshots and
-  client‑side caches.
-
-### Security & Privacy (Client‑Side)
-
-- **CSP**: Ship a Content Security Policy where deployment allows it. For SPA
-  hosting, prefer hashed scripts and forbid `eval`/`new Function`.
-- **Trusted Types**: If embedding third‑party HTML, gate through a sanitiser
-  and (where supported) Trusted Types policies.
-- **Secrets**: Never hard‑code secrets in client bundles. Use public,
-  least‑privilege tokens only; treat everything as public.
-- **Origin hygiene**: Centralize fetch base URLs; validate response schemas;
-  handle opaque redirects.
-- **Storage**: Encrypt sensitive data server‑side; treat client storage as
-  untrusted. Namespaced keys; versioned payloads; schema‑validated reads.
-
-### React, Tailwind 4, and daisyUI 5
-
-- **Tailwind v4**: Use the new config conventions and JIT‑only pipeline.
-  Co‑locate `@apply` in component‑scoped CSS when it improves clarity; prefer
-  utilities otherwise. Remove unused utilities via content‑aware purge in
-  production.
-- **daisyUI v5**: Keep theme tokens in sync with Tailwind config. Extend rather
-  than override where possible; avoid deep custom CSS that fights component
-  variables.
-- **Design tokens**: Define a single source of truth (CSS variables) for
-  colour, spacing, radius, and typography. Expose tokens to Tailwind via
-  `theme.extend` to keep utilities aligned with design.
-- **A11y**: Use semantic HTML first. Prefer daisyUI components only where they
-  don’t harm semantics. Audit focus states and colour contrast with automated
-  checks.
-- **Radix UI**: Build behaviour with Radix primitives and layer DaisyUI/Tailwind
-  classes for presentation.
-- **Purity**: Export view components as pure functions with props treated as
-  read‑only. Move state, effects, and translations into dedicated `use*` hooks.
-- **Component tests**: Use React Testing Library under Vitest for rendering and
-  user‑centric assertions.
-
-### TanStack Usage Notes
-
-- **Query**: Co‑locate query keys and fetchers; prefer stable keys; use
-  `select` to project server data for components. Wire `AbortSignal` to
-  fetches. Use `retry` policies appropriate to the endpoint.
-- **Router** (if used): Code‑split per route; prefetch data on navigation where
-  it improves perceived performance. Handle not‑found/unauthorised with typed
-  loaders.
-- **Table** (if used): Keep row models pure; virtualise for large sets; memoise
-  column defs.
-- **State**: Encapsulate server state with TanStack Query and model complex
-  local state with reducers or state machines inside custom hooks.
-
-### Internationalization
-
-- **Setup**: Initialize `react-i18next` with `i18next-http-backend` and
-  `i18next-browser-languagedetector`; set `fallbackLng: 'en'`.
-- **Translations**: Store locale files under `public/locales/<lang>/<ns>.json`
-  and load strings by namespace.
-- **Hooks**: Call `useTranslation` within logic hooks and pass all translated
-  strings to view components via props.
-
-### Testing (Vitest & Playwright)
-
-- **Vitest config**: Use the `jsdom` environment, include `tests/setup.ts`, and
-  prioritize running `**/*.a11y.test.ts` in a dedicated Vitest invocation
-  before the rest of the suite.
-- **axe integration**: Import `vitest-axe/extend-expect` in `tests/setup.ts` and
-  list this file in `tsconfig.json` so the matcher types load.
-- **Rule gaps**: Disable `color-contrast` and `scrollable-region-focusable`
-  rules in Vitest (jsdom limits these checks); verify them in Playwright.
-- **Playwright**: Run `@axe-core/playwright` scans, exercise keyboard
-  navigation, capture accessibility tree snapshots, and emulate locales to test
-  translations.
-
-### Observability (Frontend)
-
-- **Structured logs**: Gate debug logs behind a flag (`?debug=1` or build‑time
-  define). Use a small logger that emits structured objects in dev and terse
-  strings in prod.
-- **Metrics**: Basic RUM—navigation timings, error counts, and SPA route
-  transitions. Sample aggressively to preserve privacy and cost.
-- **Feature flags**: Centralize flags; keep a kill‑switch for risky features;
-  document fallback behaviour.
-
-### Documentation & Examples
-
-- **Literate examples**: Keep small TS snippets in docs that compile during
-  builds (typecheck only). Prefer examples that mirror production patterns
-  (schema‑validated fetchers, `AbortSignal`, TanStack Query hooks).
-- **Module headers**: Each file begins with `/** @file … */` stating purpose,
-  invariants, and cross‑links to related modules.
-- **Error semantics**: Document user‑visible failure modes next to components
-  and hooks that surface them.
-
-### Release Discipline
-
-- **Conventional Commits + Changesets** for versioning (libraries) and change
-  logs.
-- **SemVer**: Honour breaking changes with a major bump; avoid sneaking them in
-  via dependency updates.
-- **Reproducibility**: Pin tool versions via `.tool-versions`/`.bun-version`
-  (or document required Bun/Node versions). Rebuild the lockfile on major
-  upgrades.
-- **Bundle sanity**: Maintain a bundle size budget; track regressions; document
-  acceptable variances when adding large features.
-
-### Quick Checklist (Before Commit)
-
-- `bun run fmt`, `bun run lint`, `bun run test` all clean; no Biome warnings;
-  no TypeScript errors; coverage thresholds hold.
-- `bun run audit` passes or has justified, time‑boxed exceptions.
-- No `any`, no `@ts-ignore`; use `@ts-expect-error` only with a reason.
-- All async APIs accept `AbortSignal` where relevant; all fetchers validated
-  against runtime schemas.
-- Module headers present; public exports documented; design tokens consistent
-  across Tailwind/daisyUI.
+- [Scripting standards](docs/scripting-standards.md) - Guidance for writing
+  robust scripts, including secure command execution via `cuprum`, catalogue
+  allowlisting, and command mocking patterns with `cmd-mox`.
+- Before adding or updating helper scripts, read the scripting standards guide
+  and follow its `Cyclopts`, `cuprum`, `pathlib`, and `cmd-mox` conventions.
 
 ## Additional tooling
 
 The following tooling is available in this environment:
 
-- `mbake` – A Makefile validator. Run using `mbake validate Makefile`.
-- `strace` – Traces system calls and signals made by a process; useful for
+- `mbake` — A Makefile validator. Run using `mbake validate Makefile`.
+- `strace` — Traces system calls and signals made by a process; useful for
   debugging runtime behaviour and syscalls.
-- `gdb` – The GNU Debugger, for inspecting and controlling programs as they
+- `gdb` — The GNU Debugger, for inspecting and controlling programs as they
   execute (or post-mortem via core dumps).
-- `ripgrep` – Fast, recursive text search tool (`grep` alternative) that
+- `ripgrep` — Fast, recursive text search tool (`grep` alternative) that
   respects `.gitignore` files.
-- `ltrace` – Traces calls to dynamic library functions made by a process.
-- `valgrind` – Suite for detecting memory leaks, profiling, and debugging
+- `ltrace` — Traces calls to dynamic library functions made by a process.
+- `valgrind` — Suite for detecting memory leaks, profiling, and debugging
   low-level memory errors.
-- `bpftrace` – High-level tracing tool for eBPF, using a custom scripting
+- `bpftrace` — High-level tracing tool for eBPF, using a custom scripting
   language for kernel and application tracing.
-- `lsof` – Lists open files and the processes using them.
-- `htop` – Interactive process viewer (visual upgrade to `top`).
-- `iotop` – Displays and monitors I/O usage by processes.
-- `ncdu` – NCurses-based disk usage viewer for finding large files/folders.
-- `tree` – Displays directory structure as a tree.
-- `bat` – `cat` clone with syntax highlighting, Git integration, and paging.
-- `delta` – Syntax-highlighted pager for Git and diff output.
-- `tcpdump` – Captures and analyses network traffic at the packet level.
-- `nmap` – Network scanner for host discovery, port scanning, and service
+- `lsof` — Lists open files and the processes using them.
+- `htop` — Interactive process viewer (visual upgrade to `top`).
+- `iotop` — Displays and monitors I/O usage by processes.
+- `ncdu` — NCurses-based disk usage viewer for finding large files/folders.
+- `tree` — Displays directory structure as a tree.
+- `bat` — `cat` clone with syntax highlighting, Git integration, and paging.
+- `delta` — Syntax-highlighted pager for Git and diff output.
+- `tcpdump` — Captures and analyses network traffic at the packet level.
+- `nmap` — Network scanner for host discovery, port scanning, and service
   identification.
-- `lldb` – LLVM debugger, alternative to `gdb`.
-- `eza` – Modern `ls` replacement with more features and better defaults.
-- `fzf` – Interactive fuzzy finder for selecting files, commands, etc.
-- `hyperfine` – Command-line benchmarking tool with statistical output.
-- `shellcheck` – Linter for shell scripts, identifying errors and bad practices.
-- `fd` – Fast, user-friendly `find` alternative with sensible defaults.
-- `checkmake` – Linter for `Makefile`s, ensuring they follow best practices and
-  conventions.
-- `srgn` – [Structural grep](https://github.com/alexpovel/srgn), searches code
-  and enables editing by syntax tree patterns.
-- `difft` **(Difftastic)** – Semantic diff tool that compares code structure
-  rather than just text differences.
+- `lldb` — LLVM debugger, alternative to `gdb`.
+- `eza` — Modern `ls` replacement with more features and better defaults.
+- `fzf` — Interactive fuzzy finder for selecting files and commands.
+- `hyperfine` — Command-line benchmarking tool with statistical output.
+- `shellcheck` — Linter for shell scripts.
+- `fd` — Fast user-friendly `find` alternative with sensible defaults.
+- `checkmake` — Linter for `Makefile`s, ensuring best practices.
+- `srgn` — Structural grep and syntax-tree pattern editing.
+- `difft` **(Difftastic)** — Semantic diff tool that compares code structure.
 
-## Python Development Guidelines
-
-For Python development, refer to the detailed guidelines in the `.rules/`
-directory:
-
-- [Python Code Style Guidelines](.rules/python-00.md) - Core Python 3.13 style
-  conventions
-- [Python Context Managers](.rules/python-context-managers.md) - Best practices
-  for context managers
-- [Python Exceptions and
-  Logging(.rules/python-exception-design-raising-handling-and-logging.md) -
-  Throwing, catching and logging exceptions.
-- [Python Generators](.rules/python-generators.md) - Generator and iterator
-  patterns
-- [Python Project Configuration](.rules/python-pyproject.md) - pyproject.toml
-  and packaging
-- [Python Return Patterns](.rules/python-return.md) - Function return
-  conventions
-- [Python Typing](.rules/python-typing.md) - Type annotation best practices
-
-Additional docs:
-
-- [Scripting Standards](docs/scripting-standards.md) - Guidance for writing
-  robust scripts
-
-## Key Takeaway
+## Key takeaway
 
 These practices help maintain a high-quality codebase and facilitate
 collaboration.

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -122,6 +122,15 @@
 
 - [Documentation style guide](documentation-style-guide.md) – conventions for
   clear, consistent docs. _Audience: all contributors._
+- [PWA assistant instructions](../frontend-pwa/AGENTS.md) – scoped TypeScript,
+  JavaScript, testing, and quality-gate guidance for the browser PWA.
+  _Audience: frontend developers and automation agents._
+- [Package assistant instructions](../packages/AGENTS.md) – scoped TypeScript
+  package boundaries, testing, and quality-gate guidance for shared packages.
+  _Audience: package maintainers and automation agents._
+- [Security assistant instructions](../security/AGENTS.md) – scoped JavaScript
+  audit policy, validation, and security automation guidance. _Audience:
+  security automation maintainers and automation agents._
 - [Scripting standards](scripting-standards.md) – Python-first automation
   guidance covering `uv`, `plumbum`, and testing expectations. _Audience:
   automation authors._

--- a/docs/contents.md
+++ b/docs/contents.md
@@ -1,4 +1,7 @@
-# Documentation index
+# Documentation contents
+
+- [Documentation contents](contents.md) – the canonical index for project
+  documentation. _Audience: all readers._
 
 ## Project architecture
 
@@ -6,6 +9,8 @@
   blueprint and product vision. _Audience: stakeholders and all contributors._
 - [Repository design guide](repository-structure.md) – explains repository
   layout and request flow. _Audience: new contributors._
+- [Repository layout](repository-layout.md) – maps the major repository paths
+  and their responsibilities. _Audience: new contributors and maintainers._
 - [Wildside backend: functional design specification](wildside-backend-design.md)
   – outlines backend components and tasks. _Audience: backend developers._
 - [Wildside backend architecture](wildside-backend-architecture.md) – hexagonal

--- a/docs/documentation-style-guide.md
+++ b/docs/documentation-style-guide.md
@@ -1,32 +1,36 @@
 # Documentation style guide
 
-This guide outlines conventions for authoring documentation for Lille. Apply
-these rules to keep the documentation clear and consistent for developers.
+This guide outlines conventions for authoring documentation for software
+created by df12 Productions. Apply these rules to keep documentation clear,
+consistent, and easy to maintain across projects.
 
 ## Spelling
 
 - Use British English based on the
-  [Oxford English Dictionary](https://public.oed.com/) (en-GB-oxendict):
+  [Oxford English Dictionary](https://public.oed.com/) locale `en-GB-oxendict`,
+  which denotes English for the Great Britain market in the Oxford style:
   - suffix -ize in words like _realize_ and _organization_ instead of
      -ise endings,
   - suffix ‑lyse in words not traced to the Greek ‑izo, ‑izein suffixes,
      such as _analyse_, _paralyse_ and _catalyse_,
   - suffix -our in words such as _colour_, _behaviour_ and _neighbour_,
-  - suffix -re in words such as _calibre_, _centre_ and fibre,
+  - suffix -re in words such as _calibre_, _centre_ and _fibre_,
   - double "l" in words such as _cancelled_, _counsellor_ and _cruellest_,
   - maintain the "e" in words such as _likeable_, _liveable_ and _rateable_,
   - suffix -ogue in words such as _analogue_ and _catalogue_,
   - and so forth.
-- The word **"outwith"** is acceptable.
-- Keep US spelling when used in an API, for example `color`.
-- The project licence file is spelled `LICENSE` for community consistency.
+- The words **"outwith"** and **"caveat"** are acceptable.
+- Keep United States (US) spelling when used in an API, for example, `color`.
+- The project uses the filename `LICENSE` for community consistency.
 
 ## Punctuation and grammar
 
 - Use the Oxford comma: "ships, planes, and hovercraft" where it aids
   comprehension.
-- Company names are treated as collective nouns: "Lille Industries are
-  expanding".
+- Company names are treated as collective nouns: "df12 Productions are
+  releasing an update".
+- Avoid first and second person personal pronouns outside the `README.md`
+  file.
 
 ## Headings
 
@@ -37,7 +41,7 @@ these rules to keep the documentation clear and consistent for developers.
 ## Markdown rules
 
 - Follow [markdownlint](https://github.com/DavidAnson/markdownlint)
-  recommendations[^markdownlint].
+  recommendations[^1].
 - Provide code blocks and lists using standard Markdown syntax.
 - Always provide a language identifier for fenced code blocks; use `plaintext`
   for non-code text.
@@ -56,146 +60,299 @@ these rules to keep the documentation clear and consistent for developers.
 - Wrap paragraphs at 80 columns.
 - Wrap code at 120 columns.
 - Do not wrap tables.
-- Use footnotes referenced with `[^label]`.
+- Use GitHub-flavoured numeric footnotes referenced as `[^1]`.
+- Footnotes must be numbered in order of appearance in the document.
+- Caption every table, and caption every diagram.
 
-## Example snippet
+## Standard document types
 
-```rust
-/// A simple function demonstrating documentation style.
-fn add(a: i32, b: i32) -> i32 {
-    a + b
-}
-```
+Repositories that adopt this documentation style should keep a small set of
+high-value documents with clearly separated audiences and responsibilities.
+These document types are complementary: the contents file helps readers find
+material, the user's guide explains how to use the project, the developer's
+guide explains how to work on the project, the design document explains why the
+system is shaped the way it is, and the repository layout document explains
+where important things live. For discoverability, use canonical filenames
+unless a stronger repository-specific constraint applies. A minimal canonical
+set looks like
+`docs/{contents,users-guide,developers-guide,repository-layout}.md` plus a
+primary design document under `docs/*-design.md`, for example
+`docs/theoremc-design.md` or `docs/query-planner-design.md`.
 
-## API doc comments (Rust)
+### Contents file
 
-Use doc comments to document public APIs. Keep them consistent with the
-contents of the manual.
+Use a dedicated contents file, typically `docs/contents.md`, as the index for
+the documentation set.
 
-- Begin each block with `///`.
-- Keep the summary line short, followed by further detail.
-- Explicitly document all parameters with `# Parameters`, describing each
-  argument.
-- Document the return value with `# Returns`.
-- Document any panics or errors with `# Panics` or `# Errors` as appropriate.
-- Place examples under `# Examples` and mark the code block with `no_run` so
-  they do not execute during documentation tests.
-- Put function attributes after the doc comment.
+- Make the document title explicit, for example `# Documentation contents`.
+- Begin with the contents file linking to itself so readers can confirm they
+  are at the index.
+- List each document exactly once with an inline link and a short descriptive
+  phrase explaining why someone would open it.
+- Group related material together, such as decision records, reference
+  documents, guides, and plan directories.
+- Keep the descriptions audience-focused. Explain the purpose of the document,
+  not merely its filename.
+- Prefer stable ordering so repeated readers can scan predictably. Grouping by
+  topic is usually better than strict alphabetic ordering.
+- When listing a directory, add one nested level only where it materially
+  improves navigation, for example to enumerate execution plans beneath an
+  `execplans/` entry.
+- Update the contents file whenever a document is added, renamed, or removed.
 
-```rust
-/// Returns the sum of `a` and `b`.
-///
-/// # Parameters
-/// - `a`: The first integer to add.
-/// - `b`: The second integer to add.
-///
-/// # Returns
-/// The sum of `a` and `b`.
-///
-/// # Examples
-///
-/// ```rust,no_run
-/// assert_eq!(add(2, 3), 5);
-/// ```
-#[inline]
-pub fn add(a: i32, b: i32) -> i32 {
-    a + b
-}
-```
+### User's guide
 
-## Diagrams and images
+Use the user's guide, canonically `docs/users-guide.md`, for readers who need
+to apply the project rather than modify its internals. In a library, this means
+consumers of the application programming interface (API). In an application,
+this means operators, end users, or integrators.
 
-Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
-When embedding figures, use `![alt text](path/to/image)` and provide brief alt
-text describing the content. Add a short description before each Mermaid
-diagram so screen readers can understand it.
+- Open with one short paragraph that states the audience and scope.
+- Organize the guide around user-facing tasks, concepts, and guarantees rather
+  than internal module boundaries.
+- Introduce the primary workflow early, with a minimal working example that a
+  reader can adapt immediately.
+- Put public-facing reference material here when users need it to succeed, for
+  example CLI usage, configuration keys, file-format rules, or API surface
+  summaries.
+- Present rules, constraints, defaults, and error behaviour near the feature
+  they affect, rather than scattering them across the document.
+- Use tables where they clarify field sets, command options, or compatibility
+  matrices.
+- Include concrete examples in code or data form when describing formats,
+  schemas, or command usage.
+- Higher-level user workflows belong here, for example "load a document",
+  "configure the service", or "interpret diagnostics".
+- Link to design documents or maintainer references when deeper rationale would
+  otherwise overload the guide.
+- Exclude maintainer-only concerns such as internal layering debates, future
+  refactor plans, or enforcement tooling unless they directly affect users.
 
-For screen readers: The following flowchart outlines the documentation workflow.
+### Developer's guide
 
-```mermaid
-flowchart TD
-    A[Start] --> B[Draft]
-    B --> C[Review]
-    C --> D[Merge]
-```
+Use the developer's guide, canonically `docs/developers-guide.md`, for
+maintainers and contributors. Treat this as the operating manual for working on
+the existing system, not as the place for the project's primary design document.
 
-## Roadmap Task Writing Guidelines
+- Open with one short paragraph that states the audience and the operational
+  scope of the guide.
+- Link early to the design document, repository layout document, accepted
+  decision records, and other normative references that explain architecture or
+  rationale in depth.
+- Put maintainer-facing implementation guidance here, for example build, test,
+  lint, release, debugging, extension, and contribution workflows.
+- Use numbered sections for long-form technical documents to improve
+  cross-referencing in reviews and follow-up discussions.
+- Separate normative rules from informative explanation. Mark source-of-truth
+  sections clearly.
+- Include compact interface maps or workflow diagrams where they materially
+  improve implementation guidance.
+- Keep subsystem descriptions focused on current responsibilities,
+  integration points, and operational expectations. Put design rationale, major
+  trade-offs, and proposed architecture in design documents instead.
+- Do not embed repository-layout guidance here. The canonical location for
+  file-tree and path-responsibility documentation is
+  `docs/repository-layout.md`.
+- Keep the document synchronized with decision records, roadmap items, and the
+  codebase. A stale developer's guide is worse than a shorter one.
 
-When documenting development roadmap items, write them so that they are
-achievable, measurable, and structured. This ensures the roadmap functions as a
-practical planning tool rather than a vague wishlist. Do not commit to
-timeframes in the roadmap. Development effort should be roughly consistent from
-task to task.
+### Design document, ADR, and RFC
 
-### Principles for Roadmap Tasks
+Use these document types for different jobs. Do not collapse them into one
+catch-all "design note".
 
-- Define outcomes, not intentions: Phrase tasks in terms of the capability
-  delivered (e.g. “Implement role-based access control for API endpoints”), not
-  aspirations like “Improve security”.
-- Quantify completion criteria: Attach measurable finish lines (e.g. “90%
-  test coverage for new modules”, “response times under 200ms”, “all endpoints
-  migrated”).
-- Break into atomic increments: Ensure tasks can be completed in weeks, not
-  quarters. Large goals should be decomposed into clear, deliverable units.
-- Tie to dependencies and sequencing: Document prerequisites so tasks can be
-  scheduled realistically (e.g. “Introduce central logging service” before “Add
-  error dashboards”).
-- Bound scope explicitly: Note both in-scope and out-of-scope elements (e.g.
-  “Build analytics dashboard (excluding churn prediction)”).
+- A **design document** explains the shape of a system or subsystem: its
+  architecture, constraints, data flow, rationale, and intended evolution. It
+  is usually a living document and may describe the current implementation, the
+  target implementation, or both.
+- An **Architecture Decision Record (ADR)** captures one accepted decision. It
+  should be narrow, stable, and explicit about context, decision, consequences,
+  and status. Use an ADR when the important thing to preserve is the outcome,
+  not the full exploratory discussion that led to it.
+- A **Request for Comments (RFC)** proposes a change before acceptance. It is
+  the right format for changes that need reviewing, alternatives analysis,
+  migration planning, or cross-team discussion. An RFC may later be accepted,
+  rejected, superseded, or distilled into one or more ADRs.
 
-### Hierarchy of Scope
+In short: use a design document to explain the system, an ADR to record a
+decision, and an RFC to propose a change.
 
-Roadmaps should be expressed in three layers of scope to maintain clarity and
-navigability:
+### Design document
 
-- Phases (strategic milestones) – Broad outcome-driven stages that represent
-  significant capability shifts. Why the work matters.
-- Steps (epics / workstreams) – Mid-sized clusters of related tasks grouped
-  under a phase. What will be built.
-- Tasks (execution units) – Small, measurable pieces of work with clear
-  acceptance criteria. How it gets done.
+Use a dedicated design document, conventionally named
+`docs/<product-or-topic>-design.md`, to explain the architecture, constraints,
+rationale, and intended evolution of a system or subsystem. This document is
+the correct location for design intent; that material must not be buried in the
+user's guide or developer's guide.
 
-### Roadmap formatting conventions
+- Start with a concise front matter section that states status, scope, primary
+  audience, and the decision records or other documents that take precedence.
+- Open the main body with the problem statement, product thesis, or design goal
+  before describing the solution. Readers should understand the problem the
+  design is solving before they inspect the structure.
+- State the non-negotiable constraints explicitly. These are the rules later
+  sections assume rather than re-justify.
+- Separate normative definitions from informative explanation. If another
+  document is the source of truth for a schema, protocol, or naming rule, say
+  so plainly and link to it.
+- Describe the high-level architecture before diving into file-level or
+  module-level details. A reader should understand the major subsystems,
+  boundaries, and data flow early.
+- Use numbered sections for substantial designs so review comments, follow-up
+  changes, and decision records can cite stable anchors.
+- Include diagrams, tables, or pipeline sketches when they materially improve
+  comprehension, especially for flows, layered boundaries, or generated
+  artefacts.
+- Record risks, trade-offs, rejected alternatives, and future extension points.
+  A design document should explain not only what the system looks like, but why
+  it takes that shape.
+- Keep examples concrete and representative. Prefer one realistic example that
+  exercises the important structure over several toy fragments.
+- Keep the design document synchronized with accepted decision records and the
+  implemented system. If the code or the governing decision changes, update the
+  design or mark the divergence explicitly.
 
-- **Dotted numbering:** Number phases, steps, and headline tasks using dotted
-  notation:
-  - Phases: 1, 2, 3, …
-  - Steps: 1.1, 1.2, 1.3, …
-  - Headline tasks: 1.1.1, 1.1.2, 1.1.3, …
-- **Checkboxes:** Precede task and sub-task items with a GitHub-Flavoured
-  Markdown (GFM) checkbox (`[ ]`) to track completion status.
-- **Dependencies:** Note non-linear dependencies explicitly. Where a task
-  depends on another task outside its immediate sequence, cite the dependency
-  using dotted notation (e.g. "Requires 2.3.1").
-- **Success criteria:** Include explicit success criteria only where not
-  immediately obvious from the task description.
-- **Design document citations:** Where applicable, cite the relevant design
-  document section for each task (e.g. "See design-doc.md §3.2").
+### Request for Comments (RFC)
 
-### Roadmap example
+Use RFCs for proposed changes that need technical review before they become
+binding. Store them under `docs/rfcs/`.
+
+### RFC naming convention
+
+Name RFC files using the pattern `0001-short-topic.md`, where `0001` is a
+zero-padded sequence number. Place RFCs in the `docs/rfcs/` directory.
+
+- Number RFCs sequentially in allocation order rather than by date.
+- Do not renumber existing RFCs after publication. Gaps are acceptable when
+  numbers are reserved, drafted on another branch, or intentionally skipped.
+
+### RFC required sections
+
+Every RFC must include the following sections in order:
+
+- **Title:** Start the document with a numbered title in this form:
+  `# RFC 0001: Concise subject`.
+- **Preamble:** Follow the title with a dedicated `## Preamble` section.
+- **RFC number:** Include the allocated sequence number.
+- **Status:** State the document status. Use `Proposed` unless a later process
+  explicitly promotes, rejects, withdraws, or supersedes the RFC.
+- **Created:** The date the RFC was created (format: YYYY-MM-DD).
+- **Opening section:** Keep the first substantive section near the top.
+  `## Summary`, `## Executive summary`, or `## Problem` are all acceptable if
+  used consistently within the document.
+
+### RFC conditional sections
+
+Include these sections as appropriate to the scope and complexity of the
+proposal:
+
+- **Problem:** Describe the deficiency, risk, or missing capability that
+  motivates the RFC.
+- **Current State:** Explain the relevant current behaviour or architecture when
+  the proposal depends on existing constraints.
+- **Goals and Non-goals:** Clarify what the RFC intends to change and what it
+  deliberately leaves out of scope.
+- **Proposed Design / Proposed Change:** Describe the recommended design with
+  enough detail to support implementation review.
+- **Requirements:** Separate functional, technical, safety, or operational
+  requirements when the proposal has multiple kinds of constraints.
+- **Compatibility and Migration:** Explain rollout expectations, compatibility
+  impact, and migration sequencing when adoption is not trivial.
+- **Alternatives Considered:** Record rejected options and the reasons they
+  were not chosen.
+- **Open Questions / Outstanding Decisions:** Identify unresolved issues that
+  still need reviewing before the proposal can be treated as settled.
+- **Recommendation:** End with a clear statement of the preferred direction
+  when the preceding analysis presents multiple viable choices.
+
+### RFC formatting guidance
+
+- Use second-level headings (`##`) for major sections.
+- Use third-level headings (`###`) for subsections such as phases, options,
+  requirements groupings, or rollout stages.
+- Use numbered major sections for long RFCs when stable review anchors will
+  help discussion.
+- Use tables to compare design alternatives, rollout paths, or capability
+  trade-offs when multiple dimensions matter.
+- Include code snippets with language identifiers when illustrating interfaces,
+  payloads, or implementation seams.
+- Add screen reader descriptions before complex diagrams or code blocks.
+- Update links when RFC filenames change, especially cross-references from one
+  RFC to another.
+
+### RFC template
 
 ```markdown
-## 1. Core infrastructure
+# RFC 0001: <title>
 
-### 1.1. Logging subsystem
+## Preamble
 
-- [ ] 1.1.1. Introduce central logging service
-  - [ ] Define log message schema. See design-doc.md §2.1.
-  - [ ] Implement log collector daemon.
-  - [ ] Add structured logging to API layer.
-- [ ] 1.1.2. Add error dashboards. Requires 1.1.1.
-  - [ ] Deploy Grafana instance.
-  - [ ] Create error rate dashboard (target: <1% error rate visible within 5 min).
+- **RFC number:** 0001
+- **Status:** Proposed
+- **Created:** YYYY-MM-DD
 
-### 1.2. Authentication
+## Summary
 
-- [ ] 1.2.1. Implement role-based access control. Requires 1.1.1.
-  - [ ] Define role hierarchy. See design-doc.md §4.3.
-  - [ ] Add RBAC middleware to API endpoints.
-  - [ ] Write integration tests for permission boundaries.
+<Concise statement of the proposal and why it matters.>
+
+## Problem
+
+<Describe the current deficiency, risk, or missing capability.>
+
+## Current state
+
+<Summarize the relevant current implementation or constraints.>
+
+## Goals and non-goals
+
+- Goals:
+  - <Goal 1>
+  - <Goal 2>
+- Non-goals:
+  - <Non-goal 1>
+  - <Non-goal 2>
+
+## Proposed design
+
+<Describe the recommended design in enough detail for technical review.>
+
+## Requirements
+
+### Functional requirements
+
+- <Functional requirement 1>
+- <Functional requirement 2>
+
+### Technical requirements
+
+- <Technical requirement 1>
+- <Technical requirement 2>
+
+## Compatibility and migration
+
+<Describe compatibility impact, rollout constraints, and migration sequencing.>
+
+## Alternatives considered
+
+### Option A: <Name>
+
+<Description, consequences, and trade-offs.>
+
+### Option B: <Name>
+
+<Description, consequences, and trade-offs.>
+
+## Open questions
+
+- <Open question 1>
+- <Open question 2>
+
+## Recommendation
+
+<State the preferred direction and why it should be adopted.>
 ```
 
-## Architectural Decision Records (ADRs)
+## Architectural decision records (ADRs)
 
 Use ADRs to document significant architectural and design decisions. ADRs
 capture the context, options considered, and rationale behind decisions,
@@ -229,7 +386,7 @@ Include these sections as appropriate to the decision's complexity:
 - **Options Considered:** Describe the alternatives evaluated. Use a comparison
   table when contrasting multiple options across several dimensions.
 - **Decision Outcome / Proposed Direction:** State the chosen approach and
-  summarise the rationale. For `Proposed` ADRs, describe the recommended
+  summarize the rationale. For `Proposed` ADRs, describe the recommended
   direction.
 - **Goals and Non-Goals:** Clarify what the decision aims to achieve and what
   is explicitly out of scope.
@@ -247,7 +404,7 @@ Include these sections as appropriate to the decision's complexity:
 - Use second-level headings (`##`) for major sections.
 - Use third-level headings (`###`) for subsections (e.g. phases, option names).
 - Use tables to compare options when multiple dimensions are relevant. Include
-  a caption below the table (e.g. "_Table 1: Trade-offs between X and Y._").
+  a caption below the table (e.g. “_Table 1: Trade-offs between X and Y._”).
 - Include code snippets with language identifiers when illustrating technical
   approaches. Use `no_run` for illustrative Rust code that should not be
   executed.
@@ -256,18 +413,18 @@ Include these sections as appropriate to the decision's complexity:
 
 ### ADR template
 
-```markdown
+```plaintext
 # Architectural decision record (ADR) NNN: <title>
 
 ## Status
 
-Proposed.
+<Proposed | Accepted | Superseded | Deprecated>.
 
 ## Date
 
 YYYY-MM-DD.
 
-## Context and Problem Statement
+## Context and problem statement
 
 <Describe the situation, constraints, and the question being addressed.>
 
@@ -276,7 +433,19 @@ YYYY-MM-DD.
 - <Driver 1>
 - <Driver 2>
 
-## Options Considered
+## Requirements
+
+### Functional requirements
+
+- <Functional requirement 1>
+- <Functional requirement 2>
+
+### Technical requirements
+
+- <Technical requirement 1>
+- <Technical requirement 2>
+
+## Options considered
 
 ### Option A: <Name>
 
@@ -292,21 +461,224 @@ YYYY-MM-DD.
 
 _Table 1: Comparison of options._
 
-## Decision Outcome / Proposed Direction
+## Decision outcome / proposed direction
 
-<State the chosen or recommended approach and summarise the rationale.>
+<State the chosen or recommended approach and summarize the rationale.>
 
-## Known Risks and Limitations
+## Goals and non-goals
+
+- Goals:
+  - <Goal 1>
+  - <Goal 2>
+- Non-goals:
+  - <Non-goal 1>
+  - <Non-goal 2>
+
+## Migration plan
+
+<Use numbered phases with clear goals and deliverables where phased
+implementation is required.>
+
+## Known risks and limitations
 
 - <Risk or limitation 1>
 - <Risk or limitation 2>
 
-## Outstanding Decisions
+## Outstanding decisions
 
 - <Open question 1>
 - <Open question 2>
 ```
 
+### Repository layout document
+
+Use a repository layout document, canonically `docs/repository-layout.md`, to
+explain the shape of the tree and the responsibilities of its major paths. Use
+this standalone document as the canonical location for repository-layout
+guidance rather than embedding that material in the developer's guide.
+
+- Document the top-level directories and any critical subdirectories that a new
+  contributor must understand quickly.
+- Explain the purpose, ownership boundary, and notable conventions of each
+  path, not just its name.
+- Prefer a compact tree, table, or both. Use the tree for orientation and the
+  prose or table for semantics.
+- Distinguish between authoritative structure and illustrative sketches. If the
+  tree is incomplete or simplified, say so explicitly.
+- Highlight where source code, tests, generated artefacts, plans, and
+  long-lived reference documents belong.
+- Call out any directories with unusual constraints, such as generated output,
+  fixtures, snapshots, or capability-restricted paths.
+- Ensure the contents file links directly to `docs/repository-layout.md` so
+  readers can find it without scanning the developer's guide.
+- Update the layout document when the repository structure changes enough that
+  a contributor could otherwise follow outdated guidance.
+
+## Example snippet
+
+```rust,no_run
+/// A simple function demonstrating documentation style.
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+## API doc comments (Rust)
+
+Use doc comments to document public APIs. Keep them consistent with the
+contents of the manual.
+
+- Begin each block with `///`.
+- Keep the summary line short, followed by further detail.
+- Explicitly document all parameters with `# Parameters`, describing each
+  argument.
+- Document the return value with `# Returns`.
+- Document any panics or errors with `# Panics` or `# Errors` as appropriate.
+- Place examples under `# Examples` and mark the code block with `no_run`, so
+  they do not execute during documentation tests.
+- Put function attributes after the doc comment.
+
+```rust,no_run
+/// Returns the sum of `a` and `b`.
+///
+/// # Parameters
+/// - `a`: The first integer to add.
+/// - `b`: The second integer to add.
+///
+/// # Returns
+/// The sum of `a` and `b`.
+///
+/// # Examples
+///
+/// ```rust,no_run
+/// assert_eq!(add(2, 3), 5);
+/// ```
+#[inline]
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+```
+
+## Diagrams and images
+
+Where it adds clarity, include [Mermaid](https://mermaid.js.org/) diagrams.
+When embedding figures, use `![alt text](path/to/image)` and provide brief alt
+text describing the content. Add a short description before each Mermaid
+diagram, so screen readers can understand it.
+
+For screen readers: The following flowchart outlines the documentation workflow.
+
+```mermaid
+flowchart TD
+    A[Start] --> B[Draft]
+    B --> C[Review]
+    C --> D[Merge]
+```
+
+_Figure 1: Documentation workflow from draft through merge review._
+
+## Roadmap task writing guidelines
+
+When documenting development roadmap items, write them to be achievable,
+measurable, and structured. This ensures the roadmap functions as a practical
+planning tool rather than a vague wishlist. Do not commit to timeframes in the
+roadmap. Development effort should be roughly consistent from task to task.
+
+### Principles for roadmap tasks
+
+- Define outcomes, not intentions: Phrase tasks in terms of the capability
+  delivered (e.g. “Implement role-based access control for API endpoints”), not
+  aspirations like “Improve security”.
+- Quantify completion criteria: Attach measurable finish lines (e.g. “90%
+  test coverage for new modules”, “response times under 200ms”, “all endpoints
+  migrated”).
+- Break into atomic increments: Ensure tasks can be completed in weeks, not
+  quarters. Large goals should be decomposed into clear, deliverable units.
+- Tie to dependencies and sequencing: Document prerequisites, so tasks can be
+  scheduled realistically (e.g. “Introduce central logging service” before “Add
+  error dashboards”).
+- Bound scope explicitly: Note both in-scope and out-of-scope elements (e.g.
+  “Build analytics dashboard (excluding churn prediction)”).
+
+### Hierarchy of scope
+
+Roadmaps should be expressed in three layers of scope to maintain clarity and
+navigability:
+
+- Phases (strategic milestones) – Broad outcome-driven stages that represent
+  significant capability shifts. Why the work matters.
+- Steps (epics / workstreams) – Mid-sized clusters of related tasks grouped
+  under a phase. What will be built.
+- Tasks (execution units) – Small, measurable pieces of work with clear
+  acceptance criteria. How it gets done.
+
+This hierarchy should align with the GIST framework:
+
+- Phases correspond to strategic themes or milestones.
+- Steps correspond to GIST-style workstreams. A step must describe a coherent
+  body of delivery work with one clear objective, explicit sequencing value,
+  and a practical learning loop. A step is not just a heading used to group
+  unrelated tasks.
+- Tasks correspond to implementation-level execution units. A task should be a
+  concrete build activity, not an aspiration, research topic, or status label.
+
+### Roadmap formatting conventions
+
+- **Dotted numbering:** Number phases, steps, and headline tasks using dotted
+  notation:
+  - Phases: 1, 2, 3, …
+  - Steps: 1.1, 1.2, 1.3, …
+  - Headline tasks: 1.1.1, 1.1.2, 1.1.3, …
+- **Checkboxes:** Precede task and sub-task items with a GitHub-flavoured
+  Markdown (GFM) checkbox (`[ ]`) to track completion status.
+- **Dependencies:** Note non-linear dependencies explicitly. Where a task
+  depends on another task outside its immediate sequence, cite the dependency
+  using dotted notation (e.g. “Requires 2.3.1”).
+- **Success criteria:** Include explicit success criteria only where not
+  immediately obvious from the task description.
+- **Design document citations:** Where applicable, cite the relevant design
+  document section for each task (e.g. “See design-doc.md §3.2”).
+
+### Roadmap example
+
+```plaintext
+## 1. Core infrastructure
+
+### 1.1. Logging subsystem
+
+- [ ] 1.1.1. Introduce central logging service
+  - Define log message schema. See design-doc.md §2.1.
+  - Implement log collector daemon.
+  - Add structured logging to API layer.
+- [ ] 1.1.2. Add error dashboards. Requires 1.1.1.
+  - Deploy Grafana instance.
+  - Create error rate dashboard (target: <1% error rate visible within 5 min).
+
+### 1.2. Authentication
+
+- [ ] 1.2.1. Implement role-based access control (RBAC). Requires 1.1.1.
+  - Define role hierarchy. See design-doc.md §4.3.
+  - Add RBAC middleware to API endpoints.
+  - Write integration tests for permission boundaries.
+```
+
+### Writing GIST-aligned steps
+
+When writing a roadmap step, make it function as a real workstream:
+
+- Give the step a concrete objective that describes what will exist when the
+  workstream is complete.
+- State the learning opportunity for the step when that learning affects later
+  sequencing or design choices.
+- Group only tasks that serve the same delivery objective. If the tasks do not
+  share one operational purpose, split the step.
+- Sequence steps so each workstream either unlocks the next one or reduces a
+  specific class of delivery risk.
+
+Avoid using steps as passive document structure. Headings such as “Backend
+changes”, “Frontend work”, or “Other tasks” are not sufficient unless they are
+framed as real workstreams with a defined outcome.
+
 ______________________________________________________________________
 
-[^markdownlint]: A linter that enforces consistent Markdown formatting.
+[^1]: A linter that enforces consistent Markdown formatting.

--- a/docs/repository-layout.md
+++ b/docs/repository-layout.md
@@ -1,0 +1,70 @@
+# Repository layout
+
+This document orients contributors within the Wildside repository. It describes
+the major paths and their responsibilities; it is not an exhaustive file list.
+
+## Top-level tree
+
+```plaintext
+.
+├── backend/
+├── crates/
+├── deploy/
+├── docs/
+├── frontend-pwa/
+├── packages/
+├── scripts/
+├── security/
+├── spec/
+├── third_party/
+└── tools/
+```
+
+_Figure 1: Simplified top-level repository tree._
+
+## Path responsibilities
+
+- `AGENTS.md` contains repository-wide assistant and contributor instructions.
+- `backend/` contains Rust backend application code, migrations, fixtures, and
+  backend tests.
+- `crates/` contains shared Rust workspace crates that support backend and
+  tooling features.
+- `deploy/` contains container, Helm, nginx, and local deployment artefacts.
+- `docs/` contains long-lived project documentation, design notes, runbooks,
+  plans, diagrams, and documentation policy.
+- `frontend-pwa/` contains the browser-facing Progressive Web Application
+  (PWA), its scripts, source, and tests.
+- `packages/` contains shared TypeScript workspace packages, including design
+  tokens and cross-workspace types.
+- `scripts/` contains repository automation and local development helper
+  scripts.
+- `security/` contains JavaScript audit validation, audit exception policy, and
+  security reporting helpers.
+- `spec/` contains API and protocol specifications used by generation,
+  linting, and integration checks.
+- `third_party/` contains vendored or externally sourced code kept under
+  explicit repository control.
+- `tools/` contains repository-specific developer and architecture tooling.
+
+## Documentation paths
+
+- `docs/contents.md` is the canonical documentation index.
+- `docs/documentation-style-guide.md` is the source of truth for documentation
+  style, naming, and standard document types.
+- `docs/repository-layout.md` is the canonical repository layout guide.
+- `docs/runbooks/` contains operational procedures.
+- `docs/execplans/` contains execution plans for non-trivial implementation
+  work.
+- `docs/diagrams/` contains diagram assets referenced by documentation.
+- `docs/investigations/` contains longer-lived investigation notes.
+
+## Frontend and package paths
+
+- `frontend-pwa/AGENTS.md` contains PWA-specific TypeScript and JavaScript
+  guidance.
+- `packages/AGENTS.md` contains guidance for shared TypeScript packages.
+- `security/AGENTS.md` contains guidance for JavaScript audit and security
+  automation.
+
+Update this document when the repository structure changes enough that a new
+contributor could otherwise follow outdated path guidance.

--- a/docs/scripting-standards.md
+++ b/docs/scripting-standards.md
@@ -1,9 +1,27 @@
 # Scripting standards
 
-Wildside scripts favour clarity, reproducibility, and testability. The baseline
-tooling is Python and the [`uv`](https://github.com/astral-sh/uv) launcher so
-that scripts remain dependency-self-contained and easy to execute in Continuous
-Integration (CI) or locally.
+Project scripts must prioritize clarity, reproducibility, and testability.
+
+Cyclopts is the default command‑line interface (CLI) framework for new and
+updated scripts. This document supersedes prior guidance that recommended Typer
+as a default.
+
+## Rationale for adopting Cyclopts
+
+- Environment‑first configuration without glue. Cyclopts reads environment
+  variables with a defined prefix (for example, `INPUT_`) and maps them to
+  parameters directly. Bash argument assembly and bespoke parsing can be
+  removed.
+- Typed lists and paths from env. Parameters annotated as `list[str]` or
+  `list[pathlib.Path]` are populated from whitespace‑ or delimiter‑separated
+  environment values. Custom split/trim helpers are unnecessary.
+- Clear precedence model. CLI flags override environment variables, which
+  override code defaults. Behaviour is predictable in both CI and local runs.
+- Small API surface. The API is explicit and integrates cleanly with type
+  hints, aiding readability and testing.
+- Backwards‑compatible migration. Option aliases and per‑parameter
+  environment variable names permit preservation of existing interfaces while
+  removing shell glue.
 
 ## Language and runtime
 
@@ -14,69 +32,656 @@ Integration (CI) or locally.
   expectations travel with the file. Prefer the shebang
   `#!/usr/bin/env -S uv run python` followed by the metadata block shown in the
   example below.
-- External processes are invoked via [`plumbum`](https://plumbum.readthedocs.io)
-  to provide structured command execution rather than ad-hoc shell strings.
-- File-system interactions use `pathlib.Path`. Higher-level operations (for
+- External processes are invoked via
+  [`cuprum`](https://github.com/leynos/cuprum/) to provide typed,
+  allowlist-based command execution rather than ad‑hoc shell strings. Cuprum's
+  catalogue system ensures only registered programs can be executed, preventing
+  accidental shell access.
+- File‑system interactions use `pathlib.Path`. Higher‑level operations (for
   example, copying or removing trees) go through the `shutil` standard library
   module.
+
+### Cyclopts CLI pattern (environment‑first)
+
+Employ Cyclopts when a script requires parameters, particularly under CI with
+`INPUT_*` variables.
+
+```python
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Optional, Annotated
+
+import cyclopts
+from cyclopts import App, Parameter
+from cuprum import Catalogue, sh
+
+# Map INPUT_<PARAM> → function parameter without additional glue
+app = App(config=cyclopts.config.Env("INPUT_", command=False))
+
+
+@app.default
+def default(
+    *,
+    # Required parameters
+    bin_name: Annotated[str, Parameter(required=True)],
+    version: Annotated[str, Parameter(required=True)],
+
+    # Optional scalars
+    package_name: Optional[str] = None,
+    target: Optional[str] = None,
+    outdir: Optional[Path] = None,
+    dry_run: bool = False,
+
+    # Lists (whitespace/newline separated by default)
+    formats: list[str] | None = None,
+    man_paths: Annotated[list[Path] | None, Parameter(env_var="INPUT_MAN_PATHS")] = None,
+    deb_depends: list[str] | None = None,
+    rpm_depends: list[str] | None = None,
+):
+    name = package_name or bin_name
+
+    project_root = Path(__file__).resolve().parents[1]
+    build_dir = (outdir or (project_root / "dist")) / name
+
+    if dry_run:
+        print({
+            "name": name,
+            "version": version,
+            "target": target,
+            "formats": formats,
+            "man_paths": [str(p) for p in (man_paths or [])],
+            "deb_depends": deb_depends,
+            "rpm_depends": rpm_depends,
+            "build_dir": str(build_dir),
+        })
+        return
+
+    build_dir.mkdir(parents=True, exist_ok=True)
+    catalogue = Catalogue.from_programs("tofu")
+    with sh.scoped(catalogue):
+        sh.make("tofu")("plan", cwd=build_dir).run_sync()
+
+def main():
+    """CLI Entrypoint"""
+    app()
+
+```
+
+Guidance:
+
+- Parameter names should be descriptive and stable. Where a legacy flag name
+  must remain available, add an alias:
+
+  ```python
+  package_name: Annotated[Optional[str], Parameter(aliases=["--name"])] = None
+  ```
+
+- Where a specific delimiter is required for an environment list (for example,
+  comma‑separated `formats`), specify it per parameter:
+
+  ```python
+  formats: Annotated[list[str] | None, Parameter(env_var_split=",")] = None
+  ```
+
+- Per‑parameter environment names can be pinned for backwards compatibility:
+
+  ```python
+  config_out: Annotated[Optional[Path], Parameter(env_var="INPUT_CONFIG_PATH")] = None
+  ```
+
+## cuprum: typed command execution
+
+Cuprum provides allowlist-based command execution with built-in observability.
+Programs must be registered in a catalogue before they can be executed,
+preventing accidental shell access.
+
+### Shared vs local catalogues
+
+For application code in a multi-script repository, use a shared catalogue in a
+common module (for example, `project/utils/commands.py`). This centralizes the
+list of allowed programs and ensures consistent access control across the
+codebase:
+
+```python
+from project.utils.commands import PROJECT_CATALOGUE
+from cuprum import Catalogue, sh
+
+with sh.scoped(PROJECT_CATALOGUE):
+    # All project code uses the shared catalogue
+    ...
+```
+
+For standalone scripts and tests, define a local catalogue scoped to that
+file's requirements. This keeps scripts self-contained and avoids coupling to
+the main application:
+
+```python
+# In a standalone script or test file
+CATALOGUE = Catalogue.from_programs("git", "cargo")
+```
+
+### Catalogue and allowlisting
+
+```python
+from cuprum import Catalogue, sh
+
+# Define allowed programs for this script
+CATALOGUE = Catalogue.from_programs("git", "cargo", "grep")
+
+# Commands can only be constructed within a scoped catalogue
+with sh.scoped(CATALOGUE):
+    git = sh.make("git")
+    result = git("--no-pager", "log", "-1", "--pretty=%H").run_sync()
+    last_commit = result.stdout.strip()
+```
+
+### Capturing output and handling failures
+
+```python
+from cuprum import Catalogue, sh
+
+CATALOGUE = Catalogue.from_programs("git", "grep")
+
+with sh.scoped(CATALOGUE):
+    git = sh.make("git")
+
+    # run_sync() returns CommandResult with exit_code, stdout, stderr
+    result = git("status").run_sync()
+    if result.exit_code != 0:
+        # handle gracefully; result.stderr is available for logging
+        ...
+
+    # Pipelines via the | operator with backpressure handling
+    log_cmd = git("--no-pager", "log", "--oneline")
+    grep_cmd = sh.make("grep")("fix")
+    shortlog = (log_cmd | grep_cmd).run_sync().stdout
+```
+
+### Working directory and environment management
+
+```python
+from pathlib import Path
+from cuprum import Catalogue, sh
+
+CATALOGUE = Catalogue.from_programs("git")
+repo_dir = Path(__file__).resolve().parents[1]
+
+with sh.scoped(CATALOGUE):
+    git = sh.make("git")
+
+    # Working directory via cwd parameter
+    result = git("tag", "--list", cwd=repo_dir).run_sync()
+    tags = result.stdout
+
+    # Environment overrides via env parameter
+    result = git(
+        "config", "user.name", "CI",
+        env={"GIT_AUTHOR_NAME": "CI", "GIT_AUTHOR_EMAIL": "ci@example.org"},
+    ).run_sync()
+```
+
+### Keyword arguments as flags
+
+Cuprum transforms keyword arguments into `--flag=value` format automatically,
+with underscores converted to hyphens:
+
+```python
+from cuprum import Catalogue, sh
+
+CATALOGUE = Catalogue.from_programs("cargo")
+
+with sh.scoped(CATALOGUE):
+    cargo = sh.make("cargo")
+    # Equivalent to: cargo build --release --target=x86_64-unknown-linux-gnu
+    result = cargo("build", release=True, target="x86_64-unknown-linux-gnu").run_sync()
+```
+
+### Observability hooks
+
+```python
+import logging
+from cuprum import Catalogue, sh, Hook
+
+LOGGER = logging.getLogger(__name__)
+CATALOGUE = Catalogue.from_programs("cargo")
+
+def log_before(event):
+    LOGGER.info("Executing: %s", event.command)
+
+def log_after(event):
+    LOGGER.info("Completed with exit code %d", event.result.exit_code)
+
+with sh.scoped(CATALOGUE):
+    with sh.observe(Hook(before=log_before, after=log_after)):
+        sh.make("cargo")("check").run_sync()
+```
+
+### Async execution
+
+For I/O-bound workflows, Cuprum supports async execution:
+
+```python
+import asyncio
+from cuprum import Catalogue, sh
+
+CATALOGUE = Catalogue.from_programs("cargo")
+
+async def run_checks():
+    with sh.scoped(CATALOGUE):
+        cargo = sh.make("cargo")
+        # Async execution with run()
+        result = await cargo("check", "--all-targets").run()
+        return result.exit_code == 0
+
+asyncio.run(run_checks())
+```
+
+#### Task lifetime and `asyncio.gather`
+
+When multiple async commands run concurrently, each task's lifetime must be
+bounded by the enclosing coroutine. Await the tasks with `asyncio.gather`, or
+with `asyncio.TaskGroup` on Python 3.11 and later, so background command work
+cannot escape the calling coroutine.
+
+```python
+import asyncio
+from cuprum import Catalogue, sh
+
+CATALOGUE = Catalogue.from_programs("cargo", "python")
+
+async def run_all():
+    with sh.scoped(CATALOGUE):
+        cargo = sh.make("cargo")
+        python = sh.make("python")
+        results = await asyncio.gather(
+            cargo("check", "--all-targets").run(),
+            python("-m", "pytest", "--tb=short").run(),
+            return_exceptions=True,
+        )
+    return results
+```
+
+`return_exceptions=True` prevents a single task failure from cancelling sibling
+tasks. Callers must inspect each result individually.
+
+#### Cancellation handling
+
+`asyncio.CancelledError` is not suppressed by Cuprum. If a task running `run()`
+is cancelled, for example by a timeout or external signal, the coroutine raises
+`CancelledError` as normal. Authors must not catch `CancelledError` silently.
+
+```python
+async def check_with_timeout():
+    with sh.scoped(CATALOGUE):
+        cargo = sh.make("cargo")
+        try:
+            result = await asyncio.wait_for(
+                cargo("build", "--release").run(), timeout=120.0
+            )
+        except asyncio.TimeoutError:
+            # Handle or re-raise; do not swallow CancelledError
+            raise
+    return result
+```
+
+#### Error propagation
+
+`run()` returns a `CommandResult` and does not raise on non-zero exit codes.
+Subprocess errors are propagated as field values such as `exit_code` and
+`stderr`, not as exceptions. Callers must check `result.exit_code` explicitly.
+The exceptions raised are those from the Python event loop itself, such as
+`CancelledError` and `TimeoutError`, or from catalogue violations such as
+`UnknownProgramError`.
+
+#### Catalogue safety across concurrent tasks
+
+A `Catalogue` instance is safe to share across concurrent tasks because it is
+read-only after construction. `sh.scoped(CATALOGUE)` is a context manager that
+binds the catalogue for the current execution scope. Authors must not mutate the
+catalogue inside a concurrent task. Construct the catalogue once at module level
+and re-use it.
+
+#### Concurrent testing patterns with cmd-mox
+
+Concurrent async script paths use the same catalogue and scoped context in tests
+as they do in production code. `cmd-mox` intercepts at the catalogue boundary
+regardless of whether `run()` or `run_sync()` is used.
+
+```python
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_concurrent_commands_all_succeed(mock_catalogue):
+    mock_catalogue.register("cargo", exit_code=0, stdout="ok\n")
+    mock_catalogue.register("python", exit_code=0, stdout="passed\n")
+
+    results = await run_all()  # function under test
+
+    assert all(r.exit_code == 0 for r in results)
+
+
+@pytest.mark.asyncio
+async def test_gather_continues_after_one_failure(mock_catalogue):
+    mock_catalogue.register("cargo", exit_code=1, stderr="error\n")
+    mock_catalogue.register("python", exit_code=0, stdout="passed\n")
+
+    results = await run_all()
+
+    exit_codes = [r.exit_code for r in results]
+    assert 1 in exit_codes
+    assert 0 in exit_codes
+```
+
+The `mock_catalogue` fixture replaces the real `CATALOGUE`. Authors must inject
+it via a parameter or monkeypatch rather than relying on the module-level
+constant directly.
+
+## pathlib: robust path manipulation
+
+### Project roots, joins, and ensuring directories
+
+```python
+from __future__ import annotations
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DIST = PROJECT_ROOT / "dist"
+(DIST / "artifacts").mkdir(parents=True, exist_ok=True)
+
+# Portable joins and normalisation
+cfg = PROJECT_ROOT.joinpath("config", "release.toml").resolve()
+```
+
+### Reading / writing files and atomic updates
+
+```python
+from pathlib import Path
+import tempfile
+
+f = Path("./dist/version.txt")
+
+# Text I/O
+f.write_text("1.2.3\n", encoding="utf-8")
+version = f.read_text(encoding="utf-8").strip()
+
+# Atomic write pattern (tmp → replace)
+with tempfile.NamedTemporaryFile("w", delete=False, dir=f.parent, encoding="utf-8") as tmp:
+    tmp.write("new-contents\n")
+    tmp_path = Path(tmp.name)
+
+tmp_path.replace(f)  # atomic on POSIX
+```
+
+### Globbing, filtering, and safe deletion
+
+```python
+from pathlib import Path
+
+# Recursive glob
+md_files = sorted(Path("docs").glob("**/*.md"))
+
+# Filter by suffix / size
+small_md = [p for p in md_files if p.stat().st_size < 4096 and p.suffix == ".md"]
+
+# Safe deletion (ignore missing)
+try:
+    (Path("build") / "temp.bin").unlink()
+except FileNotFoundError:
+    pass
+```
+
+## Cyclopts + cuprum + pathlib together (reference script)
 
 ```python
 #!/usr/bin/env -S uv run python
 # /// script
 # requires-python = ">=3.13"
-# dependencies = ["plumbum", "cmd-mox"]
+# dependencies = ["cyclopts>=2.9", "cuprum", "cmd-mox"]
 # ///
 
 from __future__ import annotations
-
 from pathlib import Path
-from plumbum import local
-from plumbum.cmd import git
+from typing import Optional, Annotated
 
+import cyclopts
+from cyclopts import App, Parameter
+from cuprum import Catalogue, sh
 
-def main() -> None:
+CATALOGUE = Catalogue.from_programs("git")
+
+app = App(config=cyclopts.config.Env("INPUT_", command=False))
+
+@app.default
+def main(
+    *,
+    bin_name: Annotated[str, Parameter(required=True)],
+    version: Annotated[str, Parameter(required=True)],
+    formats: list[str] | None = None,
+    outdir: Optional[Path] = None,
+    dry_run: bool = False,
+):
     project_root = Path(__file__).resolve().parents[1]
-    with local.cwd(project_root):
-        commit_hash = git["rev-parse", "--short", "HEAD"]().strip()
+    dist = (outdir or (project_root / "dist")) / bin_name
+    dist.mkdir(parents=True, exist_ok=True)
 
-    version_path = project_root / "VERSION"
-    version_path.write_text(f"{commit_hash}\n", encoding="utf-8")
-    print(f"Wrote version {commit_hash} to {version_path}")
+    if not dry_run:
+        with sh.scoped(CATALOGUE):
+            git = sh.make("git")
+            git("tag", f"v{version}", cwd=project_root).run_sync()
 
+    print({
+        "bin_name": bin_name,
+        "version": version,
+        "formats": formats or [],
+        "dist": str(dist),
+    })
 
 if __name__ == "__main__":
-    main()
+    app()
 ```
 
 ## Testing expectations
 
-- Every script requires automated coverage via `pytest`. Use `pytest-mock` for
-  fixture-driven mocking of Python objects and
-  [`cmd-mox`](https://github.com/leynos/cmd-mox/) to simulate external
+- Automated coverage via `pytest` is required for every script. Fixtures from
+  `pytest-mock` support Python‑level mocking; `cmd-mox` simulates external
   executables without touching the host system.
-- Behavioural flows that map cleanly to scenarios should adopt
-  Behaviour-Driven Development (BDD) via `pytest-bdd` so the intent of the
-  script is captured in human-readable Given/When/Then narratives.
-- Tests reside in `scripts/tests/` mirroring the script names. For example,
-  `scripts/rotate_session_key.py` pairs with
-  `scripts/tests/test_rotate_session_key.py`.
-- When scripts rely on environment variables, assert both the happy path and
-  failure modes; the tests should demonstrate graceful error handling rather
-  than raising opaque stack traces.
+- Behavioural flows that map cleanly to scenarios should adopt Behaviour‑Driven
+  Development (BDD) via `pytest-bdd` so that intent is captured in
+  human‑readable Given/When/Then narratives.
+- Tests reside in `scripts/tests/`, mirroring script names. For example,
+  `scripts/bootstrap_doks.py` pairs with `scripts/tests/test_bootstrap_doks.py`.
+- Where scripts rely on environment variables, both happy paths and failure
+  modes must be asserted; tests should demonstrate graceful error handling
+  rather than opaque stack traces.
+
+### Mocking Python dependencies (pytest-mock) and environment (monkeypatch)
+
+```python
+import os
+from pathlib import Path
+from cyclopts.testing import invoke
+from scripts.package import app
+
+
+def test_reads_env_and_defaults(monkeypatch, tmp_path):
+    # Arrange env for Cyclopts
+    monkeypatch.setenv("INPUT_BIN_NAME", "demo")
+    monkeypatch.setenv("INPUT_VERSION", "1.2.3")
+    monkeypatch.setenv("INPUT_FORMATS", "deb rpm")  # whitespace or newlines
+
+    # Exercise
+    result = invoke(app, [])
+
+    # Assert
+    assert result.exit_code == 0
+    assert '"version": "1.2.3"' in result.stdout
+
+
+def test_patch_python_dependency(mocker):
+    # Example: patch a helper function used by the script
+    from scripts import helpers
+
+    mocker.patch_object(helpers, "compute_checksum", return_value="deadbeef")
+    assert helpers.compute_checksum(b"abc") == "deadbeef"
+```
+
+### Mocking external executables with cmd-mox (record → replay → verify)
+
+Enable the plugin in `conftest.py`:
+
+```python
+pytest_plugins = ("cmd_mox.pytest_plugin",)
+```
+
+```python
+from cuprum import Catalogue, sh
+
+CATALOGUE = Catalogue.from_programs("git")
+
+
+def test_git_tag_happy_path(cmd_mox, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    # Mock external command behaviour
+    cmd_mox.mock("git").with_args("tag", "v1.2.3").returns(exit_code=0)
+
+    # Run the code under test while shims are active
+    cmd_mox.replay()
+    with sh.scoped(CATALOGUE):
+        sh.make("git")("tag", "v1.2.3").run_sync()
+    cmd_mox.verify()
+
+
+def test_git_tag_failure_surface_error(cmd_mox, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    cmd_mox.mock("git").with_args("tag", "v1.2.3").returns(exit_code=1, stderr="denied")
+
+    cmd_mox.replay()
+    with sh.scoped(CATALOGUE):
+        result = sh.make("git")("tag", "v1.2.3").run_sync()
+        assert result.exit_code == 1
+        assert "denied" in result.stderr
+    cmd_mox.verify()
+```
+
+### Spies and passthrough capture (turn real calls into fixtures)
+
+```python
+from cuprum import Catalogue, sh
+
+CATALOGUE = Catalogue.from_programs("echo")
+
+
+def test_spy_and_record(cmd_mox, monkeypatch, tmp_path):
+    monkeypatch.chdir(tmp_path)
+
+    # Spy records actual usage; passthrough runs the real command
+    spy = cmd_mox.spy("echo").passthrough()
+
+    cmd_mox.replay()
+    with sh.scoped(CATALOGUE):
+        sh.make("echo")("hello world").run_sync()
+    cmd_mox.verify()
+
+    # Inspect what happened
+    spy.assert_called()
+    assert spy.call_count == 1
+    args = spy.invocations[0].argv[1:]
+    assert args == ["hello world"]
+```
 
 ## Operational guidelines
 
-- Scripts must be idempotent. Re-running them should converge state without
-  destructive side effects. Use guard conditions (for example, checking the
-  HashiCorp Vault secrets manager for existing secrets) before writing or
-  rotating credentials.
-- Prefer pure functions that accept configuration objects over global state so
-  tests can exercise the logic deterministically.
-- Exit codes should follow UNIX conventions: `0` for success, non-zero for
-  actionable failures. Surface human-friendly error messages that highlight the
+- Scripts must be idempotent. Re‑running should converge state without
+  destructive side effects. Guard conditions (for example, checking the secrets
+  manager for existing secrets) should precede writes or rotations.
+- Pure functions that accept configuration objects are preferred over global
+  state so that tests can exercise logic deterministically.
+- Exit codes should follow UNIX conventions: `0` for success, non‑zero for
+  actionable failures. Human‑friendly error messages should highlight
   remediation steps.
-- Keep dependencies minimal. If a new package is required, add it to the `uv`
-  block and document the rationale inside the script or companion tests.
+- Dependencies must remain minimal. Any new package should be added to the `uv`
+  block and the rationale documented within the script or companion tests.
+
+## Migration guidance (Typer → Cyclopts)
+
+1. Dependencies: replace Typer with Cyclopts in the script's `uv` block.
+2. Entry point: replace `app = typer.Typer(...)` with `app = App(...)` and
+   configure `Env("INPUT_", command=False)` where environment variables are
+   authoritative in CI.
+3. Parameters: replace `typer.Option(...)` with annotations and
+   `Parameter(...)`. Mark required options with `required=True`. Map any
+   non‑matching environment names via `env_var=...`.
+4. Lists: remove custom split/trim code. Use list‑typed parameters; add
+   `env_var_split=","` where a non‑whitespace delimiter is required.
+5. Compatibility: retain legacy flag names using `aliases=["--old-name"]`.
+6. Bash glue: delete argument arrays and conditional appends in GitHub
+   Actions. Export `INPUT_*` environment variables and call `uv run` on the
+   script.
+
+## Migration guidance (plumbum → cuprum)
+
+**Important semantic change:** Plumbum raises `ProcessExecutionError` on
+non-zero exit codes by default, whereas Cuprum's `run_sync()` always returns a
+`CommandResult` without raising. Code that relied on exception handling for
+failure detection must be rewritten to check `result.exit_code` explicitly.
+This shift improves predictability but requires careful attention when porting
+existing error handling logic.
+
+1. Dependencies: replace `plumbum` with `cuprum` in `pyproject.toml` or the
+   script's `uv` block.
+2. Define a catalogue: create a `Catalogue.from_programs(...)` listing all
+   executables the script requires.
+3. Scope execution: wrap command construction in `with sh.scoped(CATALOGUE):`.
+4. Command construction: replace `local["git"]["args"]` with
+   `sh.make("git")("args")`.
+5. Execution: replace `command()` with `command.run_sync()` and access
+   `result.stdout`, `result.stderr`, `result.exit_code`.
+6. Non‑raising execution: replace `.run(retcode=None)` patterns with
+   `run_sync()` and check `result.exit_code` explicitly. Note that this is now
+   the default behaviour, not a special case.
+7. Working directory: replace `with local.cwd(path):` context manager with
+   `cwd=path` parameter on the command.
+8. Environment: replace `with local.env(VAR=value):` with `env={"VAR": value}`
+   parameter on the command.
+9. Pipelines: the `|` operator works identically; ensure both commands are
+   constructed via `sh.make()`.
+10. Error handling: replace `CommandNotFound` with cuprum's
+    `UnknownProgramError`; replace `ProcessExecutionError` with exit code
+    checks on `CommandResult`.
+
+## CI wiring: GitHub Actions (Cyclopts‑first)
+
+```yaml
+- name: Build
+  shell: bash
+  working-directory: ${{ inputs.project-dir }}
+  env:
+    INPUT_BIN_NAME: ${{ inputs.bin-name }}
+    INPUT_VERSION: ${{ inputs.version }}
+    INPUT_FORMATS: ${{ inputs.formats }}               # multiline or space‑sep
+    INPUT_OUTDIR: ${{ inputs.outdir }}
+  run: |
+    set -euo pipefail
+    uv run "${GITHUB_ACTION_PATH}/scripts/package.py"
+```
+
+## Notes and gotchas
+
+- Newline‑separated lists are preferred for CI inputs to avoid shell quoting
+  issues across platforms.
+- Cuprum's `run_sync()` always returns a `CommandResult`; check `exit_code`
+  explicitly rather than relying on exceptions for non‑zero exits.
+- Production code should present friendly error messages; tests may assert raw
+  behaviours (non‑zero exits, stderr contents) via `cmd-mox`.
+- On Windows, newline‑separated lists are recommended for `list[Path]` to
+  sidestep `;`/`:` semantics.
+- Cuprum's catalogue must include all programs used by the script; attempting
+  to construct a command for an unregistered program raises
+  `UnknownProgramError`.
 
 This document should be referenced when introducing or updating automation
 scripts to maintain a consistent developer experience across the repository.

--- a/frontend-pwa/AGENTS.md
+++ b/frontend-pwa/AGENTS.md
@@ -13,6 +13,8 @@ These instructions apply in addition to the repository root `AGENTS.md`.
 
 ## TypeScript and JavaScript quality gates
 
+- Front end validation must succeed fully with no errors, failures, or
+  violations. This is non-negotiable.
 - Validate formatting with `make check-fmt` from the repository root. Use
   `make fmt` to apply formatting fixes.
 - Validate linting with `make lint` from the repository root.
@@ -22,18 +24,28 @@ These instructions apply in addition to the repository root `AGENTS.md`.
   PWA work, `pnpm --filter frontend-pwa test` runs the local Vitest suite.
 - Run `pnpm --filter frontend-pwa build` when a change affects routing, bundling,
   public assets, generated API clients, or production-only behaviour.
+- Use Playwright and `css-view` to validate browser-facing work.
+
+## Accessibility, localization, and styling
+
+- The application must be Web Content Accessibility Guidelines (WCAG) 2.2
+  compliant. This is non-negotiable.
+- All strings and card model data must be translatable according to
+  `docs/v2a-front-end-stack.md`.
+- Provide localizations for all supported languages, including right-to-left
+  (RTL) support.
+- The site must use semantic classes.
 
 ## Testing expectations
 
-- Ensure new features are validated with unit tests and behavioural tests using
-  the existing Vitest setup where applicable. Cover happy paths, unhappy paths,
-  and relevant edge cases.
-- Keep behavioural tests under `frontend-pwa/tests/` using the existing
-  `*.behaviour.test.ts` naming pattern. Keep narrow unit tests near the relevant
-  test area using `*.unit.test.ts` when that is already the local convention.
+- Ensure new features are validated with unit tests using `bun:test` where
+  applicable. Cover happy paths, unhappy paths, and relevant edge cases.
+- Ensure new features are validated with behavioural tests using `bun:test` and
+  `@aboviq/bun-test-cucumber` for Gherkin file support where applicable. Cover
+  happy paths, unhappy paths, and relevant edge cases.
 - Add end-to-end tests where the change affects externally observable workflows,
   integration contracts, persistence, command-line behaviour, network
-  boundaries, user interface flows, or other system-level behaviour.
+  boundaries, user interface (UI) flows, or other system-level behaviour.
 - Use property tests with `fast-check` when a change introduces an invariant over
   a range of inputs, states, orderings, or transitions.
 - For introduced axioms or contractual business logic, use an exhaustive proof,

--- a/frontend-pwa/AGENTS.md
+++ b/frontend-pwa/AGENTS.md
@@ -1,0 +1,43 @@
+# Assistant instructions for `frontend-pwa/`
+
+These instructions apply in addition to the repository root `AGENTS.md`.
+
+## Scope
+
+- Treat `frontend-pwa/` as the browser-facing Progressive Web Application
+  (PWA) workspace.
+- Keep work aligned with the frontend architecture and testing references in
+  `docs/contents.md`, especially the Wildside PWA design, data model, sitemap,
+  accessibility, localization, and front-end stack documents.
+- Prefer workspace scripts and Makefile gates over ad hoc commands.
+
+## TypeScript and JavaScript quality gates
+
+- Validate formatting with `make check-fmt` from the repository root. Use
+  `make fmt` to apply formatting fixes.
+- Validate linting with `make lint` from the repository root.
+- Validate type safety with `make typecheck` from the repository root. For this
+  workspace, the root target runs `tsc --noEmit -p frontend-pwa/tsconfig.json`.
+- Validate tests with `make test-frontend` from the repository root. For focused
+  PWA work, `pnpm --filter frontend-pwa test` runs the local Vitest suite.
+- Run `pnpm --filter frontend-pwa build` when a change affects routing, bundling,
+  public assets, generated API clients, or production-only behaviour.
+
+## Testing expectations
+
+- Ensure new features are validated with unit tests and behavioural tests using
+  the existing Vitest setup where applicable. Cover happy paths, unhappy paths,
+  and relevant edge cases.
+- Keep behavioural tests under `frontend-pwa/tests/` using the existing
+  `*.behaviour.test.ts` naming pattern. Keep narrow unit tests near the relevant
+  test area using `*.unit.test.ts` when that is already the local convention.
+- Add end-to-end tests where the change affects externally observable workflows,
+  integration contracts, persistence, command-line behaviour, network
+  boundaries, user interface flows, or other system-level behaviour.
+- Use property tests with `fast-check` when a change introduces an invariant over
+  a range of inputs, states, orderings, or transitions.
+- For introduced axioms or contractual business logic, use an exhaustive proof,
+  for example with LemmaScript. Proofs must be substantive, rigorous, and
+  well-founded rather than restating the assumed property.
+- Keep tests deterministic. Inject or isolate time, random number generation,
+  storage, fetch, environment variables, and other non-deterministic boundaries.

--- a/frontend-pwa/package.json
+++ b/frontend-pwa/package.json
@@ -10,7 +10,7 @@
     "prepreview": "pnpm --filter @app/tokens build",
     "preview": "vite preview",
     "gen:api": "bunx orval --config orval.config.cjs",
-    "test": "vitest run",
+    "test": "bun test",
     "audit": "node ./scripts/run-audit.mjs",
     "audit:snyk": "bun x snyk test"
   },
@@ -18,6 +18,7 @@
     "node": ">=22.18.0"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.14",
     "@types/node": "^22",
     "@types/react": "^18",
     "@types/react-dom": "^18",
@@ -26,8 +27,7 @@
     "orval": "^8.2.0",
     "tailwindcss": "^3",
     "typescript": "^5",
-    "vite": "^7.3.2",
-    "vitest": "^4.1.8"
+    "vite": "^7.3.2"
   },
   "dependencies": {
     "@app/types": "workspace:*",

--- a/frontend-pwa/scripts/audit-utils.test.mjs
+++ b/frontend-pwa/scripts/audit-utils.test.mjs
@@ -1,13 +1,14 @@
 /** @file Tests the shared audit helper, including the bulk advisory fallback. */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, mock } from 'bun:test';
 
-const execFileSyncMock = vi.fn();
-const spawnSyncMock = vi.fn();
+const execFileSyncMock = mock();
+const spawnSyncMock = mock();
 const githubAdvisoryIdKey = 'github_advisory_id';
 const packageNameKey = 'package_name';
+let auditUtilsImportCounter = 0;
 
-vi.mock('node:child_process', () => ({
+mock.module('node:child_process', () => ({
   execFileSync: execFileSyncMock,
   spawnSync: spawnSyncMock,
 }));
@@ -59,7 +60,8 @@ function setupRetiredPnpmAudit(lsPayload = [{ name: 'frontend-pwa', dependencies
  * @returns {Promise<typeof import('../../security/audit-utils.js')>} Imported audit utility module.
  */
 async function loadAuditUtils() {
-  const module = await import('../../security/audit-utils.js');
+  const module = await import(`../../security/audit-utils.js?bun-test=${auditUtilsImportCounter}`);
+  auditUtilsImportCounter += 1;
   return module;
 }
 
@@ -75,16 +77,21 @@ describe('buildVersionMap', () => {
 
 describe('runAuditJson', () => {
   beforeEach(() => {
-    vi.resetModules();
-    vi.clearAllMocks();
-    globalThis.fetch = vi.fn();
-    vi.unstubAllEnvs();
-    vi.stubEnv('npm_config_registry', '');
-    vi.stubEnv('NPM_CONFIG_REGISTRY', '');
+    execFileSyncMock.mockReset();
+    spawnSyncMock.mockReset();
+    globalThis.fetch = mock();
+    // biome-ignore lint/style/noProcessEnv: tests simulate registry configuration.
+    process.env.npm_config_registry = '';
+    // biome-ignore lint/style/noProcessEnv: tests simulate registry configuration.
+    process.env.NPM_CONFIG_REGISTRY = '';
   });
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    // biome-ignore lint/style/noProcessEnv: tests restore simulated registry configuration.
+    delete process.env.npm_config_registry;
+    // biome-ignore lint/style/noProcessEnv: tests restore simulated registry configuration.
+    delete process.env.NPM_CONFIG_REGISTRY;
   });
 
   /**

--- a/frontend-pwa/scripts/run-audit.test.mjs
+++ b/frontend-pwa/scripts/run-audit.test.mjs
@@ -1,10 +1,10 @@
 /** @file Exercises the audit wrapper to ensure ledger exceptions behave as expected. */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, mock, spyOn } from 'bun:test';
 
 import { VALIDATOR_ADVISORY_ID, VALIDATOR_MIN_SAFE_VERSION } from '../../security/constants.js';
 
-const validatorPatchMock = vi.fn(() => true);
+const validatorPatchMock = mock(() => true);
 
 const baselineLedgerEntries = [
   {
@@ -29,6 +29,14 @@ const cloneLedgerEntries = (entries = baselineLedgerEntries) =>
   entries.map((entry) => ({ ...entry }));
 
 let nextLedgerEntries = cloneLedgerEntries();
+let evaluateAuditImportCounter = 0;
+const consoleSpies = [];
+
+function spyOnConsole(method) {
+  const spy = spyOn(console, method).mockImplementation(() => {});
+  consoleSpies.push(spy);
+  return spy;
+}
 
 function setLedgerEntries(mutator) {
   // Allow tests to layer mutations while still supporting easy resets.
@@ -42,13 +50,13 @@ function setLedgerEntries(mutator) {
   nextLedgerEntries = cloneLedgerEntries(baselineLedgerEntries);
 }
 
-vi.mock('../../security/audit-exceptions.json', () => ({
+mock.module('../../security/audit-exceptions.json', () => ({
   get default() {
     return cloneLedgerEntries(nextLedgerEntries);
   },
 }));
 
-vi.mock('../../security/validator-patch.js', () => ({
+mock.module('../../security/validator-patch.js', () => ({
   isValidatorPatched: validatorPatchMock,
 }));
 
@@ -62,7 +70,14 @@ const createAdvisory = (id, title) => ({
 const DEFAULT_NOW = new Date('2025-03-01T00:00:00.000Z');
 
 async function loadEvaluateAudit() {
-  const { evaluateAudit } = await import('./run-audit.mjs');
+  mock.module('../../security/audit-exceptions.json', () => ({
+    default: cloneLedgerEntries(nextLedgerEntries),
+  }));
+  mock.module('../../security/validator-patch.js', () => ({
+    isValidatorPatched: validatorPatchMock,
+  }));
+  const { evaluateAudit } = await import(`./run-audit.mjs?bun-test=${evaluateAuditImportCounter}`);
+  evaluateAuditImportCounter += 1;
   return evaluateAudit;
 }
 
@@ -70,7 +85,7 @@ const evaluateAuditScenarios = [
   {
     name: 'returns success when advisories are covered by the ledger',
     advisories: [createAdvisory(VALIDATOR_ADVISORY_ID, 'validator vulnerability')],
-    spyFactory: () => vi.spyOn(console, 'info').mockImplementation(() => {}),
+    spyFactory: () => spyOnConsole('info'),
     expectedExitCode: 0,
     expectedValidatorCalls: 1,
     assertSpy: (spy) => {
@@ -82,7 +97,7 @@ const evaluateAuditScenarios = [
   {
     name: 'propagates failure when unexpected advisories are reported',
     advisories: [createAdvisory('GHSA-abcd-1234-efgh', 'Unexpected vulnerability')],
-    spyFactory: () => vi.spyOn(console, 'error').mockImplementation(() => {}),
+    spyFactory: () => spyOnConsole('error'),
     expectedExitCode: 1,
     expectedValidatorCalls: 0,
     assertSpy: (spy) => {
@@ -96,14 +111,14 @@ const evaluateAuditScenarios = [
 describe('evaluateAudit', () => {
   beforeEach(() => {
     setLedgerEntries();
-    vi.resetModules();
-    vi.clearAllMocks();
     validatorPatchMock.mockReset();
     validatorPatchMock.mockReturnValue(true);
   });
 
   afterEach(() => {
-    vi.restoreAllMocks();
+    for (const consoleSpy of consoleSpies.splice(0)) {
+      consoleSpy.mockRestore();
+    }
   });
 
   it.each(evaluateAuditScenarios)('$name', async ({
@@ -128,7 +143,7 @@ describe('evaluateAudit', () => {
   it('fails when validator advisory is present but mitigation is missing', async () => {
     const evaluateAudit = await loadEvaluateAudit();
     validatorPatchMock.mockReturnValue(false);
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = spyOnConsole('error');
 
     const exitCode = evaluateAudit(
       {
@@ -158,7 +173,7 @@ describe('evaluateAudit', () => {
       return entries;
     });
     const evaluateAudit = await loadEvaluateAudit();
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const infoSpy = spyOnConsole('info');
 
     const exitCode = evaluateAudit(
       {
@@ -201,7 +216,7 @@ describe('evaluateAudit', () => {
       return entries;
     });
     const evaluateAudit = await loadEvaluateAudit();
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const infoSpy = spyOnConsole('info');
 
     const exitCode = evaluateAudit(
       {
@@ -235,8 +250,8 @@ describe('evaluateAudit', () => {
       return entries;
     });
     const evaluateAudit = await loadEvaluateAudit();
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const infoSpy = spyOnConsole('info');
+    const errorSpy = spyOnConsole('error');
 
     const exitCode = evaluateAudit(
       {
@@ -305,7 +320,7 @@ describe('evaluateAudit', () => {
   }) => {
     setupAction();
     const evaluateAudit = await loadEvaluateAudit();
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = spyOnConsole('error');
 
     const exitCode = evaluateAudit(
       {
@@ -325,7 +340,7 @@ describe('evaluateAudit', () => {
       return entries;
     });
     const evaluateAudit = await loadEvaluateAudit();
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
+    const infoSpy = spyOnConsole('info');
 
     const exitCode = evaluateAudit(
       {
@@ -347,7 +362,7 @@ describe('evaluateAudit', () => {
       return entries;
     });
     const evaluateAudit = await loadEvaluateAudit();
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const errorSpy = spyOnConsole('error');
 
     const exitCode = evaluateAudit(
       {
@@ -371,8 +386,8 @@ describe('evaluateAudit', () => {
 
   it('passes through status when no advisories are present', async () => {
     const evaluateAudit = await loadEvaluateAudit();
-    const infoSpy = vi.spyOn(console, 'info').mockImplementation(() => {});
-    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const infoSpy = spyOnConsole('info');
+    const errorSpy = spyOnConsole('error');
 
     const successCode = evaluateAudit({ advisories: [], status: 0 }, { now: DEFAULT_NOW });
     const failureCode = evaluateAudit({ advisories: [], status: 1 }, { now: DEFAULT_NOW });

--- a/frontend-pwa/src/api/client.test.ts
+++ b/frontend-pwa/src/api/client.test.ts
@@ -4,12 +4,12 @@
  * query key helpers and delegates requests through the shared fetcher.
  */
 
+import { afterEach, describe, expect, it, mock } from 'bun:test';
 import { UserIdSchema, UsersSchema } from '@app/types';
-import { afterEach, describe, expect, it, vi } from 'vitest';
 
-const mockCustomFetchParsed = vi.fn();
+const mockCustomFetchParsed = mock();
 
-vi.mock('./fetcher', () => ({
+mock.module('./fetcher', () => ({
   customFetchParsed: mockCustomFetchParsed,
 }));
 

--- a/frontend-pwa/tests/design-tokens.behaviour.test.ts
+++ b/frontend-pwa/tests/design-tokens.behaviour.test.ts
@@ -11,26 +11,26 @@ import type {
   ResolvedConfig,
   UserConfig,
 } from 'vite';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
-import { spawnSync } from 'node:child_process';
-import { existsSync, type PathLike } from 'node:fs';
+import type { spawnSync } from 'node:child_process';
+import type { PathLike } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { designTokensPlugin } from '../vite/plugins/design-tokens';
 import { pathToString } from './test-helpers';
 import { createMockLogger } from './test-logger';
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
+const existsSyncMock = mock();
+const spawnSyncMock = mock();
+
+mock.module('node:fs', () => ({
+  existsSync: existsSyncMock,
 }));
 
-vi.mock('node:child_process', () => ({
-  spawnSync: vi.fn(),
+mock.module('node:child_process', () => ({
+  spawnSync: spawnSyncMock,
 }));
-
-const existsSyncMock = vi.mocked(existsSync);
-const spawnSyncMock = vi.mocked(spawnSync);
 
 type ConfigHook = NonNullable<Plugin['config']>;
 type ConfigHookHandler = Extract<
@@ -100,7 +100,8 @@ describe('designTokensPlugin', () => {
   const distPath = resolve(workspaceRoot, 'packages/tokens/dist');
 
   beforeEach(() => {
-    vi.resetAllMocks();
+    existsSyncMock.mockReset();
+    spawnSyncMock.mockReset();
     // biome-ignore lint/style/noProcessEnv: tests simulate npm CLI hints.
     delete process.env.npm_config_user_agent;
   });

--- a/frontend-pwa/tests/design-tokens.unit.test.ts
+++ b/frontend-pwa/tests/design-tokens.unit.test.ts
@@ -4,32 +4,33 @@
 
 // biome-ignore assist/source/organizeImports: maintain external/node/local grouping required by review.
 import type { Logger } from 'vite';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, mock } from 'bun:test';
 
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import type { spawnSync } from 'node:child_process';
+import type { PathLike } from 'node:fs';
 import { resolve } from 'node:path';
 
 import { detectPackageManager, ensureTokensDist } from '../vite/plugins/design-tokens';
 import { pathToString } from './test-helpers';
 import { createMockLogger } from './test-logger';
 
-vi.mock('node:fs', () => ({
-  existsSync: vi.fn(),
+const existsSyncMock = mock();
+const spawnSyncMock = mock();
+
+mock.module('node:fs', () => ({
+  existsSync: existsSyncMock,
 }));
 
-vi.mock('node:child_process', () => ({
-  spawnSync: vi.fn(),
+mock.module('node:child_process', () => ({
+  spawnSync: spawnSyncMock,
 }));
-
-const existsSyncMock = vi.mocked(existsSync);
-const spawnSyncMock = vi.mocked(spawnSync);
 
 describe('detectPackageManager', () => {
   const workspaceRoot = '/workspace/project';
 
   beforeEach(() => {
-    vi.resetAllMocks();
+    existsSyncMock.mockReset();
+    spawnSyncMock.mockReset();
     // biome-ignore lint/style/noProcessEnv: tests simulate npm CLI hints.
     delete process.env.npm_config_user_agent;
   });
@@ -53,12 +54,14 @@ describe('detectPackageManager', () => {
   });
 
   it('falls back to yarn lockfile discovery when user agent is missing', () => {
-    existsSyncMock.mockImplementation((path) => pathToString(path).endsWith('yarn.lock'));
+    existsSyncMock.mockImplementation((path: PathLike) => pathToString(path).endsWith('yarn.lock'));
     expect(detectPackageManager(workspaceRoot)).toBe('yarn');
   });
 
   it('falls back to npm lockfile discovery when user agent is missing', () => {
-    existsSyncMock.mockImplementation((path) => pathToString(path).endsWith('package-lock.json'));
+    existsSyncMock.mockImplementation((path: PathLike) =>
+      pathToString(path).endsWith('package-lock.json'),
+    );
     expect(detectPackageManager(workspaceRoot)).toBe('npm');
   });
 
@@ -74,7 +77,8 @@ describe('ensureTokensDist', () => {
   let logger: Logger;
 
   beforeEach(() => {
-    vi.resetAllMocks();
+    existsSyncMock.mockReset();
+    spawnSyncMock.mockReset();
     // biome-ignore lint/style/noProcessEnv: tests simulate npm CLI hints.
     delete process.env.npm_config_user_agent;
     logger = createMockLogger();
@@ -87,7 +91,7 @@ describe('ensureTokensDist', () => {
    * @param lockfileCheck - Optional matcher for lockfile discovery.
    */
   function mockDistMissing(lockfileCheck?: (path: string) => boolean): void {
-    existsSyncMock.mockImplementation((path) => {
+    existsSyncMock.mockImplementation((path: PathLike) => {
       const target = pathToString(path);
       if (lockfileCheck?.(target)) return true;
       return false;
@@ -121,7 +125,7 @@ describe('ensureTokensDist', () => {
       process.env.npm_config_user_agent = userAgent;
     }
 
-    existsSyncMock.mockImplementation((path) => {
+    existsSyncMock.mockImplementation((path: PathLike) => {
       const target = pathToString(path);
       if (lockfileCheck?.(target)) return true;
       if (target === distPath) return distExists;
@@ -146,7 +150,7 @@ describe('ensureTokensDist', () => {
   }
 
   it('returns immediately when the dist directory already exists', () => {
-    existsSyncMock.mockImplementation((path) => pathToString(path) === distPath);
+    existsSyncMock.mockImplementation((path: PathLike) => pathToString(path) === distPath);
 
     expect(ensureTokensDist({ workspaceRoot, logger })).toBe(distPath);
     expect(spawnSyncMock).not.toHaveBeenCalled();

--- a/frontend-pwa/tests/test-logger.ts
+++ b/frontend-pwa/tests/test-logger.ts
@@ -2,32 +2,34 @@
  * @file Test helpers for working with the Vite logger interface.
  */
 
+import { mock } from 'bun:test';
 import type { Logger } from 'vite';
-import { vi } from 'vitest';
+
+type MockFunction = ReturnType<typeof mock>;
 
 type LoggerExtensions = {
-  time: ReturnType<typeof vi.fn>;
-  timeEnd: ReturnType<typeof vi.fn>;
-  debug: ReturnType<typeof vi.fn>;
-  fatal: ReturnType<typeof vi.fn>;
+  time: MockFunction;
+  timeEnd: MockFunction;
+  debug: MockFunction;
+  fatal: MockFunction;
 };
 
 export function createMockLogger(): Logger {
   let errorLogged = false;
-  const info = vi.fn();
-  const warn = vi.fn();
-  const warnOnce = vi.fn();
-  const error = vi.fn(() => {
+  const info = mock();
+  const warn = mock();
+  const warnOnce = mock();
+  const error = mock(() => {
     errorLogged = true;
   });
-  const clearScreen = vi.fn();
-  const time = vi.fn();
-  const timeEnd = vi.fn();
-  const debug = vi.fn();
-  const fatal = vi.fn(() => {
+  const clearScreen = mock();
+  const time = mock();
+  const timeEnd = mock();
+  const debug = mock();
+  const fatal = mock(() => {
     errorLogged = true;
   });
-  const hasErrorLogged = vi.fn(() => errorLogged);
+  const hasErrorLogged = mock(() => errorLogged);
 
   const logger: Logger & LoggerExtensions = {
     hasWarned: false,

--- a/frontend-pwa/tsconfig.json
+++ b/frontend-pwa/tsconfig.json
@@ -8,7 +8,7 @@
     "jsx": "react-jsx",
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "types": ["vite/client"],
+    "types": ["vite/client", "bun"],
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "resolveJsonModule": true,
     "verbatimModuleSyntax": true,

--- a/packages/AGENTS.md
+++ b/packages/AGENTS.md
@@ -1,0 +1,44 @@
+# Assistant instructions for `packages/`
+
+These instructions apply in addition to the repository root `AGENTS.md`.
+
+## Scope
+
+- Treat `packages/` as shared TypeScript workspace package code consumed by the
+  PWA and repository tooling.
+- Preserve package boundaries. Do not make a package depend on application
+  internals unless a documented design decision explicitly permits it.
+- Prefer workspace scripts and Makefile gates over ad hoc commands.
+
+## TypeScript and JavaScript quality gates
+
+- Validate formatting with `make check-fmt` from the repository root. Use
+  `make fmt` to apply formatting fixes.
+- Validate linting with `make lint` from the repository root.
+- Validate type safety with `make typecheck` from the repository root. For this
+  directory, the root target checks `packages/tokens/tsconfig.json` and
+  `packages/types/tsconfig.json`.
+- Validate tests with `make test-frontend` from the repository root. For focused
+  package work, run the package script that exists locally, such as
+  `pnpm --filter @app/tokens test` or `pnpm --filter @app/types build`.
+- Run `pnpm --filter @app/tokens build` when token source files or token build
+  utilities change. Run `pnpm --filter @app/types build` when shared type
+  exports or schemas change.
+
+## Testing expectations
+
+- Ensure new features are validated with unit tests and behavioural tests using
+  `bun:test` where applicable, covering happy paths, unhappy paths, and relevant
+  edge cases. If the package already uses a different local test runner, keep the
+  local convention and document any runner change before introducing it.
+- Add end-to-end tests where the change affects externally observable workflows,
+  integration contracts, persistence, command-line behaviour, network
+  boundaries, user interface flows, or other system-level behaviour.
+- Use property tests with `fast-check` when a change introduces an invariant over
+  a range of inputs, states, orderings, or transitions.
+- For introduced axioms or contractual business logic, use an exhaustive proof,
+  for example with LemmaScript. Proofs must be substantive, rigorous, and
+  well-founded rather than restating the assumed property.
+- Shared package tests must protect the public package contract. Cover exported
+  schemas, generated artefacts, token resolution, and package entry points when
+  they change.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
         specifier: ^3
         version: 3.25.76
     devDependencies:
+      '@types/bun':
+        specifier: ^1.3.14
+        version: 1.3.14
       '@types/node':
         specifier: ^22
         version: 22.18.12
@@ -117,9 +120,6 @@ importers:
       vite:
         specifier: ^7.3.2
         version: 7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3)
-      vitest:
-        specifier: ^4.1.8
-        version: 4.1.8(@types/node@22.18.12)(vite@7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3))
 
   packages/tokens:
     devDependencies:
@@ -906,6 +906,9 @@ packages:
   '@types/babel__traverse@7.28.0':
     resolution: {integrity: sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/chai@5.2.2':
     resolution: {integrity: sha512-8kB30R7Hwqf40JPiKhVzodJs2Qc1ZJ5zuT3uzw5Hq/dhNCl3G3l83jfpdI1e20BP348+fV7VIL/+FxaXkqBmWg==}
 
@@ -1252,6 +1255,9 @@ packages:
 
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   call-bind-apply-helpers@1.0.2:
     resolution: {integrity: sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==}
@@ -3961,6 +3967,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.4
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/chai@5.2.2':
     dependencies:
       '@types/deep-eql': 4.0.2
@@ -4155,14 +4165,6 @@ snapshots:
       '@vitest/utils': 4.1.8
       chai: 6.2.2
       tinyrainbow: 3.1.0
-
-  '@vitest/mocker@4.1.8(vite@7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3))':
-    dependencies:
-      '@vitest/spy': 4.1.8
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3)
 
   '@vitest/mocker@4.1.8(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
@@ -4361,6 +4363,10 @@ snapshots:
     dependencies:
       base64-js: 1.5.1
       ieee754: 1.2.1
+
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 22.18.12
 
   call-bind-apply-helpers@1.0.2:
     dependencies:
@@ -6354,33 +6360,6 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.6.1
       yaml: 2.8.3
-
-  vitest@4.1.8(@types/node@22.18.12)(vite@7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3)):
-    dependencies:
-      '@vitest/expect': 4.1.8
-      '@vitest/mocker': 4.1.8(vite@7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3))
-      '@vitest/pretty-format': 4.1.8
-      '@vitest/runner': 4.1.8
-      '@vitest/snapshot': 4.1.8
-      '@vitest/spy': 4.1.8
-      '@vitest/utils': 4.1.8
-      es-module-lexer: 2.1.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.1
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@22.18.12)(jiti@2.6.1)(yaml@2.8.3)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@types/node': 22.18.12
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.8(@types/node@24.3.1)(vite@7.3.2(@types/node@24.3.1)(jiti@2.6.1)(yaml@2.8.3)):
     dependencies:

--- a/security/AGENTS.md
+++ b/security/AGENTS.md
@@ -1,0 +1,43 @@
+# Assistant instructions for `security/`
+
+These instructions apply in addition to the repository root `AGENTS.md`.
+
+## Scope
+
+- Treat `security/` as JavaScript security automation for dependency audit
+  policy, audit exception validation, and audit reporting.
+- Keep security policy changes reflected in the relevant documentation under
+  `docs/`, and update `docs/contents.md` if new long-lived security documents
+  are added.
+- Prefer root scripts and Makefile gates over ad hoc commands.
+
+## TypeScript and JavaScript quality gates
+
+- Validate formatting with `make check-fmt` from the repository root. Use
+  `make fmt` to apply formatting fixes.
+- Validate linting with `make lint` from the repository root.
+- Validate repository JavaScript tests with `pnpm test` or `make test-frontend`
+  from the repository root when security script tests are added or changed.
+- Validate audit policy with `pnpm run audit:validate` from the repository root
+  after changes to audit exceptions, audit schemas, or validator code.
+- Run `make audit-node` when dependency audit behaviour or exception handling
+  changes.
+
+## Testing expectations
+
+- Ensure new features are validated with unit tests and behavioural tests using
+  `bun:test` where applicable, covering happy paths, unhappy paths, and relevant
+  edge cases. The current root JavaScript test harness is Vitest; keep local
+  tests compatible with the active repository harness unless the runner change
+  is deliberate and documented.
+- Add end-to-end tests where the change affects externally observable workflows,
+  integration contracts, persistence, command-line behaviour, network
+  boundaries, user interface flows, or other system-level behaviour.
+- Use property tests with `fast-check` when audit validation or reporting
+  introduces an invariant over a range of inputs, states, orderings, or
+  transitions.
+- For introduced axioms or contractual business logic, use an exhaustive proof,
+  for example with LemmaScript. Proofs must be substantive, rigorous, and
+  well-founded rather than restating the assumed property.
+- Security tests must cover malformed inputs and policy bypass attempts where
+  relevant, not only accepted configuration.


### PR DESCRIPTION
## Summary

This branch updates the repository's assistant and documentation guidance from the latest upstream agent template and documentation style guide. It renders the root assistant instructions without the template-only Rust behaviour, adds canonical repository layout documentation, and introduces scoped guidance for the PWA, shared packages, and security automation directories.

No issue or roadmap task is linked to this documentation maintenance branch.

## Review walkthrough

- Start with [AGENTS.md](https://github.com/leynos/wildside/blob/chore/agent-docs-guidance/AGENTS.md) to review the rendered repository-wide assistant instructions.
- Review [docs/documentation-style-guide.md](https://github.com/leynos/wildside/blob/chore/agent-docs-guidance/docs/documentation-style-guide.md) for the imported upstream documentation conventions.
- Check [docs/contents.md](https://github.com/leynos/wildside/blob/chore/agent-docs-guidance/docs/contents.md) and [docs/repository-layout.md](https://github.com/leynos/wildside/blob/chore/agent-docs-guidance/docs/repository-layout.md) for documentation navigation and repository orientation.
- Finish with [frontend-pwa/AGENTS.md](https://github.com/leynos/wildside/blob/chore/agent-docs-guidance/frontend-pwa/AGENTS.md), [packages/AGENTS.md](https://github.com/leynos/wildside/blob/chore/agent-docs-guidance/packages/AGENTS.md), and [security/AGENTS.md](https://github.com/leynos/wildside/blob/chore/agent-docs-guidance/security/AGENTS.md) for the subdirectory-specific TypeScript and JavaScript guidance.

## Validation

- `make markdownlint`: passed.
- `make nixie`: passed.

## Notes

- `make nixie` refreshed `bun.lock` as a side effect of `bun install`; that unrelated lockfile churn was restored before committing.
- The pull request is opened as a draft by default.